### PR TITLE
chore: fix flake8 formatting across anilist, mal, jellyfin, parse_test, scheduler, and routes

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -5,19 +5,19 @@ anilist.py – AniList API client for fetching user lists.
 from __future__ import annotations
 
 import requests
-from typing import Any
 
 ANILIST_API_URL = "https://graphql.anilist.co"
+
 
 def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
     """
     Fetch anime IDs from a user's AniList profile.
-    
+
     Args:
         username: The AniList username.
         status: The list status to fetch (e.g., "COMPLETED", "PLANNING", "CURRENT").
                 If None, all lists are fetched.
-                
+
     Returns:
         A list of AniList anime IDs (integers).
     """
@@ -33,7 +33,7 @@ def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
       }
     }
     """
-    
+
     variables = {
         "userName": username,
     }
@@ -59,7 +59,7 @@ def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
         timeout=15
     )
     response.raise_for_status()
-    
+
     data = response.json()
     root = data.get("data")
     if not isinstance(root, dict):
@@ -67,11 +67,11 @@ def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
     collection = root.get("MediaListCollection") or {}
     if not collection:
         return []
-        
+
     ids = []
     for user_list in collection.get("lists", []):
         for entry in user_list.get("entries", []):
             if entry.get("mediaId"):
                 ids.append(entry["mediaId"])
-                
+
     return ids

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -172,9 +172,9 @@ def add_virtual_folder(
     """
     # Strategy: Try to create with all info in query string first (most common for simple cases)
     # If it already exists, we skip creation.
-    
+
     headers = {"X-Emby-Token": api_key}
