### PR TITLE
fix: document environment variable overrides for API keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,16 @@ services:
     restart: unless-stopped
     ports:
       - "5000:5000"
+    environment:
+      # Use environment variables for sensitive API keys instead of
+      # storing them in plaintext in config/config.json.
+      # Values set here override whatever is in the config file.
+      - JELLYFIN_API_KEY=${JELLYFIN_API_KEY:-}
+      - TRAKT_CLIENT_ID=${TRAKT_CLIENT_ID:-}
+      - TMDB_API_KEY=${TMDB_API_KEY:-}
+      - MAL_CLIENT_ID=${MAL_CLIENT_ID:-}
+      # Uncomment to disable debug mode in production:
+      # - FLASK_DEBUG=false
     volumes:
       # 1. Config persistence
       # Stores your API keys and group definitions. 

--- a/templates/partials/main/api-connections.html
+++ b/templates/partials/main/api-connections.html
@@ -8,19 +8,19 @@
             <div class="sub-panel">
                 <h3 style="font-size: 0.82rem; display:flex; align-items:center; gap:0.4rem;">Trakt <span style="font-weight:400; color:var(--text-secondary);">(Optional)</span></h3>
                 <p style="font-size: 0.72rem; color: var(--text-secondary); margin-bottom: 0.5rem;">Create an app at <a href="https://trakt.tv/oauth/applications/new" target="_blank" rel="noopener" style="color: var(--accent-color);">trakt.tv</a>.</p>
-                <label style="font-size: 0.68rem;">Trakt Client ID</label>
+                <label style="font-size: 0.68rem;">Trakt Client ID <span style="color:var(--text-secondary);">(or env TRAKT_CLIENT_ID)</span></label>
                 <input type="text" id="trakt_client_id" placeholder="Your Trakt API Client ID" style="font-size:0.85rem; padding: 0.5rem 0.7rem;">
             </div>
             <div class="sub-panel">
                 <h3 style="font-size: 0.82rem; display:flex; align-items:center; gap:0.4rem;">TMDb <span style="font-weight:400; color:var(--text-secondary);">(Optional)</span></h3>
                 <p style="font-size: 0.72rem; color: var(--text-secondary); margin-bottom: 0.5rem;">Get v3 API Key at <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noopener" style="color: var(--accent-color);">themoviedb.org</a>.</p>
-                <label style="font-size: 0.68rem;">TMDb API Key</label>
+                <label style="font-size: 0.68rem;">TMDb API Key <span style="color:var(--text-secondary);">(or env TMDB_API_KEY)</span></label>
                 <input type="text" id="tmdb_api_key" placeholder="Your TMDb API Key" style="font-size:0.85rem; padding: 0.5rem 0.7rem;">
             </div>
             <div class="sub-panel">
                 <h3 style="font-size: 0.82rem; display:flex; align-items:center; gap:0.4rem;">MyAnimeList <span style="font-weight:400; color:var(--text-secondary);">(Optional)</span></h3>
                 <p style="font-size: 0.72rem; color: var(--text-secondary); margin-bottom: 0.5rem;">Get Client ID at <a href="https://myanimelist.net/apiconfig" target="_blank" rel="noopener" style="color: var(--accent-color);">myanimelist.net</a>.</p>
-                <label style="font-size: 0.68rem;">MAL Client ID</label>
+                <label style="font-size: 0.68rem;">MAL Client ID <span style="color:var(--text-secondary);">(or env MAL_CLIENT_ID)</span></label>
                 <input type="text" id="mal_client_id" placeholder="Your MyAnimeList API Client ID" style="font-size:0.85rem; padding: 0.5rem 0.7rem;">
             </div>
         </div>

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -26,7 +26,7 @@
             <div class="form-group">
                 <label for="api_key">API Key</label>
                 <input type="password" id="api_key" placeholder="Your Jellyfin API Key" required>
-                <small>Dashboard &rarr; API Keys.</small>
+                <small>Dashboard &rarr; API Keys. Can also be set via <code>JELLYFIN_API_KEY</code> env variable.</small>
             </div>
             <div class="form-group">
                 <label for="target_path">Base Target Path</label>


### PR DESCRIPTION
## Summary
- Added environment variables to docker-compose.yml for all API keys
- Added env var hints to sidebar (Jellyfin API Key) and API Connections panel (Trakt, TMDb, MAL)
- Code already supported `JELLYFIN_API_KEY`, `TRAKT_CLIENT_ID`, `TMDB_API_KEY`, `MAL_CLIENT_ID` env vars

Closes #63

🤖 Generated with Claude Code