### PR TITLE
fix: align CI coverage threshold to 80% to match pre-commit hook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
     - name: Run standard tests with coverage
       run: |
         export PYTHONPATH=$PYTHONPATH:.
-        pytest --cov=. --cov-report=term-missing --cov-fail-under=60 --ignore=tests/test_virtual_jellyfin_api.py --ignore=tests/test_virtual_jellyfin_exhaustive.py --ignore=tests/test_deep_sync.py tests/
+        pytest --cov=. --cov-report=term-missing --cov-fail-under=80 --ignore=tests/test_virtual_jellyfin_api.py --ignore=tests/test_virtual_jellyfin_exhaustive.py --ignore=tests/test_deep_sync.py tests/


### PR DESCRIPTION
## Summary
- Raised CI `--cov-fail-under` from 60% to 80%
- Now consistent with the pre-commit hook threshold

Closes #65

🤖 Generated with Claude Code