### PR TITLE
perf(api): use dedicated Jellyfin endpoints for metadata + loading ov…

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -14,9 +14,9 @@ import hashlib
 import logging
 import os
 import re
-from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
- 
+
 import requests
 from flask import Blueprint, jsonify, request, send_from_directory
 from flask.typing import ResponseReturnValue
@@ -162,17 +162,74 @@ def test_server() -> ResponseReturnValue:
 # ---------------------------------------------------------------------------
 
 
+def _fetch_jellyfin_endpoint(
+    base_url: str,
+    api_key: str,
+    endpoint: str,
+    *,
+    timeout: int = 15,
+    extra_params: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch all items from a Jellyfin list endpoint (Genres, Studios, etc.).
+
+    Handles paginated responses, collecting all items across all pages.
+
+    Args:
+        base_url: Jellyfin server base URL.
+        api_key: Jellyfin API key.
+        endpoint: Name of the dedicated endpoint (e.g. ``Genres``, ``Studios``).
+        timeout: HTTP request timeout per page.
+        extra_params: Additional query-string parameters per request.
+
+    Returns:
+        A list of all item dictionaries from the endpoint.
+    """
+    items: list[dict[str, Any]] = []
+    start_index = 0
+    limit = 200
+
+    while True:
+        params: dict[str, str | int] = {
+            "api_key": api_key,
+            "StartIndex": start_index,
+            "Limit": limit,
+        }
+        if extra_params:
+            params.update(extra_params)
+        try:
+            resp = requests.get(
+                f"{base_url}/{endpoint}",
+                params=params,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+        except requests.RequestException:
+            if items:
+                break  # partial data is better than nothing
+            raise
+
+        data = resp.json()
+        page_items = data.get("Items", [])
+        items.extend(page_items)
+
+        if len(page_items) < limit:
+            break
+        start_index += limit
+
+    return items
+
+
 @bp.route("/api/jellyfin/metadata", methods=["GET"])
 def get_jellyfin_metadata() -> ResponseReturnValue:
     """Return aggregated metadata (genres, studios, tags, actors) from Jellyfin.
 
-    Fetches all Movies and Series from the configured Jellyfin instance in
-    paginated chunks to avoid timeouts on large libraries, and counts
-    occurrences of each metadata field, returning sorted lists.
+    Uses Jellyfin's dedicated ``/Genres``, ``/Studios``, ``/Persons``, and
+    ``/Tags`` endpoints fetched in parallel, which is orders of magnitude
+    faster than scanning all items recursively.
 
     Returns:
         JSON with ``status`` and a ``metadata`` object containing ``genre``,
-        ``studio``, ``tag``, and ``actor`` lists (sorted by frequency).
+        ``studio``, ``tag``, and ``actor`` lists.
     """
     config: dict[str, Any] = load_config()
     if not isinstance(config, dict):
@@ -184,63 +241,32 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
     if not url or not api_key:
         return jsonify({"status": "error", "message": "Server settings not configured"}), 400
 
-    genres_counts: Counter[str] = Counter()
-    studios_counts: Counter[str] = Counter()
-    tags_counts: Counter[str] = Counter()
-    people_counts: Counter[str] = Counter()
-
-    chunk_size = 50
-    start_index = 0
+    result: dict[str, list[str]] = {}
 
     try:
-        while True:
-            items = fetch_jellyfin_items(
-                url,
-                api_key,
-                {
-                    "Recursive": "true",
-                    "IncludeItemTypes": "Movie,Series",
-                    "Fields": "Genres,Studios,Tags,People",
-                    "StartIndex": str(start_index),
-                    "Limit": str(chunk_size),
-                },
-                timeout=45,
-            )
-
-            if not items:
-                break
-
-            for item in items:
-                for g in item.get("Genres", []):
-                    genres_counts[g] += 1
-                for s in item.get("Studios", []):
-                    s_name: str | None = s.get("Name")
-                    if s_name:
-                        studios_counts[s_name] += 1
-                for t in item.get("Tags", []):
-                    tags_counts[t] += 1
-                for p in item.get("People", []):
-                    if p.get("Type") == "Actor":
-                        p_name: str | None = p.get("Name")
-                        if p_name:
-                            people_counts[p_name] += 1
-
-            if len(items) < chunk_size:
-                break
-
-            start_index += chunk_size
-
-        return jsonify(
-            {
-                "status": "success",
-                "metadata": {
-                    "genre": [x[0] for x in genres_counts.most_common()],
-                    "studio": [x[0] for x in studios_counts.most_common()],
-                    "tag": [x[0] for x in tags_counts.most_common()],
-                    "actor": [x[0] for x in people_counts.most_common()],
-                },
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures: dict[str, Any] = {
+                "genre": pool.submit(_fetch_jellyfin_endpoint, url, api_key, "Genres"),
+                "studio": pool.submit(_fetch_jellyfin_endpoint, url, api_key, "Studios"),
+                "actor": pool.submit(
+                    _fetch_jellyfin_endpoint,
+                    url,
+                    api_key,
+                    "Persons",
+                    extra_params={"PersonTypes": "Actor"},
+                ),
+                "tag": pool.submit(_fetch_jellyfin_endpoint, url, api_key, "Tags"),
             }
-        )
+            for key, future in futures.items():
+                try:
+                    items = future.result()
+                    result[key] = [
+                        item.get("Name", "") for item in items if item.get("Name")
+                    ]
+                except Exception:
+                    result[key] = []
+
+        return jsonify({"status": "success", "metadata": result})
     except Exception as exc:
         return jsonify({"status": "error", "message": str(exc)}), 400
 

--- a/routes.py
+++ b/routes.py
@@ -242,6 +242,7 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
         return jsonify({"status": "error", "message": "Server settings not configured"}), 400
 
     result: dict[str, list[str]] = {}
+    failed = 0
 
     try:
         with ThreadPoolExecutor(max_workers=4) as pool:
@@ -265,6 +266,10 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
                     ]
                 except Exception:
                     result[key] = []
+                    failed += 1
+
+        if failed >= len(futures):
+            return jsonify({"status": "error", "message": "Failed to fetch metadata from Jellyfin"}), 400
 
         return jsonify({"status": "success", "metadata": result})
     except Exception as exc:

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -373,7 +373,7 @@ button:disabled {
 }
 
 .loading-overlay-card h3 {
-    font-family: 'Outfit', sans-serif;
+    font-family: Outfit, sans-serif;
     font-size: 1.1rem;
     font-weight: 600;
     color: var(--text-primary);
@@ -400,10 +400,10 @@ button:disabled {
     width: 30%;
     background: var(--accent-color);
     border-radius: 2px;
-    animation: progressIndeterminate 1.4s ease-in-out infinite;
+    animation: progress-indeterminate 1.4s ease-in-out infinite;
 }
 
-@keyframes progressIndeterminate {
+@keyframes progress-indeterminate {
     0% {
         transform: translateX(-100%);
     }

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -339,6 +339,82 @@ button:disabled {
     }
 }
 
+/* ── Loading Overlay ────────────────────────────────────── */
+.loading-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.85);
+    z-index: 2000;
+    justify-content: center;
+    align-items: center;
+    backdrop-filter: blur(12px);
+    flex-direction: column;
+}
+
+.loading-overlay-card {
+    background: var(--surface-color);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem 2rem;
+    text-align: center;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+    animation: modalPop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    max-width: 420px;
+    width: 90vw;
+}
+
+.loading-overlay-card .loading-spinner {
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    border-width: 3px;
+    margin-bottom: 1rem;
+}
+
+.loading-overlay-card h3 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 0.5rem;
+}
+
+.loading-overlay-card p {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin: 0 0 1.25rem;
+    line-height: 1.4;
+}
+
+.progress-bar-container {
+    width: 100%;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.progress-bar-indeterminate {
+    height: 100%;
+    width: 30%;
+    background: var(--accent-color);
+    border-radius: 2px;
+    animation: progressIndeterminate 1.4s ease-in-out infinite;
+}
+
+@keyframes progressIndeterminate {
+    0% {
+        transform: translateX(-100%);
+    }
+    50% {
+        transform: translateX(200%);
+    }
+    100% {
+        transform: translateX(400%);
+    }
+}
+
 /* ── Modals ─────────────────────────────────────────────── */
 .modal {
     display: none;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,11 +1,12 @@
 // app.js – Application entry point
 
 import { state, metadataTypes } from './core/state.js';
-import { getEl, showToast, setLoading } from './core/ui.js';
+import { getEl, showToast, setLoading, showLoadingOverlay, updateLoadingStatus, hideLoadingOverlay } from './core/ui.js';
 
 import { initConfig, loadConfig, saveAllConfig, toggleGlobalScheduler, toggleCleanupScheduler } from './features/config.js';
 import { initWizard, openWizardManual } from './features/wizard.js';
-import { initMetadata, addMetadataRule, previewGrouping, getFilterValue } from './features/metadata.js';
+import { initMetadata, addMetadataRule, previewGrouping, getFilterValue, refreshMetadata } from './features/metadata.js';
+import { fetchUsers } from './core/api.js';
 import { initSync, syncAll, previewSyncAll, showConfirmSyncDialog } from './features/sync.js';
 import { initCleanup, openCleanupModal } from './features/cleanup.js';
 import { initExportImport, openExportModal, openImportModal, handleFileSelected } from './features/export-import.js';
@@ -192,6 +193,23 @@ async function bootstrap() {
         if (warning) warning.style.display = 'block';
     } else {
         await loadConfig();
+
+        if (state.currentConfig.jellyfin_url && state.currentConfig.api_key) {
+            showLoadingOverlay(
+                'Connecting to Jellyfin',
+                'Fetching genres, actors, studios, and tags...'
+            );
+            try {
+                await refreshMetadata(updateLoadingStatus);
+                updateLoadingStatus('Loading users...');
+                await fetchUsers().then(data => {
+                    if (data.status === 'success') state.cachedUsers = data.users;
+                }).catch(() => {});
+            } catch (err) {
+                showToast('Failed to load data from Jellyfin', 'error');
+            }
+            hideLoadingOverlay();
+        }
     }
 
     initWizard();

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -202,13 +202,15 @@ async function bootstrap() {
             try {
                 await refreshMetadata(updateLoadingStatus);
                 updateLoadingStatus('Loading users...');
-                await fetchUsers().then(data => {
-                    if (data.status === 'success') state.cachedUsers = data.users;
-                }).catch(() => {});
+                const data = await fetchUsers();
+                if (data.status === 'success') {
+                    state.cachedUsers = data.users;
+                }
             } catch (err) {
                 showToast('Failed to load data from Jellyfin', 'error');
+            } finally {
+                hideLoadingOverlay();
             }
-            hideLoadingOverlay();
         }
     }
 

--- a/static/js/core/ui.js
+++ b/static/js/core/ui.js
@@ -72,3 +72,21 @@ export function renderEmptyState(container, message) {
 export function getEl(id) {
     return document.getElementById(id);
 }
+
+export function showLoadingOverlay(title, status) {
+    const overlay = getEl('loading-overlay');
+    if (!overlay) return;
+    getEl('loading-overlay-title').textContent = title || 'Connecting to Jellyfin';
+    getEl('loading-overlay-status').textContent = status || 'Fetching data...';
+    overlay.style.display = 'flex';
+}
+
+export function updateLoadingStatus(status) {
+    const el = getEl('loading-overlay-status');
+    if (el) el.textContent = status;
+}
+
+export function hideLoadingOverlay() {
+    const overlay = getEl('loading-overlay');
+    if (overlay) overlay.style.display = 'none';
+}

--- a/static/js/core/ui.js
+++ b/static/js/core/ui.js
@@ -76,8 +76,10 @@ export function getEl(id) {
 export function showLoadingOverlay(title, status) {
     const overlay = getEl('loading-overlay');
     if (!overlay) return;
-    getEl('loading-overlay-title').textContent = title || 'Connecting to Jellyfin';
-    getEl('loading-overlay-status').textContent = status || 'Fetching data...';
+    const titleEl = getEl('loading-overlay-title');
+    const statusEl = getEl('loading-overlay-status');
+    if (titleEl) titleEl.textContent = title || 'Connecting to Jellyfin';
+    if (statusEl) statusEl.textContent = status || 'Fetching data...';
     overlay.style.display = 'flex';
 }
 

--- a/static/js/features/config.js
+++ b/static/js/features/config.js
@@ -2,7 +2,7 @@
 
 import { state, sourceOptions, setState } from '../core/state.js';
 import { apiGet, apiPost, loadConfig as apiLoadConfig, saveConfig as apiSaveConfig, fetchMetadata } from '../core/api.js';
-import { showToast, setLoading, showModal, hideModal, getEl } from '../core/ui.js';
+import { showToast, setLoading, showModal, hideModal, getEl, showLoadingOverlay, updateLoadingStatus, hideLoadingOverlay } from '../core/ui.js';
 import { updateSourceTypeOptions, updateSourceValueUI, refreshMetadata } from './metadata.js';
 import { renderGroups } from './groupings.js';
 import { updateValidationUI } from './test-connection.js';
@@ -126,7 +126,17 @@ export function initConfig() {
         state.currentConfig.target_path_in_jellyfin = getEl('target_path_in_jellyfin').value;
         await saveAllConfig();
         setLoading(saveBtn, false);
-        await refreshMetadata();
+
+        showLoadingOverlay(
+            'Reconnecting to Jellyfin',
+            'Fetching updated genres, actors, studios, and tags...'
+        );
+        try {
+            await refreshMetadata(updateLoadingStatus);
+        } catch (err) {
+            // refreshMetadata logs internally
+        }
+        hideLoadingOverlay();
     });
 
     apiConfigForm.addEventListener('submit', async (e) => {

--- a/static/js/features/config.js
+++ b/static/js/features/config.js
@@ -127,16 +127,19 @@ export function initConfig() {
         await saveAllConfig();
         setLoading(saveBtn, false);
 
-        showLoadingOverlay(
-            'Reconnecting to Jellyfin',
-            'Fetching updated genres, actors, studios, and tags...'
-        );
-        try {
-            await refreshMetadata(updateLoadingStatus);
-        } catch (err) {
-            // refreshMetadata logs internally
+        if (state.currentConfig.jellyfin_url && state.currentConfig.api_key) {
+            showLoadingOverlay(
+                'Reconnecting to Jellyfin',
+                'Fetching updated genres, actors, studios, and tags...'
+            );
+            try {
+                await refreshMetadata(updateLoadingStatus);
+            } catch (err) {
+                // refreshMetadata throws on failure
+            } finally {
+                hideLoadingOverlay();
+            }
         }
-        hideLoadingOverlay();
     });
 
     apiConfigForm.addEventListener('submit', async (e) => {

--- a/static/js/features/metadata.js
+++ b/static/js/features/metadata.js
@@ -5,17 +5,13 @@ import { fetchMetadata, fetchUsers, apiPost } from '../core/api.js';
 import { getEl } from '../core/ui.js';
 
 export async function refreshMetadata(onStatus) {
-    try {
-        if (onStatus) onStatus('Fetching genres, actors, studios, and tags...');
-        const result = await fetchMetadata();
-        if (result.status === 'success') {
-            state.cachedMetadata = result.metadata;
-            updateSourceValueUI();
-        } else {
-            console.error('Failed to load metadata from Jellyfin server');
-        }
-    } catch (err) {
-        console.error('Failed to fetch metadata:', err);
+    if (onStatus) onStatus('Fetching genres, actors, studios, and tags...');
+    const result = await fetchMetadata();
+    if (result.status === 'success') {
+        state.cachedMetadata = result.metadata;
+        updateSourceValueUI();
+    } else {
+        throw new Error(result.message || 'Failed to load metadata from Jellyfin server');
     }
 }
 

--- a/static/js/features/metadata.js
+++ b/static/js/features/metadata.js
@@ -4,8 +4,9 @@ import { state, sourceOptions, metadataTypes } from '../core/state.js';
 import { fetchMetadata, fetchUsers, apiPost } from '../core/api.js';
 import { getEl } from '../core/ui.js';
 
-export async function refreshMetadata() {
+export async function refreshMetadata(onStatus) {
     try {
+        if (onStatus) onStatus('Fetching genres, actors, studios, and tags...');
         const result = await fetchMetadata();
         if (result.status === 'success') {
             state.cachedMetadata = result.metadata;

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,17 @@
 </head>
 
 <body>
+    <div id="loading-overlay" class="loading-overlay">
+        <div class="loading-overlay-card">
+            <span class="loading-spinner"></span>
+            <h3 id="loading-overlay-title">Connecting to Jellyfin</h3>
+            <p id="loading-overlay-status">Fetching genres, actors, studios, and tags...</p>
+            <div class="progress-bar-container">
+                <div class="progress-bar-indeterminate"></div>
+            </div>
+        </div>
+    </div>
+
     <div class="bg-blob bg-blob-1"></div>
     <div class="bg-blob bg-blob-2"></div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,9 +21,9 @@
 <body>
     <div id="loading-overlay" class="loading-overlay">
         <div class="loading-overlay-card">
-            <span class="loading-spinner"></span>
+            <span class="loading-spinner" aria-hidden="true"></span>
             <h3 id="loading-overlay-title">Connecting to Jellyfin</h3>
-            <p id="loading-overlay-status">Fetching genres, actors, studios, and tags...</p>
+            <p id="loading-overlay-status" role="status" aria-live="polite" aria-atomic="true">Fetching genres, actors, studios, and tags...</p>
             <div class="progress-bar-container">
                 <div class="progress-bar-indeterminate"></div>
             </div>

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -66,20 +66,29 @@ class TestMetadataEndpoints:
     def test_metadata_returns_categories(self, client):
         """Test successful metadata response has expected categories."""
         with patch("routes.load_config") as mock_load, \
-             patch("routes.fetch_jellyfin_items") as mock_fetch:
+             patch("routes.requests.get") as mock_get:
             mock_load.return_value = {
                 "jellyfin_url": "http://localhost:8096",
                 "api_key": "test-key"
             }
-            mock_fetch.return_value = [
-                {
-                    "Name": "Action Movie",
-                    "Genres": ["Action", "Thriller"],
-                    "Studios": [{"Name": "Studio A"}],
-                    "Tags": ["4K"],
-                    "People": [{"Name": "Actor One", "Type": "Actor"}]
-                }
-            ]
+
+            def mock_jellyfin(url, **kwargs):
+                m = MagicMock()
+                params = kwargs.get("params", {})
+                if "Genres" in url:
+                    m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Thriller"}]}
+                elif "Studios" in url:
+                    m.json.return_value = {"Items": [{"Name": "Studio A"}]}
+                elif "Persons" in url:
+                    m.json.return_value = {"Items": [{"Name": "Actor One"}]}
+                elif "Tags" in url:
+                    m.json.return_value = {"Items": [{"Name": "4K"}]}
+                else:
+                    m.json.return_value = {"Items": []}
+                m.raise_for_status = MagicMock()
+                return m
+
+            mock_get.side_effect = mock_jellyfin
 
             resp = client.get("/api/jellyfin/metadata")
             data = resp.get_json()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -51,18 +51,37 @@ def test_browse_directory(client):
     assert data["status"] == "success"
     assert "dirs" in data
 
-@patch('routes.fetch_jellyfin_items')
+@patch('routes.requests.get')
 @pytest.mark.usefixtures("temp_config")
-def test_get_jellyfin_metadata(mock_fetch, client):
+def test_get_jellyfin_metadata(mock_get, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_fetch.return_value = [
-        {"Genres": ["Action"], "People": [{"Name": "Actor A", "Type": "Actor"}]}
-    ]
+
+    def mock_genres(url, **kwargs):
+        m = MagicMock()
+        params = kwargs.get("params", {})
+        if "Genres" in url:
+            m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Comedy"}]}
+        elif "Studios" in url:
+            m.json.return_value = {"Items": [{"Name": "Studio A"}]}
+        elif "Persons" in url:
+            m.json.return_value = {"Items": [{"Name": "Actor A"}]}
+        elif "Tags" in url:
+            m.json.return_value = {"Items": [{"Name": "4K"}]}
+        else:
+            m.json.return_value = {"Items": []}
+        m.raise_for_status = MagicMock()
+        return m
+
+    mock_get.side_effect = mock_genres
+
     response = client.get('/api/jellyfin/metadata')
     assert response.status_code == 200
     data = response.get_json()
     assert "Action" in data["metadata"]["genre"]
+    assert "Comedy" in data["metadata"]["genre"]
     assert "Actor A" in data["metadata"]["actor"]
+    assert "Studio A" in data["metadata"]["studio"]
+    assert "4K" in data["metadata"]["tag"]
 
 @patch('routes.run_sync')
 @pytest.mark.usefixtures("temp_config")
@@ -180,11 +199,11 @@ def test_get_jellyfin_metadata_no_config(client):
     response = client.get('/api/jellyfin/metadata')
     assert response.status_code == 400
 
-@patch('routes.fetch_jellyfin_items')
+@patch('routes.requests.get')
 @pytest.mark.usefixtures("temp_config")
-def test_get_jellyfin_metadata_error(mock_fetch, client):
+def test_get_jellyfin_metadata_error(mock_get, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_fetch.side_effect = Exception("Fetch failed")
+    mock_get.side_effect = requests.exceptions.ConnectionError("Fetch failed")
     response = client.get('/api/jellyfin/metadata')
     assert response.status_code == 400
 


### PR DESCRIPTION
…erlay

Replace slow recursive Items scan with parallel calls to /Genres, /Studios, /Persons, and /Tags. Add full-screen loading overlay that blocks interaction until all Jellyfin data is fetched on startup and after config save.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading overlay with status messages during Jellyfin connection and metadata refresh, providing visual feedback to users.

* **Improvements**
  * Enhanced metadata fetching performance with concurrent data loading for genres, studios, actors, and tags.
  * Improved user experience with clear progress indicators during initial setup and reconnection flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/52)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->