### PR TITLE
fix: tag Docker images with commit SHA in addition to latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/entcheneric/jellyfin-groupings:latest
+          tags: ghcr.io/entcheneric/jellyfin-groupings:latest, ghcr.io/entcheneric/jellyfin-groupings:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Added commit SHA tag to Docker images for traceability
- `latest` tag still maintained for convenience
- Enables rollback to specific versions

Closes #66

🤖 Generated with Claude Code