### PR TITLE
chore: align docker-compose healthcheck with Dockerfile and add security options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,10 @@ services:
       # - /path/to/your/media:/media:ro
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/')"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 10s
+    security_opt:
+      - no-new-privileges:true


### PR DESCRIPTION
## Summary
Updates the `docker-compose.yml` healthcheck to use the same Python-based approach as the Dockerfile (added in #104) and adds a `security_opt` for defense in depth.

## Changes
- Switches healthcheck test from `curl` to Python `urllib.request` to match the Dockerfile's `HEALTHCHECK` instruction.
- Increases `start_period` from 5s to 10s to give the Flask app more time to boot.
- Adds `security_opt: no-new-privileges:true`.

Closes #108