### PR TITLE
fix: use X-Emby-Token header instead of query string for API key

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -63,11 +63,12 @@ def fetch_jellyfin_items(
         requests.HTTPError: If the server returns a non-2xx status code.
         requests.RequestException: For any other network-level error.
     """
-    params: dict[str, str] = {"api_key": api_key}
+    headers = {"X-Emby-Token": api_key}
+    params: dict[str, str] = {}
     if extra_params:
         params.update(extra_params)
 
-    response = requests.get(f"{base_url}/Items", params=params, timeout=timeout)
+    response = requests.get(f"{base_url}/Items", headers=headers, params=params, timeout=timeout)
     response.raise_for_status()
     return response.json().get("Items", [])
 
@@ -85,7 +86,7 @@ def get_libraries(base_url: str, api_key: str, timeout: int = 30) -> list[str]:
     """
     response = requests.get(
         f"{base_url}/Library/VirtualFolders",
-        params={"api_key": api_key},
+        headers={"X-Emby-Token": api_key},
         timeout=timeout,
     )
     response.raise_for_status()
@@ -128,7 +129,6 @@ def get_user_recent_items(
         A list of item dictionaries.
     """
     params = {
-        "api_key": api_key,
         "Filters": "IsPlayed",
         "SortBy": "DatePlayed",
         "SortOrder": "Descending",
@@ -139,6 +139,7 @@ def get_user_recent_items(
     }
     response = requests.get(
         f"{base_url}/Users/{user_id}/Items",
+        headers={"X-Emby-Token": api_key},
         params=params,
         timeout=timeout,
     )
@@ -279,7 +280,7 @@ def get_library_id(base_url: str, api_key: str, name: str, timeout: int = 30) ->
     try:
         response = requests.get(
             f"{base_url}/Library/VirtualFolders",
-            params={"api_key": api_key},
+            headers={"X-Emby-Token": api_key},
             timeout=timeout,
         )
         response.raise_for_status()

--- a/routes.py
+++ b/routes.py
@@ -136,7 +136,7 @@ def test_server() -> ResponseReturnValue:
     try:
         response = requests.get(
             f"{url}/System/Info",
-            params={"api_key": api_key},
+            headers={"X-Emby-Token": api_key},
             timeout=5,
         )
         if response.status_code == 200:
@@ -190,7 +190,6 @@ def _fetch_jellyfin_endpoint(
 
     while True:
         params: dict[str, str | int] = {
-            "api_key": api_key,
             "StartIndex": start_index,
             "Limit": limit,
         }
@@ -199,6 +198,7 @@ def _fetch_jellyfin_endpoint(
         try:
             resp = requests.get(
                 f"{base_url}/{endpoint}",
+                headers={"X-Emby-Token": api_key},
                 params=params,
                 timeout=timeout,
             )


### PR DESCRIPTION
## Summary
- Changed all Jellyfin API requests to use `X-Emby-Token` header instead of `?api_key=` query parameter
- Affected functions: `fetch_jellyfin_items`, `get_libraries`, `get_user_recent_items`, `get_library_id`, `test_server`, `_fetch_jellyfin_endpoint`
- Prevents API keys from appearing in server logs, browser history, and proxy caches

Closes #55

🤖 Generated with Claude Code