### PR TITLE
fix: remove dev dependencies from Docker production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # Install dependencies
-COPY requirements.txt requirements-dev.txt ./
-RUN pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application files
 COPY . .


### PR DESCRIPTION
## Summary
- Removed `requirements-dev.txt` from Docker production image
- Only installs production `requirements.txt` now
- Reduces image size and security surface

Closes #61

🤖 Generated with Claude Code