### PR TITLE
chore: add mypy configuration file and centralize lint/type hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,18 @@
 repos:
 -   repo: local
     hooks:
+    -   id: flake8
+        name: flake8 linting
+        entry: bash -c "flake8 . --max-line-length=120 --exclude=venv,__pycache__,.git,node_modules"
+        language: system
+        pass_filenames: false
+        always_run: true
+    -   id: mypy
+        name: mypy type checking
+        entry: bash -c "mypy ."
+        language: system
+        pass_filenames: false
+        always_run: true
     -   id: pytest-coverage
         name: check code coverage
         entry: bash -c "export PYTHONPATH=$PYTHONPATH:. && pytest --cov=. --cov-fail-under=80 tests/"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+exclude = (venv|__pycache__|tests|node_modules)
+warn_redundant_casts = True


### PR DESCRIPTION
## Summary
Adds a dedicated `mypy.ini` configuration file so type-checking options are discoverable and reusable outside of pre-commit. Also updates `.pre-commit-config.yaml` with flake8, mypy, and pytest-coverage hooks.

## Changes
- Creates `mypy.ini` with `ignore_missing_imports = True` and `warn_redundant_casts = True`.
- Updates `.pre-commit-config.yaml` to include:
  - `flake8` hook
  - `mypy` hook (using `mypy .` without extra CLI flags)
  - `pytest-coverage` hook (existing behaviour preserved)

## Notes
- `mypy .` currently reports 10 errors on `development` because the type fixes in #103 are not yet merged. Once #103 lands, running `mypy .` will pass cleanly.

Closes #109