### PR TITLE
fix: improve error handling and logging in Letterboxd and IMDb scrapers

### DIFF
--- a/imdb.py
+++ b/imdb.py
@@ -7,9 +7,12 @@ public IMDb list page via regex extraction over the rendered HTML.
 
 from __future__ import annotations
 
+import logging
 import re
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 # Maximum number of pages to scrape (safety guard, ~2 000 items at 100/page)
 _MAX_PAGES: int = 20
@@ -63,7 +66,8 @@ def fetch_imdb_list(list_id: str) -> list[str]:
         try:
             resp = requests.get(page_url, headers=_REQUEST_HEADERS, timeout=15)
             resp.raise_for_status()
-        except Exception as exc:
+        except requests.RequestException as exc:
+            logger.error("HTTP error fetching IMDb list page %d: %s", page, exc)
             raise RuntimeError(f"Failed to fetch IMDb list page {page}: {exc}") from exc
 
         html: str = resp.text

--- a/letterboxd.py
+++ b/letterboxd.py
@@ -7,11 +7,14 @@ Letterboxd list by parsing the HTML.
 
 from __future__ import annotations
 
+import logging
 import re
 import time
 from typing import Any
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 # Maximum pages to scrape (safety guard, 100 items per page)
 _MAX_PAGES: int = 10
@@ -63,7 +66,7 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
             if resp.status_code == 404 and page > 1:
                 break
             resp.raise_for_status()
-        except Exception as exc:
+        except requests.RequestException as exc:
             raise RuntimeError(f"Failed to fetch Letterboxd list page {page}: {exc}") from exc
 
         html = resp.text
@@ -88,20 +91,19 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
                 unique_slugs_in_page.append(slug)
 
         if not unique_slugs_in_page:
-            print("No slugs found on page.")
+            logger.warning("No film slugs found on Letterboxd page %d", page)
             break
 
-        print(f"Found {len(unique_slugs_in_page)} slugs on page {page}. Fetching IDs...")
+        logger.info("Found %d slugs on Letterboxd page %d, fetching IDs...", len(unique_slugs_in_page), page)
         for slug in unique_slugs_in_page:
-            print(f"  Fetching ID for: {slug}")
             film_id = _fetch_id_for_slug(session, slug)
             if film_id:
-                print(f"    Found ID: {film_id}")
+                logger.debug("  Found ID for %s: %s", slug, film_id)
                 if film_id not in seen_ids:
                     ids.append(film_id)
                     seen_ids.add(film_id)
             else:
-                print(f"    No ID found for: {slug}")
+                logger.debug("  No ID found for: %s", slug)
 
         # Check for next page
         if 'class="next"' not in html or page >= _MAX_PAGES:
@@ -149,7 +151,8 @@ def _fetch_id_for_slug(session: requests.Session, slug: str) -> str | None:
         if tmdb_attr:
             return tmdb_attr.group(1)
 
-    except Exception:
+    except requests.RequestException:
+        logger.warning("Failed to fetch Letterboxd film page for '%s'", slug, exc_info=True)
         return None
-    
+
     return None


### PR DESCRIPTION
## Summary
- Replaced bare `except Exception` with specific `requests.RequestException` in both scrapers
- Replaced `print()` debug output with proper `logging` module
- Added `logger` instances with module-level scope
- Added `exc_info=True` for failed film page fetches in Letterboxd
- Better log messages on HTTP errors in IMDb scraper

Closes #62

🤖 Generated with Claude Code