### PR TITLE
chore: add flake8 and mypy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,18 @@
 repos:
 -   repo: local
     hooks:
+    -   id: flake8
+        name: flake8 linting
+        entry: bash -c "flake8 . --max-line-length=120 --exclude=venv,__pycache__,.git,node_modules"
+        language: system
+        pass_filenames: false
+        always_run: true
+    -   id: mypy
+        name: mypy type checking
+        entry: bash -c "mypy . --ignore-missing-imports --exclude '(venv|__pycache__|tests|node_modules)'"
+        language: system
+        pass_filenames: false
+        always_run: true
     -   id: pytest-coverage
         name: check code coverage
         entry: bash -c "export PYTHONPATH=$PYTHONPATH:. && pytest --cov=. --cov-fail-under=80 tests/"


### PR DESCRIPTION
## Summary
Adds `flake8` and `mypy` local hooks to `.pre-commit-config.yaml` so style and type issues are caught before commits reach CI.

## Changes
- **flake8 hook**: runs `flake8 . --max-line-length=120 --exclude=venv,__pycache__,.git,node_modules`
- **mypy hook**: runs `mypy . --ignore-missing-imports --exclude '(venv|__pycache__|tests|node_modules)'`
- **pytest-coverage hook**: kept unchanged (existing behaviour)

## Notes
- This PR is based on `development` and will pass cleanly once the type/formatting fixes in #103 and #105 are merged.

Closes #100