### PR TITLE
fix: replace all print() calls with structured logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,13 +16,20 @@ The bulk of the application logic lives in the following modules:
 
 from __future__ import annotations
 
+import logging
+import os
+
 from flask import Flask
 
 from config import DEFAULT_CONFIG, CONFIG_FILE, save_config
 from routes import bp
 from scheduler import start_scheduler
 
-import os
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 # ---------------------------------------------------------------------------
 # Application factory

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 from typing import Any
 
 import mimetypes
+import logging
 import requests
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Sort-order mapping
@@ -261,7 +264,7 @@ def delete_virtual_folder(base_url: str, api_key: str, name: str, timeout: int =
         timeout=timeout,
     )
     if not response.ok:
-        print(f"DEBUG: Delete Virtual Folder Failed ({response.status_code}): {response.text}")
+        logger.warning("Delete Virtual Folder Failed (%s): %s", response.status_code, response.text)
     response.raise_for_status()
 
 
@@ -291,7 +294,7 @@ def get_library_id(base_url: str, api_key: str, name: str, timeout: int = 30) ->
                 if item_id is not None:
                     return str(item_id)
     except requests.exceptions.RequestException as exc:
-        print(f"Failed to get library ID for {name!r}: {exc}")
+        logger.error(f"Failed to get library ID for {name!r}: {exc}")
     
     return None
 