-    
+
     # Step 1: Create the virtual folder shell
     # We omit 'paths' here to avoid the 400 error.
     create_params = {
@@ -183,7 +183,7 @@ def add_virtual_folder(
     }
     if collection_type != "mixed":
         create_params["collectionType"] = collection_type
-    
+
     try:
         # data="" ensures non-JSON POST works for creation if needed
         create_resp = requests.post(
@@ -210,7 +210,7 @@ def add_virtual_folder(
             "Name": name,
             "Path": path
         }
-        
+
         try:
             # We use json= which automatically sets Content-Type: application/json
             path_resp = requests.post(
@@ -227,7 +227,7 @@ def add_virtual_folder(
             else:
                 msg += f": {exc!s}"
             raise RuntimeError(msg) from exc
-            
+
     # Step 3: Trigger a library refresh if requested
     if refresh_library:
         try:
@@ -287,7 +287,7 @@ def get_library_id(base_url: str, api_key: str, name: str, timeout: int = 30) ->
             timeout=timeout,
         )
         response.raise_for_status()
-        
+
         for folder in response.json():
             if folder.get("Name") == name:
                 item_id = folder.get("ItemId")
@@ -295,7 +295,7 @@ def get_library_id(base_url: str, api_key: str, name: str, timeout: int = 30) ->
                     return str(item_id)
     except requests.exceptions.RequestException as exc:
         logger.error(f"Failed to get library ID for {name!r}: {exc}")
-    
+
     return None
 
 
@@ -334,7 +334,7 @@ def set_virtual_folder_image(
         "X-Emby-Token": api_key,
         "Content-Type": mime_type,
     }
-    
+
     url = f"{base_url}/Items/{library_id}/Images/Primary"
     try:
         response = requests.post(

--- a/mal.py
+++ b/mal.py
@@ -9,16 +9,17 @@ from typing import Any
 
 MAL_API_BASE_URL = "https://api.myanimelist.net/v2"
 
+
 def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> list[int]:
     """
     Fetch anime IDs from a user's MyAnimeList profile.
-    
+
     Args:
         username: The MAL username.
         client_id: The MAL API Client ID.
         status: The list status to fetch (e.g., "watching", "completed", "on_hold", "dropped", "plan_to_watch").
                 If None, all lists are fetched.
-                
+
     Returns:
         A list of MyAnimeList anime IDs (integers).
     """
@@ -43,7 +44,7 @@ def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> 
         elif s == "all":
             normalized_status = None
         else:
-            normalized_status = s # Fallback to whatever user typed
+            normalized_status = s  # Fallback to whatever user typed
 
     url = f"{MAL_API_BASE_URL}/users/{username}/animelist"
     params: dict[str, Any] = {
@@ -58,20 +59,20 @@ def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> 
     }
 
     ids = []
-    
+
     while url:
         response = requests.get(url, params=params, headers=headers, timeout=15)
         response.raise_for_status()
-        
+
         data = response.json()
         for entry in data.get("data", []):
             node = entry.get("node", {})
             if node.get("id"):
                 ids.append(node["id"])
-        
+
         # MAL pagination uses a 'next' URL in the 'paging' object
         url = data.get("paging", {}).get("next")
         # Once we have the 'next' URL, params are already included in it by MAL
-        params = {} 
+        params = {}
 
     return ids

--- a/parse_test.py
+++ b/parse_test.py
@@ -1,11 +1,13 @@
-import logging
-
-logger = logging.getLogger(__name__)
 """
 parse_test.py - Unit tests for complex query parsing.
 """
 
+import logging
+
 from sync import parse_complex_query
+
+logger = logging.getLogger(__name__)
+
 
 def test_parse_complex_query():
     """Verify that complex textual queries are correctly parsed into structured rules."""
@@ -16,6 +18,7 @@ def test_parse_complex_query():
     ]
     result = parse_complex_query("Horror AND animation AND NOT comedy", "genre")
     assert result == expected
+
 
 if __name__ == "__main__":
     test_parse_complex_query()

--- a/routes.py
+++ b/routes.py
@@ -10,12 +10,10 @@ other modules, and serialise results back to JSON.
 from __future__ import annotations
 
 import base64
-import hashlib
 import logging
 import os
-import re
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import requests
@@ -25,7 +23,7 @@ from flask.typing import ResponseReturnValue
 from config import load_config, save_config
 from jellyfin import delete_virtual_folder, fetch_jellyfin_items, get_users
 from scheduler import update_scheduler_jobs, validate_cron
-from sync import get_cover_path, parse_complex_query, preview_group, run_sync
+from sync import get_cover_path, preview_group, run_sync
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +36,7 @@ MAX_B64_SIZE = 4 * 1024 * 1024
 # CSRF protection
 # ---------------------------------------------------------------------------
 
+
 @bp.before_request
 def _check_csrf() -> ResponseReturnValue | None:
     """Require X-Requested-With header on state-changing requests."""
@@ -48,6 +47,7 @@ def _check_csrf() -> ResponseReturnValue | None:
         if request.headers.get("X-Requested-With") != "XMLHttpRequest":
             return jsonify({"status": "error", "message": "CSRF validation failed"}), 403
     return None
+
 
 # ---------------------------------------------------------------------------
 # Security helpers for the filesystem browser
@@ -363,11 +363,11 @@ def upload_cover() -> ResponseReturnValue:
     """Save a base64-encoded cover image for a group.
 
     Expects a JSON body with ``group_name`` and ``image`` (data URL).
-    Decodes and saves the image to a location determined by 
-    :func:`sync.get_cover_path`: it saves to 
-    ``target_base/.covers/[md5(group_name)].jpg`` when the target directory 
+    Decodes and saves the image to a location determined by
+    :func:`sync.get_cover_path`: it saves to
+    ``target_base/.covers/[md5(group_name)].jpg`` when the target directory
     exists, otherwise it falls back to ``config/covers/[md5(group_name)].jpg``.
-    The file name used is md5(group_name) + .jpg. Reference 
+    The file name used is md5(group_name) + .jpg. Reference
     :func:`sync.get_cover_path` for the detailed storage precedence.
 
     Returns:
@@ -381,13 +381,13 @@ def upload_cover() -> ResponseReturnValue:
     image_data = data.get("image")
     if not isinstance(group_name, str) or not isinstance(image_data, str):
         return jsonify({"status": "error", "message": "group_name and image must be strings"}), 400
-    
+
     if not image_data.startswith("data:image/"):
         return jsonify({"status": "error", "message": "Invalid image format"}), 400
-    
+
     try:
         _header, encoded = image_data.split(",", 1)
-        
+
         if len(encoded) > MAX_B64_SIZE:
             return (
                 jsonify({"status": "error", "message": "Payload too large"}),
@@ -395,11 +395,11 @@ def upload_cover() -> ResponseReturnValue:
             )
 
         decoded = base64.b64decode(encoded)
-        
+
         # Determine cover storage path using the shared helper
         cfg = load_config()
         target_path = str(cfg.get("target_path", ""))
-        
+
         cover_path = get_cover_path(group_name, target_path, check_exists=False)
         # get_cover_path with check_exists=False never returns None
         assert cover_path is not None
@@ -495,7 +495,7 @@ def preview_grouping() -> ResponseReturnValue:
     type_raw = data.get("type")
     if not isinstance(type_raw, str):
         return jsonify({"status": "error", "message": "Missing or invalid 'type'"}), 400
-    
+
     type_name = type_raw.lower().strip()
     allowed_types = {"genre", "studio", "tag", "year", "actor", "general", "complex"}
     if not type_name or type_name not in allowed_types:
@@ -508,7 +508,7 @@ def preview_grouping() -> ResponseReturnValue:
     val_raw = data.get("value")
     if not isinstance(val_raw, str):
         return jsonify({"status": "error", "message": "Value must be a string"}), 400
-    
+
     val = val_raw.strip()
     if not val:
         return jsonify({"status": "error", "message": "Value cannot be empty"}), 400
@@ -549,9 +549,9 @@ def get_cleanup_items() -> ResponseReturnValue:
     target_base: str = str(config.get("target_path", ""))
     if not target_base or not os.path.exists(target_base):
         return jsonify({"status": "success", "items": []})
-        
+
     configured_groups: set[str] = {str(g.get("name")) for g in config.get("groups", []) if g.get("name")}
-    
+
     try:
         entries: list[dict[str, Any]] = []
         for name in os.listdir(target_base):
@@ -572,30 +572,30 @@ def perform_cleanup() -> ResponseReturnValue:
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return jsonify({"status": "error", "message": "Request body must be JSON"}), 400
-        
+
     folders = data.get("folders", [])
     if not isinstance(folders, list):
-         return jsonify({"status": "error", "message": "'folders' must be a list"}), 400
-         
+        return jsonify({"status": "error", "message": "'folders' must be a list"}), 400
+
     config: dict[str, Any] = load_config()
     target_base: str = str(config.get("target_path", ""))
     if not target_base or not os.path.exists(target_base):
         return jsonify({"status": "error", "message": "Target path not found"}), 404
-        
+
     deleted: int = 0
     errors: list[str] = []
     for name in folders:
         if not isinstance(name, str) or not name or "/" in name or "\\" in name or name == ".." or name == ".":
             errors.append(f"Invalid folder name: {name}")
             continue
-            
+
         path = os.path.join(target_base, name)
         if os.path.exists(path) and os.path.isdir(path):
             try:
                 import shutil
                 shutil.rmtree(path)
                 deleted += 1
-                
+
                 # Also delete from Jellyfin if configured
                 if config.get("auto_create_libraries"):
                     url = str(config.get("jellyfin_url", "")).rstrip("/")
@@ -607,7 +607,7 @@ def perform_cleanup() -> ResponseReturnValue:
                             logger.warning(f"Failed to delete Jellyfin library '{name}': {e}")
             except OSError as exc:
                 errors.append(f"Failed to delete {name}: {exc}")
-                
+
     if errors:
         return jsonify({"status": "partial_success", "deleted": deleted, "errors": errors}), 207
     return jsonify({"status": "success", "deleted": deleted})
@@ -825,7 +825,7 @@ def get_test_results() -> ResponseReturnValue:
                 results[filename] = "Error reading file."
         else:
             results[filename] = "No output found."
-            
+
     return jsonify({"status": "success", "results": results})
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -8,10 +8,9 @@ to either a global schedule (with exclusions) or per-group schedules.
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
+from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore[import-untyped]
+from apscheduler.triggers.cron import CronTrigger  # type: ignore[import-untyped]
 
 import threading
 from config import load_config
@@ -22,12 +21,14 @@ _scheduler = BackgroundScheduler()
 sync_lock = threading.Lock()
 logger = logging.getLogger(__name__)
 
+
 def start_scheduler() -> None:
     """Start the background scheduler and load jobs from config."""
     if not _scheduler.running:
         _scheduler.start()
         logger.info("Background scheduler started")
     update_scheduler_jobs()
+
 
 def update_scheduler_jobs() -> None:
     """Synchronise the scheduled jobs with the current configuration."""
@@ -42,7 +43,7 @@ def update_scheduler_jobs() -> None:
         cron_expr = sched_cfg.get("global_schedule")
         if cron_expr:
             try:
-                excluded_names = sched_cfg.get("global_exclude_ids", []) # We use names as IDs for now
+                excluded_names = sched_cfg.get("global_exclude_ids", [])  # We use names as IDs for now
                 _scheduler.add_job(
                     _run_global_sync_job,
                     CronTrigger.from_crontab(cron_expr),
@@ -58,11 +59,11 @@ def update_scheduler_jobs() -> None:
     for group in groups:
         if not isinstance(group, dict):
             continue
-            
+
         group_name = group.get("name")
         if not group_name:
             continue
-            
+
         if group.get("schedule_enabled") and group.get("schedule"):
             cron_expr = group["schedule"]
             try:
@@ -78,7 +79,7 @@ def update_scheduler_jobs() -> None:
                 logger.exception(f"Failed to schedule sync for group '{group_name}'")
 
     # 3. Cleanup Scheduler
-    if sched_cfg.get("cleanup_enabled", True): # Default to true
+    if sched_cfg.get("cleanup_enabled", True):  # Default to true
         cleanup_cron = sched_cfg.get("cleanup_schedule", "0 * * * *")
         if cleanup_cron:
             try:
@@ -97,7 +98,7 @@ def _run_global_sync_job(exclude_names: list[str]) -> None:
     """Job handler for global sync."""
     config = load_config()
     all_groups = config.get("groups", [])
-    
+
     # Filter out excluded groups
     sync_names: list[str] = []
     for g in all_groups:
@@ -105,7 +106,7 @@ def _run_global_sync_job(exclude_names: list[str]) -> None:
             name = g.get("name")
             if isinstance(name, str) and name not in exclude_names:
                 sync_names.append(name)
-    
+
     if sync_names:
         logger.info(f"Background global sync starting for groups: {sync_names}")
         with sync_lock:
@@ -113,12 +114,14 @@ def _run_global_sync_job(exclude_names: list[str]) -> None:
     else:
         logger.info("Background global sync skipped: no groups to sync after exclusions")
 
+
 def _run_group_sync_job(group_name: str) -> None:
     """Job handler for a single group sync."""
     config = load_config()
     logger.info(f"Background sync starting for group: {group_name}")
     with sync_lock:
         run_sync(config, group_names=[group_name])
+
 
 def _run_cleanup_job() -> None:
     """Job handler for cleaning up broken symlinks."""
@@ -151,4 +154,3 @@ def validate_cron(expr: str) -> str | None:
     except (ValueError, TypeError, AttributeError) as exc:
         return f"Invalid cron expression: {exc}"
     return None
-


### PR DESCRIPTION
## Summary
Fixes flake8 formatting issues across multiple files and resolves mypy import-untyped errors in scheduler.py.

### Changes
- **anilist.py**: Remove unused `typing.Any` import; fix blank lines and trailing whitespace
- **mal.py**: Fix blank lines, trailing whitespace, and inline comment spacing
- **jellyfin.py**: Strip whitespace from blank lines
- **parse_test.py**: Restructure module docstring/imports order; fix blank lines
- **scheduler.py**: Remove unused `typing.Any`; fix blank lines and inline comment spacing; add `# type: ignore[import-untyped]` for apscheduler imports
- **routes.py**: Remove unused imports (`hashlib`, `re`, `as_completed`, `parse_complex_query`); fix trailing whitespace and indentation error

### Issues resolved
- Closes #113
- Closes #114
- Closes #115
- Closes #116
- Closes #117