### PR TITLE
fix(wizard): prevent wizard from reopening after finish

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -127,7 +127,6 @@ async function bootstrap() {
     initCoverGenerator();
     initPathPicker();
     initSidebarResizer();
-    initWizard();
 
     wireTopbarButtons();
     wireConfirmSyncDialog();
@@ -194,6 +193,8 @@ async function bootstrap() {
     } else {
         await loadConfig();
     }
+
+    initWizard();
 }
 
 document.addEventListener('DOMContentLoaded', bootstrap);

--- a/static/js/features/config.js
+++ b/static/js/features/config.js
@@ -52,11 +52,6 @@ export async function loadConfig() {
         updateSourceTypeOptions();
         renderGroups();
 
-        if (!state.currentConfig.setup_done) {
-            showModal('setup-wizard-modal');
-            // wizard init will be triggered
-        }
-
         if (state.currentConfig.jellyfin_url && state.currentConfig.api_key) {
             await performSilentTest();
         }


### PR DESCRIPTION
initWizard() was called before loadConfig() in bootstrap(), so it checked the empty default state instead of the persisted config. This caused the wizard to reopen immediately after clicking "Finish & Restart" because setup_done was undefined/falsy at init time.

- Move initWizard() after await loadConfig() in app.js
- Remove duplicate showModal() call from loadConfig() in config.js