@@ -314,14 +317,14 @@ def set_virtual_folder_image(
     """
     library_id = get_library_id(base_url, api_key, name, timeout=timeout)
     if not library_id:
-        print(f"Cannot set image: Library {name!r} not found or ID unknown.")
+        logger.info(f"Cannot set image: Library {name!r} not found or ID unknown.")
         return
 
     try:
         with open(image_path, "rb") as f:
             image_bytes = f.read()
     except OSError as exc:
-        print(f"Cannot set image: Failed to read image file {image_path!r}: {exc}")
+        logger.error(f"Cannot set image: Failed to read image file {image_path!r}: {exc}")
         return
 
     mime_type, _ = mimetypes.guess_type(image_path)
@@ -341,14 +344,14 @@ def set_virtual_folder_image(
             timeout=timeout,
         )
         response.raise_for_status()
-        print(f"Successfully updated cover image for library {name!r}")
+        logger.info(f"Successfully updated cover image for library {name!r}")
     except requests.exceptions.RequestException as exc:
         msg = f"Failed to set image for library {name!r}"
         if hasattr(exc, "response") and exc.response is not None:
             msg += f" (Status {exc.response.status_code}): {exc.response.text}"
         else:
             msg += f": {exc!s}"
-        print(msg)
+        logger.info(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -585,7 +588,7 @@ def set_collection_image(
         with open(image_path, "rb") as f:
             image_bytes = f.read()
     except OSError as exc:
-        print(f"Cannot set collection image: Failed to read {image_path!r}: {exc}")
+        logger.error(f"Cannot set collection image: Failed to read {image_path!r}: {exc}")
         return
 
     mime_type, _ = mimetypes.guess_type(image_path)
@@ -604,11 +607,11 @@ def set_collection_image(
             timeout=timeout,
         )
         resp.raise_for_status()
-        print(f"Successfully updated cover image for collection {collection_id!r}")
+        logger.info(f"Successfully updated cover image for collection {collection_id!r}")
     except requests.exceptions.RequestException as exc:
         msg = f"Failed to set image for collection {collection_id!r}"
         if hasattr(exc, "response") and exc.response is not None:
             msg += f" (Status {exc.response.status_code}): {exc.response.text}"
         else:
             msg += f": {exc!s}"
-        print(msg)
+        logger.info(msg)

--- a/parse_test.py
+++ b/parse_test.py
@@ -1,3 +1,6 @@
+import logging
+
+logger = logging.getLogger(__name__)
 """
 parse_test.py - Unit tests for complex query parsing.
 """
@@ -16,4 +19,4 @@ def test_parse_complex_query():
 
 if __name__ == "__main__":
     test_parse_complex_query()
-    print("Test passed!")
+    logger.info("Test passed!")

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -1,3 +1,6 @@
+import logging
+
+logger = logging.getLogger(__name__)
 #!/usr/bin/env python3
 """
 Helper script to run the virtual Jellyfin mock server for development and testing.
@@ -8,8 +11,8 @@ import os
 from tests.virtual_jellyfin import app
 
 if __name__ == "__main__":
-    print("Starting Virtual Jellyfin Mock Server...")
-    print("Dashboard: http://localhost:8096")
-    print("Press Ctrl+C to stop.")
+    logger.info("Starting Virtual Jellyfin Mock Server...")
+    logger.info("Dashboard: http://localhost:8096")
+    logger.info("Press Ctrl+C to stop.")
     debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
     app.run(host="0.0.0.0", port=8096, debug=debug)

--- a/sync.py
+++ b/sync.py
@@ -41,6 +41,8 @@ from mal import fetch_mal_list
 from tmdb import fetch_tmdb_list, get_tmdb_recommendations
 from trakt import fetch_trakt_list
 
+
+logger = logging.getLogger(__name__)
 # Source types that come from external lists (IMDb / Trakt / TMDb / AniList / MyAnimeList / Letterboxd) rather than
 # from a Jellyfin metadata filter.
 _LIST_SOURCES: frozenset[str] = frozenset(
@@ -182,12 +184,12 @@ def _fetch_full_library(
             start_index += page_size
 
         pages_fetched = (start_index // page_size) + 1
-        print(f"Jellyfin library: {len(all_items)} items fetched for matching (in {pages_fetched} pages)")
+        logger.info(f"Jellyfin library: {len(all_items)} items fetched for matching (in {pages_fetched} pages)")
         with _LIBRARY_CACHE_LOCK:
             _LIBRARY_CACHE[cache_key] = all_items
         return all_items, None, 200
     except requests.exceptions.RequestException as exc:
-        print(f"Infrastructure error fetching Jellyfin library for group {group_name!r}: {exc!s}")
+        logger.error(f"Infrastructure error fetching Jellyfin library for group {group_name!r}: {exc!s}")
         return [], f"Jellyfin connection error: {exc!s}", 500
     except Exception as exc:
         logging.exception("Unexpected error fetching Jellyfin library for group %r", group_name)
@@ -318,13 +320,13 @@ def _fetch_items_for_imdb_group(
     """
     try:
         imdb_ids = fetch_imdb_list(source_value)
-        print(f"IMDb list {source_value!r}: {len(imdb_ids)} IDs found")
+        logger.info(f"IMDb list {source_value!r}: {len(imdb_ids)} IDs found")
     except Exception as exc:
-        print(f"Error fetching IMDb list for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching IMDb list for group {group_name!r}: {exc!s}")
         return [], f"IMDb fetch error: {exc!s}", 400
 
     if not imdb_ids:
-        print(f"No IMDb IDs found for group {group_name!r}")
+        logger.info(f"No IMDb IDs found for group {group_name!r}")
         return [], None, 200
 
     return _match_jellyfin_items_by_provider(
@@ -357,18 +359,18 @@ def _fetch_items_for_trakt_group(
     """
     if not trakt_client_id:
         msg = "Trakt Client ID not set — add trakt_client_id in Server Settings"
-        print(f"No Trakt Client ID configured for group {group_name!r}")
+        logger.info(f"No Trakt Client ID configured for group {group_name!r}")
         return [], msg, 400
 
     try:
         trakt_ids = fetch_trakt_list(source_value, trakt_client_id)
-        print(f"Trakt list {source_value!r}: {len(trakt_ids)} IMDb IDs found")
+        logger.info(f"Trakt list {source_value!r}: {len(trakt_ids)} IMDb IDs found")
     except Exception as exc:
-        print(f"Error fetching Trakt list for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching Trakt list for group {group_name!r}: {exc!s}")
         return [], f"Trakt fetch error: {exc!s}", 400
 
     if not trakt_ids:
-        print(f"No items found in Trakt list for group {group_name!r}")
+        logger.info(f"No items found in Trakt list for group {group_name!r}")
         return [], None, 200
 
     return _match_jellyfin_items_by_provider(
@@ -401,18 +403,18 @@ def _fetch_items_for_tmdb_group(
     """
     if not tmdb_api_key:
         msg = "TMDb API Key not set — add tmdb_api_key in Server Settings"
-        print(f"No TMDb API Key configured for group {group_name!r}")
+        logger.info(f"No TMDb API Key configured for group {group_name!r}")
         return [], msg, 400
 
     try:
         tmdb_ids = fetch_tmdb_list(source_value, tmdb_api_key)
-        print(f"TMDb list {source_value!r}: {len(tmdb_ids)} items found")
+        logger.info(f"TMDb list {source_value!r}: {len(tmdb_ids)} items found")
     except Exception as exc:
-        print(f"Error fetching TMDb list for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching TMDb list for group {group_name!r}: {exc!s}")
         return [], f"TMDb fetch error: {exc!s}", 400
 
     if not tmdb_ids:
-        print(f"No items found in TMDb list for group {group_name!r}")
+        logger.info(f"No items found in TMDb list for group {group_name!r}")
         return [], None, 200
 
     return _match_jellyfin_items_by_provider(
@@ -451,13 +453,13 @@ def _fetch_items_for_anilist_group(
 
     try:
         anilist_ids = fetch_anilist_list(username, status)
-        print(f"AniList user {username!r} (status={status!r}): {len(anilist_ids)} items found")
+        logger.info(f"AniList user {username!r} (status={status!r}): {len(anilist_ids)} items found")
     except Exception as exc:
-        print(f"Error fetching AniList items for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching AniList items for group {group_name!r}: {exc!s}")
         return [], f"AniList fetch error: {exc!s}", 400
 
     if not anilist_ids:
-        print(f"No items found for AniList user {username!r}")
+        logger.info(f"No items found for AniList user {username!r}")
         return [], None, 200
 
     return _match_jellyfin_items_by_provider(
@@ -490,7 +492,7 @@ def _fetch_items_for_mal_group(
     """
     if not mal_client_id:
         msg = "MyAnimeList Client ID not set — add mal_client_id in Server Settings"
-        print(f"No MAL Client ID configured for group {group_name!r}")
+        logger.info(f"No MAL Client ID configured for group {group_name!r}")
         return [], msg, 400
 
     username = source_value
@@ -502,13 +504,13 @@ def _fetch_items_for_mal_group(
 
     try:
         mal_ids = fetch_mal_list(username, mal_client_id, status)
-        print(f"MyAnimeList user {username!r} (status={status!r}): {len(mal_ids)} items found")
+        logger.info(f"MyAnimeList user {username!r} (status={status!r}): {len(mal_ids)} items found")
     except Exception as exc:
-        print(f"Error fetching MyAnimeList items for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching MyAnimeList items for group {group_name!r}: {exc!s}")
         return [], f"MAL fetch error: {exc!s}", 400
 
     if not mal_ids:
-        print(f"No items found for MyAnimeList user {username!r}")
+        logger.info(f"No items found for MyAnimeList user {username!r}")
         return [], None, 200
 
     return _match_jellyfin_items_by_provider(
@@ -540,13 +542,13 @@ def _fetch_items_for_letterboxd_group(
     """
     try:
         external_ids = fetch_letterboxd_list(source_value)
-        print(f"Letterboxd list {source_value!r}: {len(external_ids)} IDs found")
+        logger.info(f"Letterboxd list {source_value!r}: {len(external_ids)} IDs found")
     except Exception as exc:
-        print(f"Error fetching Letterboxd items for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching Letterboxd items for group {group_name!r}: {exc!s}")
         return [], f"Letterboxd fetch error: {exc!s}", 400
 
     if not external_ids:
-        print(f"No items found in Letterboxd list for group {group_name!r}")
+        logger.info(f"No items found in Letterboxd list for group {group_name!r}")
         return [], None, 200
 
     # Letterboxd IDs can be IMDb (tt...) or TMDb (numeric)
@@ -622,7 +624,7 @@ def _fetch_items_for_recommendations_group(
     """
     if not tmdb_api_key:
         msg = "TMDb API Key not set — add tmdb_api_key in Server Settings"
-        print(f"No TMDb API Key configured for recommendations group {group_name!r}")
+        logger.info(f"No TMDb API Key configured for recommendations group {group_name!r}")
         return [], msg, 400
 
     if not source_value:
@@ -643,18 +645,18 @@ def _fetch_items_for_recommendations_group(
                 tmdb_requests.append((str(tmdb_id), media_type))
                 
         if not tmdb_requests:
-            print(f"No TMDb IDs found in recent items for user {user_id!r}")
+            logger.info(f"No TMDb IDs found in recent items for user {user_id!r}")
             return [], None, 200
 
         # Fetch recommendations based on these items
         tmdb_ids = get_tmdb_recommendations(tmdb_requests, tmdb_api_key)
-        print(f"TMDb recommendations: {len(tmdb_ids)} items found")
+        logger.info(f"TMDb recommendations: {len(tmdb_ids)} items found")
     except Exception as exc:
-        print(f"Error fetching recommendations for group {group_name!r}: {exc!s}")
+        logger.error(f"Error fetching recommendations for group {group_name!r}: {exc!s}")
         return [], f"Recommendations fetch error: {exc!s}", 400
 
     if not tmdb_ids:
-        print(f"No items found in TMDb recommendations for group {group_name!r}")
+        logger.info(f"No items found in TMDb recommendations for group {group_name!r}")
         return [], None, 200
 
     return _match_jellyfin_items_by_provider(
@@ -779,7 +781,7 @@ def _fetch_items_for_complex_group(
             if r_t and r_v:
                 valid_rules.append({"operator": r_o, "type": r_t, "value": r_v})
         except (TypeError, ValueError, AttributeError) as exc:
-            print(f"DEBUG: Skipping malformed rule {r}: {exc}")
+            logger.debug("Skipping malformed rule %s: %s", r, exc)
             continue
 
     if not valid_rules:
@@ -855,10 +857,10 @@ def _fetch_items_for_metadata_group(
 
     try:
         items = fetch_jellyfin_items(url, api_key, params, timeout=30)
-        print(f"Found {len(items)} potential items for group {group_name!r}")
+        logger.info(f"Found {len(items)} potential items for group {group_name!r}")
         return items, None, 200
     except requests.exceptions.RequestException as exc:
-        print(f"Infrastructure error fetching items for group {group_name!r}: {exc!s}")
+        logger.error(f"Infrastructure error fetching items for group {group_name!r}: {exc!s}")
         return [], f"Jellyfin connection error: {exc!s}", 500
     except Exception as exc:
         logging.exception("Unexpected error fetching items for group %r", group_name)
@@ -968,13 +970,13 @@ def _process_collection_group(
     try:
         collection_id = find_collection_by_name(url, api_key, group_name)
         if collection_id:
-            print(f"Found existing collection {group_name!r} (id={collection_id})")
+            logger.info(f"Found existing collection {group_name!r} (id={collection_id})")
         else:
             collection_id = create_collection(url, api_key, group_name, item_ids)
-            print(f"Created collection {group_name!r} (id={collection_id})")
+            logger.info(f"Created collection {group_name!r} (id={collection_id})")
 
         add_to_collection(url, api_key, collection_id, item_ids)
-        print(f"Added {len(item_ids)} items to collection {group_name!r}")
+        logger.info(f"Added {len(item_ids)} items to collection {group_name!r}")
     except Exception as exc:
         return {"group": group_name, "links": 0, "error": str(exc)}
 
@@ -986,7 +988,7 @@ def _process_collection_group(
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
             except Exception as exc:
-                print(f"Failed to set collection image for {group_name!r}: {exc}")
+                logger.error(f"Failed to set collection image for {group_name!r}: {exc}")
 
     return result
 
@@ -1037,12 +1039,12 @@ def _process_group(
     source_type: str | None = group.get("source_type")
     source_value: str | None = group.get("source_value")
 
-    print(f"Processing group: {group_name!r} -> {group_dir}  (sort_order={sort_order!r})")
+    logger.info(f"Processing group: {group_name!r} -> {group_dir}  (sort_order={sort_order!r})")
 
     # Clean up and recreate the group directory
     if not dry_run:
         if os.path.exists(group_dir):
-            print(f"Cleaning existing directory: {group_dir}")
+            logger.info(f"Cleaning existing directory: {group_dir}")
             shutil.rmtree(group_dir)
         os.makedirs(group_dir, exist_ok=True)
 
@@ -1053,9 +1055,9 @@ def _process_group(
             poster_dest = os.path.join(group_dir, "poster.jpg")
             try:
                 shutil.copy2(source_cover, poster_dest)
-                print(f"Copied cover image from {source_cover} to {poster_dest}")
+                logger.info(f"Copied cover image from {source_cover} to {poster_dest}")
             except OSError as exc:
-                print(f"Failed to copy cover image: {exc}")
+                logger.error(f"Failed to copy cover image: {exc}")
 
     # --- Resolve items ---
     error: str | None = None
@@ -1149,15 +1151,15 @@ def _process_group(
 
         source_path: str | None = item.get("Path")
         if not source_path or not isinstance(source_path, str):
-            print(f"Item {item.get('Id')} has no valid Path — skipping")
+            logger.info(f"Item {item.get('Id')} has no valid Path — skipping")
             continue
 
         host_path = _translate_path(source_path, jellyfin_root, host_root)
         if host_path != source_path:
-            print(f"Translated path: {source_path} -> {host_path}")
+            logger.info(f"Translated path: {source_path} -> {host_path}")
 
         if not os.path.exists(host_path):
-            print(f"Skipping (path not found on host): {host_path}")
+            logger.info(f"Skipping (path not found on host): {host_path}")
             continue
 
         file_name: str = os.path.basename(host_path)
@@ -1172,15 +1174,15 @@ def _process_group(
         else:
             try:
                 os.symlink(host_path, dest_path)
-                print(f"Created symlink: {dest_path} -> {host_path}")
+                logger.info(f"Created symlink: {dest_path} -> {host_path}")
                 links_created += 1
             except OSError as exc:
-                print(f"Error creating symlink {dest_path}: {exc}")
+                logger.error(f"Error creating symlink {dest_path}: {exc}")
 
     if dry_run:
-        print(f"Would create {links_created} symlinks for {group_name!r}")
+        logger.info(f"Would create {links_created} symlinks for {group_name!r}")
     else:
-        print(f"Created {links_created} symlinks for {group_name!r}")
+        logger.info(f"Created {links_created} symlinks for {group_name!r}")
     result: dict[str, Any] = {"group": group_name, "links": links_created}
     if dry_run:
         result["items"] = preview_items
@@ -1192,7 +1194,7 @@ def _process_group(
         and links_created > 0
     ):
         if existing_libraries is not None and group_name not in existing_libraries:
-            print(f"Creating Jellyfin library for grouping: {group_name!r}")
+            logger.info(f"Creating Jellyfin library for grouping: {group_name!r}")
             # Resolve the path as Jellyfin sees it
             if target_path_in_jellyfin:
                 lib_path = os.path.join(target_path_in_jellyfin, group_name)
@@ -1201,16 +1203,16 @@ def _process_group(
                 
             try:
                 add_virtual_folder(url, api_key, group_name, [lib_path], collection_type="mixed")
-                print(f"Successfully created library {group_name!r} with path {lib_path!r}")
+                logger.info(f"Successfully created library {group_name!r} with path {lib_path!r}")
                 existing_libraries.append(group_name) # Prevent double creation in same run
             except Exception as exc:
-                print(f"Failed to create Jellyfin library {group_name!r}: {exc}")
+                logger.error(f"Failed to create Jellyfin library {group_name!r}: {exc}")
                 result["library_error"] = str(exc)
 
     # --- Automatic Library Cover ---
     if not dry_run and auto_set_library_covers:
         if source_cover and os.path.exists(source_cover):
-            print(f"Setting cover image for library {group_name!r} via API")
+            logger.info(f"Setting cover image for library {group_name!r} via API")
             set_virtual_folder_image(url, api_key, group_name, source_cover)
 
     return result
@@ -1291,17 +1293,17 @@ def run_sync(
     if not dry_run and not os.path.exists(target_base):
         os.makedirs(target_base, exist_ok=True)
 
-    print(f"Starting sync to: {target_base}")
+    logger.info(f"Starting sync to: {target_base}")
     if jellyfin_root and host_root:
-        print(f"Path translation active: {jellyfin_root} -> {host_root}")
+        logger.info(f"Path translation active: {jellyfin_root} -> {host_root}")
 
     existing_libraries: list[str] = []
     if auto_create_libraries:
         try:
             existing_libraries = get_libraries(url, api_key)
-            print(f"Found {len(existing_libraries)} existing virtual folders in Jellyfin")
+            logger.info(f"Found {len(existing_libraries)} existing virtual folders in Jellyfin")
         except Exception as exc:
-            print(f"Warning: Could not fetch existing libraries: {exc}")
+            logger.warning(f"Warning: Could not fetch existing libraries: {exc}")
             # We'll continue, but library creation might fail or try to recreate existing ones
             auto_create_libraries = False 
 
@@ -1311,7 +1313,7 @@ def run_sync(
     results: list[dict[str, Any]] = []
     for group in groups:
         if not isinstance(group, dict):
-            print(f"Skipping invalid group entry: {group}")
+            logger.info(f"Skipping invalid group entry: {group}")
             continue
         
         name = group.get("name", "").strip()
@@ -1327,7 +1329,7 @@ def run_sync(
                 if not dry_run and name:
                     group_dir = os.path.join(target_base, name)
                     if os.path.isdir(group_dir):
-                        print(f"Seasonal group {name!r} is out of season. Deleting directory: {group_dir}")
+                        logger.info(f"Seasonal group {name!r} is out of season. Deleting directory: {group_dir}")
                         shutil.rmtree(group_dir)
                 results.append({"group": name or "(unnamed)", "links": 0, "status": "out_of_season"})
                 continue
@@ -1367,7 +1369,7 @@ def run_cleanup_broken_symlinks(config: dict[str, Any]) -> int:
     target_base: str = str(config.get("target_path", ""))
     
     if not target_base or not os.path.isdir(target_base):
-        print(f"Cleanup aborted: invalid target base path '{target_base}'")
+        logger.info(f"Cleanup aborted: invalid target base path '{target_base}'")
         return 0
 
     deleted_count = 0
@@ -1379,9 +1381,9 @@ def run_cleanup_broken_symlinks(config: dict[str, Any]) -> int:
                 # The symlink is broken
                 try:
                     os.unlink(path)
-                    print(f"Deleted broken symlink: {path}")
+                    logger.info(f"Deleted broken symlink: {path}")
                     deleted_count += 1
                 except OSError as exc:
-                    print(f"Error deleting broken symlink {path}: {exc}")
+                    logger.error(f"Error deleting broken symlink {path}: {exc}")
                     
     return deleted_count

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -58,7 +58,7 @@ def test_fetch_letterboxd_invalid_url():
 def test_fetch_letterboxd_http_error(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 500
-    mock_resp.raise_for_status.side_effect = Exception("HTTP Error")
+    mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("HTTP Error")
     mock_get.return_value = mock_resp
     with pytest.raises(RuntimeError, match="Failed to fetch Letterboxd"):
         fetch_letterboxd_list("https://letterboxd.com/user/list/list")

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -16,7 +16,7 @@ def test_fetch_jellyfin_items(mock_get):
     assert items == [{"Name": "M1"}]
     # Verify params
     _args, kwargs = mock_get.call_args
-    assert kwargs['params']['api_key'] == "key"
+    assert kwargs['headers']['X-Emby-Token'] == "key"
     assert kwargs['params']['Type'] == "Movie"
 
 @patch('imdb.requests.get')

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch, MagicMock
 import pytest
 from jellyfin import get_libraries, add_virtual_folder, delete_virtual_folder, get_library_id, set_virtual_folder_image, get_users, get_user_recent_items
@@ -13,7 +14,7 @@ def test_get_libraries(mock_get):
     assert libs == ["Movies", "TV Shows"]
     mock_get.assert_called_with(
         "http://localhost:8096/Library/VirtualFolders",
-        params={"api_key": "test_key"},
+        headers={"X-Emby-Token": "test_key"},
         timeout=30
     )
 
@@ -190,7 +191,6 @@ def test_get_user_recent_items(mock_get):
     assert items[0]["Name"] == "Movie 1"
     
     expected_params = {
-        "api_key": "test_key",
         "Filters": "IsPlayed",
         "SortBy": "DatePlayed",
         "SortOrder": "Descending",
@@ -201,6 +201,7 @@ def test_get_user_recent_items(mock_get):
     }
     mock_get.assert_called_once_with(
         "http://localhost:8096/Users/u1/Items",
+        headers={"X-Emby-Token": "test_key"},
         params=expected_params,
         timeout=30
     )
@@ -266,84 +267,79 @@ def test_add_virtual_folder_refresh_failure_no_response(mock_post):
     assert "Failed to trigger library refresh for 'RefreshFail': Refresh Network Error" in str(excinfo.value)
 
 @patch('requests.delete')
-def test_delete_virtual_folder_not_ok(mock_delete, capsys):
+def test_delete_virtual_folder_not_ok(mock_delete, caplog):
     mock_response = MagicMock()
     mock_response.ok = False
     mock_response.status_code = 404
     mock_response.text = "Not Found"
     mock_delete.return_value = mock_response
-    
-    delete_virtual_folder("http://localhost:8096", "test_key", "ToDelete")
-    
-    captured = capsys.readouterr()
-    assert "DEBUG: Delete Virtual Folder Failed (404): Not Found" in captured.out
+
+    with caplog.at_level(logging.WARNING):
+        delete_virtual_folder("http://localhost:8096", "test_key", "ToDelete")
+
+    assert "Delete Virtual Folder Failed (404): Not Found" in caplog.text
 
 @patch('requests.get')
-def test_get_library_id_request_exception(mock_get, capsys):
+def test_get_library_id_request_exception(mock_get, caplog):
     mock_get.side_effect = requests.exceptions.RequestException("Fetch Error")
-    
+
     result = get_library_id("http://localhost:8096", "test_key", "MyLib")
     assert result is None
-    
-    captured = capsys.readouterr()
-    assert "Failed to get library ID for 'MyLib': Fetch Error" in captured.out
+
+    assert "Failed to get library ID for 'MyLib': Fetch Error" in caplog.text
 
 @patch('jellyfin.get_library_id')
-def test_set_virtual_folder_image_no_library_id(mock_get_library_id, capsys):
+def test_set_virtual_folder_image_no_library_id(mock_get_library_id, caplog):
     mock_get_library_id.return_value = None
-    
+
     set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
-    
-    captured = capsys.readouterr()
-    assert "Cannot set image: Library 'MyLib' not found or ID unknown." in captured.out
+
+    assert "Cannot set image: Library 'MyLib' not found or ID unknown." in caplog.text
 
 @patch('jellyfin.get_library_id')
-def test_set_virtual_folder_image_os_error(mock_get_library_id, capsys):
+def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
     mock_get_library_id.return_value = "123"
-    
+
     with patch('builtins.open', side_effect=OSError("Permission Denied")):
         set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
-        
-    captured = capsys.readouterr()
-    assert "Cannot set image: Failed to read image file '/path/to/img.jpg': Permission Denied" in captured.out
+
+    assert "Cannot set image: Failed to read image file '/path/to/img.jpg': Permission Denied" in caplog.text
 
 @patch('mimetypes.guess_type')
 @patch('builtins.open')
 @patch('requests.post')
 @patch('jellyfin.get_library_id')
-def test_set_virtual_folder_image_request_exception(mock_get_library_id, mock_post, mock_open, mock_guess, capsys):
+def test_set_virtual_folder_image_request_exception(mock_get_library_id, mock_post, mock_open, mock_guess, caplog):
     mock_guess.return_value = ("image/jpeg", None)
     mock_get_library_id.return_value = "123"
     mock_open.return_value.__enter__.return_value.read.return_value = b"image_data"
-    
+
     mock_response_fail = MagicMock()
     mock_response_fail.ok = False
     mock_response_fail.status_code = 400
     mock_response_fail.text = "Bad Request"
     import requests
     fail_exc = requests.exceptions.HTTPError(response=mock_response_fail)
-    
+
     # We assign the response to the exception so the handler can use exc.response
     fail_exc.response = mock_response_fail
     mock_post.side_effect = fail_exc
-    
+
     set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
-    
-    captured = capsys.readouterr()
-    assert "Failed to set image for library 'MyLib' (Status 400): Bad Request" in captured.out
+
+    assert "Failed to set image for library 'MyLib' (Status 400): Bad Request" in caplog.text
 
 @patch('mimetypes.guess_type')
 @patch('builtins.open')
 @patch('requests.post')
 @patch('jellyfin.get_library_id')
-def test_set_virtual_folder_image_request_exception_no_response(mock_get_library_id, mock_post, mock_open, mock_guess, capsys):
+def test_set_virtual_folder_image_request_exception_no_response(mock_get_library_id, mock_post, mock_open, mock_guess, caplog):
     mock_guess.return_value = ("image/jpeg", None)
     mock_get_library_id.return_value = "123"
     mock_open.return_value.__enter__.return_value.read.return_value = b"image_data"
-    
+
     mock_post.side_effect = requests.exceptions.RequestException("Upload Error")
-    
+
     set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
-    
-    captured = capsys.readouterr()
-    assert "Failed to set image for library 'MyLib': Upload Error" in captured.out
+
+    assert "Failed to set image for library 'MyLib': Upload Error" in caplog.text


### PR DESCRIPTION
## Summary
- Replaced ~72 `print()` calls with `logging.info/warning/error/debug` across all modules
- Added `logging.basicConfig()` in `app.py` for consistent log formatting
- Added module-level loggers to files that were missing them
- Updated test assertions from `capsys` to `caplog` fixture
- Updated test mocks to expect `X-Emby-Token` header instead of `api_key` query param

Closes #57

🤖 Generated with Claude Code