### PR TITLE
fix: control Flask debug mode via FLASK_DEBUG env variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,4 +45,5 @@ if __name__ == "__main__":
         save_config(DEFAULT_CONFIG.copy())
 
     port = int(os.environ.get("FLASK_PORT", "5000"))
-    app.run(host="0.0.0.0", debug=True, port=port)
+    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(host="0.0.0.0", debug=debug, port=port)

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -4,10 +4,12 @@ Helper script to run the virtual Jellyfin mock server for development and testin
 Provides a dashboard at http://localhost:8096
 """
 
+import os
 from tests.virtual_jellyfin import app
 
 if __name__ == "__main__":
     print("Starting Virtual Jellyfin Mock Server...")
     print("Dashboard: http://localhost:8096")
     print("Press Ctrl+C to stop.")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(host="0.0.0.0", port=8096, debug=debug)


### PR DESCRIPTION
## Summary
- Replaced hardcoded `debug=True` with `FLASK_DEBUG` env variable
- Fixes both `app.py` and `start_virtual_jellyfin.py`
- Prevents accidental debug mode in production

Closes #54

🤖 Generated with Claude Code