### PR TITLE
fix: resolve undefined logger and mypy type errors across codebase

### DIFF
--- a/config.py
+++ b/config.py
@@ -74,13 +74,14 @@ def load_config() -> dict[str, Any]:
         "mal_client_id": "MAL_CLIENT_ID",
     }
 
+    cfg: dict[str, Any]
     if not os.path.exists(CONFIG_FILE):
         save_config(DEFAULT_CONFIG.copy())
         cfg = DEFAULT_CONFIG.copy()
     else:
         try:
             with open(CONFIG_FILE, "r") as fh:
-                cfg: dict[str, Any] = json.load(fh)
+                cfg = json.load(fh)
 
             # Fill in any keys added after initial creation
             for key, default_value in DEFAULT_CONFIG.items():

--- a/network.py
+++ b/network.py
@@ -93,6 +93,6 @@ def _patched_delete(url, **kwargs):
         raise
 
 
-requests.get = _patched_get         # type: ignore[method-assign]
-requests.post = _patched_post       # type: ignore[method-assign]
-requests.delete = _patched_delete   # type: ignore[method-assign]
+requests.get = _patched_get         # type: ignore[method-assign, assignment]
+requests.post = _patched_post       # type: ignore[method-assign, assignment]
+requests.delete = _patched_delete   # type: ignore[method-assign, assignment]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==8.0.0
 pytest-cov==4.1.0
 pytest-flask==1.3.0
 pytest-mock==3.12.0
+types-requests

--- a/routes.py
+++ b/routes.py
@@ -27,6 +27,8 @@ from jellyfin import delete_virtual_folder, fetch_jellyfin_items, get_users
 from scheduler import update_scheduler_jobs, validate_cron
 from sync import get_cover_path, parse_complex_query, preview_group, run_sync
 
+logger = logging.getLogger(__name__)
+
 bp = Blueprint("main", __name__)
 
 # Max size for base64 encoded cover image (approx 4MB)
@@ -400,7 +402,8 @@ def upload_cover() -> ResponseReturnValue:
         
         cover_path = get_cover_path(group_name, target_path, check_exists=False)
         # get_cover_path with check_exists=False never returns None
-            
+        assert cover_path is not None
+
         os.makedirs(os.path.dirname(cover_path), exist_ok=True)
         with open(cover_path, "wb") as f:
             f.write(decoded)

--- a/scheduler.py
+++ b/scheduler.py
@@ -99,10 +99,12 @@ def _run_global_sync_job(exclude_names: list[str]) -> None:
     all_groups = config.get("groups", [])
     
     # Filter out excluded groups
-    sync_names = [
-        g.get("name") for g in all_groups 
-        if isinstance(g, dict) and g.get("name") and g.get("name") not in exclude_names
-    ]
+    sync_names: list[str] = []
+    for g in all_groups:
+        if isinstance(g, dict):
+            name = g.get("name")
+            if isinstance(name, str) and name not in exclude_names:
+                sync_names.append(name)
     
     if sync_names:
         logger.info(f"Background global sync starting for groups: {sync_names}")

--- a/sync.py
+++ b/sync.py
@@ -1143,7 +1143,7 @@ def _process_group(
     use_prefix: bool = bool(sort_order)  # numbered prefix ↔ any sort order
     width: int = max(len(str(len(items))) if items else 4, 4)
     links_created: int = 0
-    preview_items = []
+    preview_items: list[dict[str, Any]] = []
 
     for idx, item in enumerate(items, start=1):
         if not isinstance(item, dict):


### PR DESCRIPTION
## Summary
This PR fixes a runtime bug where `logger` was undefined in `routes.py`, and resolves all outstanding `mypy` type errors across the codebase.

## Changes
- **routes.py**: adds missing `logger = logging.getLogger(__name__)` so auto-detect timeout/file-limit warnings don't raise `NameError` (#98).
- **routes.py**: adds `assert cover_path is not None` after `get_cover_path(..., check_exists=False)` to satisfy mypy (#99).
- **config.py**: hoists `cfg: dict[str, Any]` before the `if/else` to avoid `no-redef` error (#99).
- **scheduler.py**: builds `sync_names` with an explicit loop so mypy sees `list[str]` instead of `list[Any | None]` (#99).
- **sync.py**: adds `list[dict[str, Any]]` annotation to `preview_items` (#99).
- **network.py**: broadens `type: ignore` comments to cover `[assignment]` error code from `types-requests` stubs (#99).
- **requirements-dev.txt**: adds `types-requests` so mypy can type-check `requests` usage (#99).

## Verification
- `mypy . --ignore-missing-imports --exclude '(venv|__pycache__|tests|node_modules)'` → 0 errors
- `pytest tests/` → 255 passed, 17 skipped

## Issues
Closes #98
Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code type safety and consistency across internal modules
  * Added development dependency for enhanced type checking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/103)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->