### PR TITLE
chore: fix flake8 formatting across all test files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,11 @@
-import sys
-import os
-import json
-import shutil
+from app import app as flask_app
 import threading
 import time
 import requests
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from tests.virtual_jellyfin import app as jelly_mock_app
+
 
 @pytest.fixture(scope="session")
 def virtual_jellyfin():
@@ -43,8 +41,6 @@ def mock_scheduler():
 def pytest_configure(config):
     config.addinivalue_line("markers", "e2e: end-to-end tests requiring real Jellyfin instance")
 
-from app import app as flask_app
-from config import DEFAULT_CONFIG, CONFIG_DIR
 
 @pytest.fixture
 def app():
@@ -53,15 +49,17 @@ def app():
     flask_app.config.update({
         "TESTING": True,
     })
-    
+
     with flask_app.app_context():
         yield flask_app
-    
+
     flask_app.config = old_config
+
 
 @pytest.fixture
 def client(app):
     return app.test_client()
+
 
 @pytest.fixture
 def temp_config(tmp_path):
@@ -69,20 +67,21 @@ def temp_config(tmp_path):
     test_config_dir = tmp_path / "config"
     test_config_dir.mkdir()
     test_config_file = test_config_dir / "config.json"
-    
+
     # Mock CONFIG_FILE in config module
     import config
     original_config_file = config.CONFIG_FILE
     original_config_dir = config.CONFIG_DIR
-    
+
     config.CONFIG_FILE = str(test_config_file)
     config.CONFIG_DIR = str(test_config_dir)
-    
+
     yield test_config_file
-    
+
     # Restore original paths
     config.CONFIG_FILE = original_config_file
     config.CONFIG_DIR = original_config_dir
+
 
 @pytest.fixture
 def mock_jellyfin_items():

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,7 +1,5 @@
 """Tests for API route handlers with mocked Jellyfin client."""
 
-import json
-import pytest
 from unittest.mock import MagicMock, patch
 import requests as requests_lib
 
@@ -66,7 +64,7 @@ class TestMetadataEndpoints:
     def test_metadata_returns_categories(self, client):
         """Test successful metadata response has expected categories."""
         with patch("routes.load_config") as mock_load, \
-             patch("routes.requests.get") as mock_get:
+                patch("routes.requests.get") as mock_get:
             mock_load.return_value = {
                 "jellyfin_url": "http://localhost:8096",
                 "api_key": "test-key"
@@ -74,7 +72,6 @@ class TestMetadataEndpoints:
 
             def mock_jellyfin(url, **kwargs):
                 m = MagicMock()
-                params = kwargs.get("params", {})
                 if "Genres" in url:
                     m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Thriller"}]}
                 elif "Studios" in url:
@@ -111,7 +108,7 @@ class TestPreviewEndpoint:
     def test_preview_with_valid_params(self, client):
         """Preview with genre type returns item count."""
         with patch("routes.load_config") as mock_load, \
-             patch("routes.preview_group") as mock_preview:
+                patch("routes.preview_group") as mock_preview:
             mock_load.return_value = {
                 "jellyfin_url": "http://localhost:8096",
                 "api_key": "test-key"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,30 +1,25 @@
 import os
-import pytest
 from sync import run_cleanup_broken_symlinks
+
 
 def test_run_cleanup_broken_symlinks(tmp_path):
     """Test that broken symlinks are removed and healthy ones are kept."""
     target_base = tmp_path / "target"
     target_base.mkdir()
-    
     # Create a real file
     real_file = tmp_path / "original.txt"
     real_file.write_text("hello")
-    
     # Create a healthy symlink
     healthy_link = target_base / "healthy.txt"
     os.symlink(str(real_file), str(healthy_link))
-    
     # Create a broken symlink (target doesn't exist)
     broken_link = target_base / "broken.txt"
     os.symlink(str(tmp_path / "nonexistent.txt"), str(broken_link))
-    
     # Create a broken symlink in a subdirectory
     sub_dir = target_base / "subdir"
     sub_dir.mkdir()
     broken_sub_link = sub_dir / "broken_sub.txt"
     os.symlink(str(tmp_path / "nonexistent_sub.txt"), str(broken_sub_link))
-    
     # Verify initial state
     assert healthy_link.is_symlink()
     assert os.path.exists(healthy_link)
@@ -32,16 +27,15 @@ def test_run_cleanup_broken_symlinks(tmp_path):
     assert not os.path.exists(broken_link)
     assert broken_sub_link.is_symlink()
     assert not os.path.exists(broken_sub_link)
-    
     # Run cleanup
     config = {"target_path": str(target_base), "groups": []}
     deleted_count = run_cleanup_broken_symlinks(config)
-    
     # Verify final state
     assert deleted_count == 2
     assert healthy_link.exists()
     assert not broken_link.is_symlink()
     assert not broken_sub_link.is_symlink()
+
 
 def test_run_cleanup_invalid_path():
     """Test cleanup with a non-existent path."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import os
 import json
 from config import load_config, save_config, DEFAULT_CONFIG
 
+
 def test_load_config_defaults(temp_config):
     """Test that loading a non-existent config returns defaults."""
     cfg = load_config()
@@ -9,15 +10,17 @@ def test_load_config_defaults(temp_config):
     assert cfg["groups"] == []
     assert os.path.exists(temp_config)
 
+
 def test_save_and_load_config(temp_config):
     """Test saving and then loading configuration."""
     import copy
     new_cfg = copy.deepcopy(DEFAULT_CONFIG)
     new_cfg["jellyfin_url"] = "http://localhost:8096"
     save_config(new_cfg)
-    
+
     loaded_cfg = load_config()
     assert loaded_cfg["jellyfin_url"] == "http://localhost:8096"
+
 
 def test_config_migration(temp_config):
     """Test that legacy keys are migrated to new names."""
@@ -27,12 +30,13 @@ def test_config_migration(temp_config):
     }
     with open(temp_config, "w") as f:
         json.dump(legacy_cfg, f)
-        
+
     cfg = load_config()
     assert cfg["media_path_in_jellyfin"] == "/jellyfin/path"
     assert cfg["media_path_on_host"] == "/host/path"
     assert "jellyfin_root" not in cfg
     assert "host_root" not in cfg
+
 
 def test_nested_defaults(temp_config):
     """Test that nested keys gain defaults if missing."""
@@ -43,7 +47,7 @@ def test_nested_defaults(temp_config):
     }
     with open(temp_config, "w") as f:
         json.dump(partial_cfg, f)
-        
+
     cfg = load_config()
     assert cfg["scheduler"]["global_enabled"] is True
     assert cfg["scheduler"]["global_schedule"] == "0 0 * * *"

--- a/tests/test_deep_sync.py
+++ b/tests/test_deep_sync.py
@@ -1,24 +1,25 @@
 import pytest
 import requests
 from sync import run_sync
-from jellyfin import fetch_jellyfin_items
-
 from unittest.mock import patch
+
 
 @pytest.fixture(autouse=True)
 def mock_filesystem():
     """Mock filesystem checks to avoid dependency on real files."""
     with patch('sync.os.path.exists', return_value=True), \
-         patch('sync.os.makedirs'), \
-         patch('sync.os.symlink'), \
-         patch('sync.shutil.rmtree'):
+            patch('sync.os.makedirs'), \
+            patch('sync.os.symlink'), \
+            patch('sync.shutil.rmtree'):
         yield
+
 
 def test_mock_server_up(virtual_jellyfin):
     """Verify the mock server is actually reachable."""
     response = requests.get(f"{virtual_jellyfin}/System/Info")
     assert response.status_code == 200
     assert response.json()["ServerName"] == "Virtual-Jellyfin-Mock"
+
 
 def test_sync_with_diverse_data(virtual_jellyfin):
     """Test sync with the expanded dataset from virtual_jellyfin."""
@@ -43,17 +44,14 @@ def test_sync_with_diverse_data(virtual_jellyfin):
             }
         ]
     }
-    
     # Action classics: The Matrix (1999) [Action, Sci-Fi]
     # Modern Sci-Fi: Inception (2010), Interstellar (2014)
-    
     results = run_sync(config, dry_run=True)
-    
     action_classics = next(r for r in results if r["group"] == "Action Classics")
     modern_scifi = next(r for r in results if r["group"] == "Modern Sci-Fi")
-    
     assert action_classics["links"] >= 1
     assert modern_scifi["links"] >= 2
+
 
 def test_sync_robustness_missing_metadata(virtual_jellyfin):
     """Test sync handles items with missing metadata gracefully."""
@@ -70,12 +68,12 @@ def test_sync_robustness_missing_metadata(virtual_jellyfin):
             }
         ]
     }
-    
     # This should not crash even with items like "Empty Item" or "Movie Without Year"
     results = run_sync(config, dry_run=True)
     assert len(results) == 1
     # We have ~70 movies + some edge cases. Total items ~140.
     assert results[0]["links"] >= 70
+
 
 def test_sync_large_volume(virtual_jellyfin):
     """Test sync with a large volume of items (1000+)."""
@@ -92,10 +90,10 @@ def test_sync_large_volume(virtual_jellyfin):
             }
         ]
     }
-    
     results = run_sync(config, dry_run=True)
     # 106 unique items * 40 = 4240 items.
     assert results[0]["links"] >= 4000
+
 
 def test_sync_complex_nested_queries(virtual_jellyfin):
     """Test deep nested logical queries."""
@@ -112,9 +110,9 @@ def test_sync_complex_nested_queries(virtual_jellyfin):
             }
         ]
     }
-    
     results = run_sync(config, dry_run=True)
     assert results[0]["links"] > 0
+
 
 def test_sync_chaos_robustness(virtual_jellyfin):
     """Test sync handles 'Digital Chaos' scenarios (duplicates, emojis, malformed data)."""
@@ -131,7 +129,6 @@ def test_sync_chaos_robustness(virtual_jellyfin):
             }
         ]
     }
-    
     # This should not crash despite:
     # - Duplicate ID "chaos_1"
     # - Malformed Year "Nineteen Ninety Nine"
@@ -141,6 +138,7 @@ def test_sync_chaos_robustness(virtual_jellyfin):
     results = run_sync(config, dry_run=True)
     assert len(results) == 1
     assert results[0]["links"] > 0
+
 
 def test_sync_mixed_character_encodings(virtual_jellyfin):
     """Test handles mixed LTR/RTL and emoji titles without encoding errors."""
@@ -157,6 +155,5 @@ def test_sync_mixed_character_encodings(virtual_jellyfin):
             }
         ]
     }
-    
     results = run_sync(config, dry_run=True)
     assert results[0]["links"] > 0

--- a/tests/test_e2e/conftest.py
+++ b/tests/test_e2e/conftest.py
@@ -5,7 +5,7 @@ Run with: pytest tests/test_e2e/ -v -m e2e
 """
 
 import os
-import json
+
 import time
 import pytest
 import requests

--- a/tests/test_e2e/test_e2e_sync.py
+++ b/tests/test_e2e/test_e2e_sync.py
@@ -1,7 +1,6 @@
 """E2E tests for full sync cycle."""
 
-import os
-import json
+
 import pytest
 import requests
 from .conftest import api_post, api_get

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -14,45 +14,48 @@ def test_fetch_letterboxd_list(mock_get):
     mock_list_resp = MagicMock()
     mock_list_resp.status_code = 200
     mock_list_resp.text = 'data-film-slug="the-godfather"'
-    
+
     # Mock film detail page
     mock_film_resp = MagicMock()
     mock_film_resp.status_code = 200
     mock_film_resp.text = 'href="https://www.imdb.com/title/tt0068646/"'
-    
+
     mock_get.side_effect = [mock_list_resp, mock_film_resp]
-    
+
     ids = fetch_letterboxd_list("https://letterboxd.com/user/list/my-list")
     assert ids == ["tt0068646"]
+
 
 @patch('requests.Session.get')
 def test_fetch_letterboxd_list_tmdb(mock_get):
     # Test TMDb ID extraction and pagination stop
     mock_list_resp = MagicMock()
     mock_list_resp.status_code = 200
-    mock_list_resp.text = 'data-film-slug="film1" class="next"' 
-    
+    mock_list_resp.text = 'data-film-slug="film1" class="next"'
+
     mock_film_resp = MagicMock()
     mock_film_resp.status_code = 200
     mock_film_resp.text = 'data-tmdb-id="500"'
-    
+
     # Page 2
     mock_list_page2 = MagicMock()
     mock_list_page2.status_code = 200
-    mock_list_page2.text = 'data-film-slug="film2"' # No "next" class
-    
+    mock_list_page2.text = 'data-film-slug="film2"'  # No "next" class
+
     mock_film2_resp = MagicMock()
     mock_film2_resp.status_code = 200
     mock_film2_resp.text = 'href="https://www.themoviedb.org/movie/600"'
 
     mock_get.side_effect = [mock_list_resp, mock_film_resp, mock_list_page2, mock_film2_resp]
-    
+
     ids = fetch_letterboxd_list("https://letterboxd.com/user/list/my-list")
     assert ids == ["500", "600"]
+
 
 def test_fetch_letterboxd_invalid_url():
     with pytest.raises(ValueError, match="Invalid Letterboxd URL"):
         fetch_letterboxd_list("https://not-lb-domain.com")
+
 
 @patch('requests.Session.get')
 def test_fetch_letterboxd_http_error(mock_get):
@@ -63,6 +66,7 @@ def test_fetch_letterboxd_http_error(mock_get):
     with pytest.raises(RuntimeError, match="Failed to fetch Letterboxd"):
         fetch_letterboxd_list("https://letterboxd.com/user/list/list")
 
+
 @patch('requests.get')
 def test_fetch_mal_list(mock_get):
     mock_resp = MagicMock()
@@ -72,12 +76,13 @@ def test_fetch_mal_list(mock_get):
         "paging": {}
     }
     mock_get.return_value = mock_resp
-    
+
     ids = fetch_mal_list("user", "client_id", "watching")
     assert ids == [123]
     # Verify status normalization
     _args, kwargs = mock_get.call_args
     assert kwargs['params']['status'] == "watching"
+
 
 @patch('requests.get')
 def test_fetch_mal_pagination(mock_get):
@@ -97,6 +102,7 @@ def test_fetch_mal_pagination(mock_get):
     ids = fetch_mal_list("user", "cid")
     assert ids == [1, 2]
 
+
 @patch('requests.get')
 def test_fetch_trakt_list(mock_get):
     mock_resp = MagicMock()
@@ -106,10 +112,9 @@ def test_fetch_trakt_list(mock_get):
     ]
     mock_resp.headers = {"X-Pagination-Page-Count": "1"}
     mock_get.return_value = mock_resp
-    
+
     ids = fetch_trakt_list("username/list", "client_id")
     assert ids == ["tt123"]
-
 
 
 @patch('requests.post')
@@ -123,12 +128,12 @@ def test_fetch_anilist_all(mock_post):
     assert 'status' not in kwargs['json']['variables']
 
 
-
 def test_fetch_tmdb_invalid_args():
     with pytest.raises(ValueError, match=r"A TMDb API Key is required to fetch TMDb lists\."):
         fetch_tmdb_list("123", "")
     with pytest.raises(ValueError, match=r"A TMDb List ID is required\."):
         fetch_tmdb_list("", "key")
+
 
 @patch('requests.get')
 def test_fetch_tmdb_url_parsing(mock_get):
@@ -140,6 +145,7 @@ def test_fetch_tmdb_url_parsing(mock_get):
     args, _kwargs = mock_get.call_args
     assert "list/999" in args[0]
 
+
 @patch('requests.get')
 def test_fetch_mal_error(mock_get):
     mock_resp = MagicMock()
@@ -148,6 +154,7 @@ def test_fetch_mal_error(mock_get):
     mock_get.return_value = mock_resp
     with pytest.raises(requests.exceptions.HTTPError):
         fetch_mal_list("u", "c")
+
 
 @patch('requests.get')
 def test_fetch_trakt_pagination(mock_get):
@@ -162,6 +169,7 @@ def test_fetch_trakt_pagination(mock_get):
     mock_get.side_effect = [resp1, resp2]
     ids = fetch_trakt_list("u/l", "c")
     assert ids == ["tt1", "tt2"]
+
 
 @patch('requests.post')
 def test_fetch_anilist_empty_data(mock_post):

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -1,9 +1,9 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from imdb import fetch_imdb_list
 from tmdb import fetch_tmdb_list
 from anilist import fetch_anilist_list
 from jellyfin import fetch_jellyfin_items
+
 
 @patch('jellyfin.requests.get')
 def test_fetch_jellyfin_items(mock_get):
@@ -11,7 +11,6 @@ def test_fetch_jellyfin_items(mock_get):
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"Items": [{"Name": "M1"}]}
     mock_get.return_value = mock_resp
-    
     items = fetch_jellyfin_items("http://jf", "key", {"Type": "Movie"})
     assert items == [{"Name": "M1"}]
     # Verify params
@@ -19,14 +18,15 @@ def test_fetch_jellyfin_items(mock_get):
     assert kwargs['headers']['X-Emby-Token'] == "key"
     assert kwargs['params']['Type'] == "Movie"
 
+
 @patch('imdb.requests.get')
 def test_fetch_imdb_list(mock_get):
     mock_response = MagicMock()
     mock_response.text = '<html><div class="lister-item-header"><a href="/title/tt1234567/"></a></div></html>'
     mock_get.return_value = mock_response
-    
     ids = fetch_imdb_list("ls12345")
     assert ids == ["tt1234567"]
+
 
 @patch('tmdb.requests.get')
 def test_fetch_tmdb_list(mock_get):
@@ -39,9 +39,9 @@ def test_fetch_tmdb_list(mock_get):
         "total_pages": 1
     }
     mock_get.return_value = mock_response
-    
     ids = fetch_tmdb_list("123", "api_key")
     assert ids == ["101", "202"]
+
 
 @patch('anilist.requests.post')
 def test_fetch_anilist_list(mock_post):
@@ -56,7 +56,6 @@ def test_fetch_anilist_list(mock_post):
         }
     }
     mock_post.return_value = mock_response
-    
     ids = fetch_anilist_list("username", "completed")
     assert ids == [12345]
     _args, kwargs = mock_post.call_args

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -1,3 +1,4 @@
+import requests
 import logging
 from unittest.mock import patch, MagicMock
 import pytest
@@ -8,13 +9,14 @@ from jellyfin import (
     remove_from_collection, delete_collection, set_collection_image,
 )
 
+
 @patch('requests.get')
 def test_get_libraries(mock_get):
     mock_response = MagicMock()
     mock_response.json.return_value = [{"Name": "Movies"}, {"Name": "TV Shows"}]
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
-    
+
     libs = get_libraries("http://localhost:8096", "test_key")
     assert libs == ["Movies", "TV Shows"]
     mock_get.assert_called_with(
@@ -23,33 +25,36 @@ def test_get_libraries(mock_get):
         timeout=30
     )
 
+
 @patch('requests.post')
 def test_add_virtual_folder_success(mock_post):
     mock_response = MagicMock()
     mock_response.ok = True
     mock_response.status_code = 200
     mock_post.return_value = mock_response
-    
+
     add_virtual_folder("http://localhost:8096", "test_key", "NewLib", ["/path1"])
-    
+
     # 1 for creation, 1 for path addition, 1 for refresh
     assert mock_post.call_count == 3
+
 
 @patch('requests.post')
 def test_add_virtual_folder_already_exists(mock_post):
     mock_response_409 = MagicMock()
     mock_response_409.ok = False
     mock_response_409.status_code = 409
-    
+
     mock_response_200 = MagicMock()
     mock_response_200.ok = True
     mock_response_200.status_code = 200
-    
+
     # 409 on create, then 200 on path and refresh
     mock_post.side_effect = [mock_response_409, mock_response_200, mock_response_200]
-    
+
     add_virtual_folder("http://localhost:8096", "test_key", "Exists", ["/path1"])
     assert mock_post.call_count == 3
+
 
 @patch('requests.post')
 def test_add_virtual_folder_creation_failure(mock_post):
@@ -57,49 +62,51 @@ def test_add_virtual_folder_creation_failure(mock_post):
     mock_response.ok = False
     mock_response.status_code = 500
     mock_response.text = "Internal Server Error"
-    
+
     # We need to mock raise_for_status to raise an exception
     import requests
     mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
     mock_post.return_value = mock_response
-    
+
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder("http://localhost:8096", "test_key", "FailLib", ["/path1"])
-    
+
     assert "Failed to create virtual folder 'FailLib'" in str(excinfo.value)
     assert "Status 500" in str(excinfo.value)
     assert "Internal Server Error" in str(excinfo.value)
+
 
 @patch('requests.post')
 def test_add_virtual_folder_path_failure(mock_post):
     mock_response_ok = MagicMock()
     mock_response_ok.ok = True
     mock_response_ok.status_code = 200
-    
+
     mock_response_fail = MagicMock()
     mock_response_fail.ok = False
     mock_response_fail.status_code = 400
     mock_response_fail.text = "Invalid Path"
-    
+
     import requests
     mock_response_fail.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response_fail)
-    
+
     # OK on create, Fail on path
     mock_post.side_effect = [mock_response_ok, mock_response_fail]
-    
+
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder("http://localhost:8096", "test_key", "PathFail", ["/bad/path"])
-    
+
     assert "Failed to add path '/bad/path' to library 'PathFail'" in str(excinfo.value)
     assert "Status 400" in str(excinfo.value)
     assert "Invalid Path" in str(excinfo.value)
+
 
 @patch('requests.delete')
 def test_delete_virtual_folder(mock_delete):
     mock_response = MagicMock()
     mock_response.ok = True
     mock_delete.return_value = mock_response
-    
+
     delete_virtual_folder("http://localhost:8096", "test_key", "ToDelete")
     assert mock_delete.called
     mock_delete.assert_called_with(
@@ -109,22 +116,24 @@ def test_delete_virtual_folder(mock_delete):
         timeout=30
     )
 
+
 @patch('requests.post')
 def test_add_virtual_folder_mixed(mock_post):
     mock_response = MagicMock()
     mock_response.ok = True
     mock_response.status_code = 200
     mock_post.return_value = mock_response
-    
+
     add_virtual_folder("http://localhost:8096", "test_key", "MixedLib", ["/path1"], collection_type="mixed")
-    
+
     # Check the first call (creation) parameters
     args, kwargs = mock_post.call_args_list[0]
     params = kwargs.get('params', {})
-    
+
     assert "collectionType" not in params
     assert params["name"] == "MixedLib"
     assert params["refreshLibrary"] == "false"
+
 
 @patch('requests.get')
 def test_get_library_id(mock_get):
@@ -144,6 +153,7 @@ def test_get_library_id(mock_get):
     item_id_orphans = get_library_id("http://localhost:8096", "test_key", "Orphans")
     assert item_id_orphans is None
 
+
 @patch('mimetypes.guess_type')
 @patch('builtins.open')
 @patch('requests.post')
@@ -152,19 +162,20 @@ def test_set_virtual_folder_image(mock_get_library_id, mock_post, mock_open, moc
     mock_guess.return_value = ("image/jpeg", None)
     mock_get_library_id.return_value = "12345"
     mock_open.return_value.__enter__.return_value.read.return_value = b"image_data"
-    
+
     mock_response = MagicMock()
     mock_response.ok = True
     mock_post.return_value = mock_response
 
     set_virtual_folder_image("http://localhost:8096", "test_key", "Movies", "/path/to/image.jpg")
-    
+
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
     assert args[0] == "http://localhost:8096/Items/12345/Images/Primary"
     assert kwargs["data"] == b"image_data"
     assert kwargs["headers"]["X-Emby-Token"] == "test_key"
     assert kwargs["headers"]["Content-Type"] == "image/jpeg"
+
 
 @patch('requests.get')
 def test_get_users(mock_get):
@@ -177,12 +188,13 @@ def test_get_users(mock_get):
     assert len(users) == 2
     assert users[0]["Id"] == "u1"
     assert users[0]["Name"] == "Alice"
-    
+
     mock_get.assert_called_once_with(
         "http://localhost:8096/Users",
         headers={"X-Emby-Token": "test_key"},
         timeout=30
     )
+
 
 @patch('requests.get')
 def test_get_user_recent_items(mock_get):
@@ -194,7 +206,7 @@ def test_get_user_recent_items(mock_get):
     items = get_user_recent_items("http://localhost:8096", "test_key", "u1", limit=10)
     assert len(items) == 2
     assert items[0]["Name"] == "Movie 1"
-    
+
     expected_params = {
         "Filters": "IsPlayed",
         "SortBy": "DatePlayed",
@@ -211,65 +223,69 @@ def test_get_user_recent_items(mock_get):
         timeout=30
     )
 
-import requests
 
 @patch('requests.post')
 def test_add_virtual_folder_creation_failure_no_response(mock_post):
     mock_post.side_effect = requests.exceptions.RequestException("Network Error")
-    
+
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder("http://localhost:8096", "test_key", "FailLib", ["/path1"])
-    
+
     assert "Failed to create virtual folder 'FailLib': Network Error" in str(excinfo.value)
+
 
 @patch('requests.post')
 def test_add_virtual_folder_path_failure_no_response(mock_post):
     mock_response_ok = MagicMock()
     mock_response_ok.ok = True
     mock_response_ok.status_code = 200
-    
+
     # First call OK, second call RequestException
     mock_post.side_effect = [mock_response_ok, requests.exceptions.RequestException("Path Network Error")]
-    
+
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder("http://localhost:8096", "test_key", "FailLib", ["/path1"])
-    
+
     assert "Failed to add path '/path1' to library 'FailLib': Path Network Error" in str(excinfo.value)
+
 
 @patch('requests.post')
 def test_add_virtual_folder_refresh_failure(mock_post):
     mock_response_ok = MagicMock()
     mock_response_ok.ok = True
     mock_response_ok.status_code = 200
-    
+
     mock_response_fail = MagicMock()
     mock_response_fail.ok = False
     mock_response_fail.status_code = 502
     mock_response_fail.text = "Bad Gateway"
-    
+
     mock_response_fail.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response_fail)
-    
+
     # create OK, path OK, refresh HTTPError
     mock_post.side_effect = [mock_response_ok, mock_response_ok, mock_response_fail]
-    
+
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder("http://localhost:8096", "test_key", "RefreshFail", ["/path1"])
-    
+
     assert "Failed to trigger library refresh for 'RefreshFail' (Status 502): Bad Gateway" in str(excinfo.value)
+
 
 @patch('requests.post')
 def test_add_virtual_folder_refresh_failure_no_response(mock_post):
     mock_response_ok = MagicMock()
     mock_response_ok.ok = True
     mock_response_ok.status_code = 200
-    
+
     # create OK, path OK, refresh RequestException
-    mock_post.side_effect = [mock_response_ok, mock_response_ok, requests.exceptions.RequestException("Refresh Network Error")]
-    
+    mock_post.side_effect = [mock_response_ok, mock_response_ok,
+                             requests.exceptions.RequestException("Refresh Network Error")]
+
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder("http://localhost:8096", "test_key", "RefreshFail", ["/path1"])
-    
+
     assert "Failed to trigger library refresh for 'RefreshFail': Refresh Network Error" in str(excinfo.value)
+
 
 @patch('requests.delete')
 def test_delete_virtual_folder_not_ok(mock_delete, caplog):
@@ -284,6 +300,7 @@ def test_delete_virtual_folder_not_ok(mock_delete, caplog):
 
     assert "Delete Virtual Folder Failed (404): Not Found" in caplog.text
 
+
 @patch('requests.get')
 def test_get_library_id_request_exception(mock_get, caplog):
     mock_get.side_effect = requests.exceptions.RequestException("Fetch Error")
@@ -293,6 +310,7 @@ def test_get_library_id_request_exception(mock_get, caplog):
 
     assert "Failed to get library ID for 'MyLib': Fetch Error" in caplog.text
 
+
 @patch('jellyfin.get_library_id')
 def test_set_virtual_folder_image_no_library_id(mock_get_library_id, caplog):
     mock_get_library_id.return_value = None
@@ -300,6 +318,7 @@ def test_set_virtual_folder_image_no_library_id(mock_get_library_id, caplog):
     set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
 
     assert "Cannot set image: Library 'MyLib' not found or ID unknown." in caplog.text
+
 
 @patch('jellyfin.get_library_id')
 def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
@@ -309,6 +328,7 @@ def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
         set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
 
     assert "Cannot set image: Failed to read image file '/path/to/img.jpg': Permission Denied" in caplog.text
+
 
 @patch('mimetypes.guess_type')
 @patch('builtins.open')
@@ -334,11 +354,14 @@ def test_set_virtual_folder_image_request_exception(mock_get_library_id, mock_po
 
     assert "Failed to set image for library 'MyLib' (Status 400): Bad Request" in caplog.text
 
+
 @patch('mimetypes.guess_type')
 @patch('builtins.open')
 @patch('requests.post')
 @patch('jellyfin.get_library_id')
-def test_set_virtual_folder_image_request_exception_no_response(mock_get_library_id, mock_post, mock_open, mock_guess, caplog):
+def test_set_virtual_folder_image_request_exception_no_response(
+    mock_get_library_id, mock_post, mock_open, mock_guess, caplog
+):
     mock_guess.return_value = ("image/jpeg", None)
     mock_get_library_id.return_value = "123"
     mock_open.return_value.__enter__.return_value.read.return_value = b"image_data"

--- a/tests/test_metadata_rules.py
+++ b/tests/test_metadata_rules.py
@@ -1,14 +1,9 @@
 """Tests for metadata rule parsing used in grouping filters.
-
 The JS frontend parses filter strings like "Horror AND Action AND NOT Comedy".
 These tests verify the Python-side logic for parsing and filtering rules.
 """
-
-import pytest
-
 # Replicating the frontend's parseMetadataValue logic in Python for testing
 # the algorithm's correctness (the backend sync engine applies these rules).
-
 import re
 
 
@@ -16,7 +11,6 @@ def parse_metadata_value(val_str):
     """Python equivalent of parseMetadataValue from metadata.js."""
     if not val_str or val_str.strip() == "":
         return [{"operator": "", "value": ""}]
-
     pattern = r"\s+(AND NOT|OR NOT|AND|OR)\s+"
     parts = re.split(pattern, val_str, flags=re.IGNORECASE)
     rules = []
@@ -27,15 +21,12 @@ def parse_metadata_value(val_str):
         if match:
             return {"type": match.group(1), "value": match.group(2).strip()}
         return {"value": s}
-
     first = parse_rule(parts[0])
     rules.append({"operator": "", **first})
-
     for i in range(1, len(parts), 2):
         rest = parse_rule(parts[i + 1])
         op = parts[i].strip().upper().replace(r"\s+", " ")
         rules.append({"operator": op, **rest})
-
     return rules
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -50,8 +50,10 @@ def test_patched_get_success(monkeypatch):
 
     class FakeResp:
         status_code = 200
+
         def json(self):
             return {"ok": True}
+
         def raise_for_status(self):
             pass
 
@@ -97,8 +99,10 @@ def test_patched_post_success(monkeypatch):
 
     class FakeResp:
         status_code = 201
+
         def json(self):
             return {"created": True}
+
         def raise_for_status(self):
             pass
 
@@ -129,8 +133,10 @@ def test_patched_delete_success(monkeypatch):
 
     class FakeResp:
         status_code = 204
+
         def json(self):
             return {}
+
         def raise_for_status(self):
             pass
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -4,6 +4,7 @@ import requests
 from unittest.mock import patch, MagicMock
 from config import save_config
 
+
 @pytest.mark.usefixtures("temp_config")
 def test_get_config(client):
     response = client.get('/api/config')
@@ -11,37 +12,41 @@ def test_get_config(client):
     data = response.get_json()
     assert "jellyfin_url" in data
 
+
 @pytest.mark.usefixtures("temp_config")
 def test_update_config(client):
     new_cfg = {"jellyfin_url": "http://new-url", "api_key": "new-key"}
     response = client.post('/api/config', json=new_cfg)
     assert response.status_code == 200
-    
+
     # Verify it was saved
     response = client.get('/api/config')
     data = response.get_json()
     assert data["jellyfin_url"] == "http://new-url"
+
 
 @patch('routes.requests.get')
 def test_test_server_success(mock_get, client):
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_get.return_value = mock_response
-    
+
     response = client.post('/api/test-server', json={"jellyfin_url": "http://test", "api_key": "key"})
     assert response.status_code == 200
     assert response.get_json()["status"] == "success"
     assert "successfully" in response.get_json()["message"]
+
 
 @patch('routes.requests.get')
 def test_test_server_failure(mock_get, client):
     mock_response = MagicMock()
     mock_response.status_code = 401
     mock_get.return_value = mock_response
-    
+
     response = client.post('/api/test-server', json={"jellyfin_url": "http://test", "api_key": "wrong"})
     assert response.status_code == 400
     assert response.get_json()["status"] == "error"
+
 
 def test_browse_directory(client):
     # Test with home directory
@@ -51,6 +56,7 @@ def test_browse_directory(client):
     assert data["status"] == "success"
     assert "dirs" in data
 
+
 @patch('routes.requests.get')
 @pytest.mark.usefixtures("temp_config")
 def test_get_jellyfin_metadata(mock_get, client):
@@ -58,7 +64,6 @@ def test_get_jellyfin_metadata(mock_get, client):
 
     def mock_genres(url, **kwargs):
         m = MagicMock()
-        params = kwargs.get("params", {})
         if "Genres" in url:
             m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Comedy"}]}
         elif "Studios" in url:
@@ -83,6 +88,7 @@ def test_get_jellyfin_metadata(mock_get, client):
     assert "Studio A" in data["metadata"]["studio"]
     assert "4K" in data["metadata"]["tag"]
 
+
 @patch('routes.run_sync')
 @pytest.mark.usefixtures("temp_config")
 def test_api_sync(mock_sync, client):
@@ -92,20 +98,26 @@ def test_api_sync(mock_sync, client):
     data = response.get_json()
     assert data["results"][0]["group"] == "G1"
 
+
 def test_upload_cover_security_check(client):
     # Test with massive payload
-    large_data = "data:image/jpeg;base64," + "a" * (5 * 1024 * 1024) # 5MB
+    large_data = "data:image/jpeg;base64," + "a" * (5 * 1024 * 1024)  # 5MB
     response = client.post('/api/upload_cover', json={"group_name": "G", "image": large_data})
     assert response.status_code == 413
+
 
 @patch('routes.get_cover_path')
 def test_upload_cover_success(mock_get_path, client, tmp_path):
     mock_get_path.return_value = str(tmp_path / "test.jpg")
     # Base64 for a tiny transparent pixel
-    img_data = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    img_data = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
     response = client.post('/api/upload_cover', json={"group_name": "Test Group", "image": img_data})
     assert response.status_code == 200
     assert os.path.exists(tmp_path / "test.jpg")
+
 
 @pytest.mark.usefixtures("temp_config")
 def test_save_config_route(client):
@@ -115,13 +127,12 @@ def test_save_config_route(client):
     assert response.get_json()["config"]["jellyfin_url"] == "http://new"
 
 
-
 @patch('routes.fetch_jellyfin_items')
 @pytest.mark.usefixtures("temp_config")
 def test_auto_detect_paths(mock_fetch, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
     mock_fetch.return_value = [{"Path": "/data/Movies/M1.mkv"}]
-    
+
     with patch('os.walk') as mock_walk:
         mock_walk.return_value = [
             ('/home/user/Movies', [], ['M1.mkv'])
@@ -131,17 +142,19 @@ def test_auto_detect_paths(mock_fetch, client):
         data = response.get_json()
         assert data["detected"]["media_path_on_host"] == "/home/user"
 
+
 @patch('routes.preview_group')
 @pytest.mark.usefixtures("temp_config")
 def test_preview_grouping(mock_preview, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
     mock_preview.return_value = ([{"Name": "M1"}], None, 200)
-    
+
     # Simple
     response = client.post('/api/grouping/preview', json={"type": "genre", "value": "Action"})
     assert response.status_code == 200
     assert response.get_json()["count"] == 1
-    
+
+
 @patch('routes.run_sync')
 @pytest.mark.usefixtures("temp_config")
 def test_preview_all_sync(mock_sync, client):
@@ -150,26 +163,31 @@ def test_preview_all_sync(mock_sync, client):
     assert response.status_code == 200
     assert "Preview" in response.get_json()["message"]
 
+
 def test_index(client):
     response = client.get('/')
     assert response.status_code == 200
+
 
 def test_browse_security(client):
     # Test disallowed path
     response = client.get('/api/browse?path=/etc')
     assert response.status_code == 403
 
+
 def test_update_config_non_dict(client):
     response = client.post('/api/config', data="not json", content_type='application/json')
     assert response.status_code == 400
+
 
 @patch('routes.update_scheduler_jobs')
 @pytest.mark.usefixtures("temp_config")
 def test_update_config_scheduler_fail(mock_sched, client):
     mock_sched.side_effect = Exception("Fail")
     response = client.post('/api/config', json={"jellyfin_url": "http://jf"})
-    assert response.status_code == 200 # Should not fail the whole request
+    assert response.status_code == 200  # Should not fail the whole request
     assert response.get_json()["status"] == "success"
+
 
 @patch('routes.requests.get')
 def test_test_server_unexpected_error(mock_get, client):
@@ -178,13 +196,16 @@ def test_test_server_unexpected_error(mock_get, client):
     assert response.status_code == 500
     assert "Server error" in response.get_json()["message"]
 
+
 def test_test_server_invalid_body(client):
     response = client.post('/api/test-server', data="not json")
     assert response.status_code == 400
 
+
 def test_test_server_missing_fields(client):
     response = client.post('/api/test-server', json={"url": "missing key"})
     assert response.status_code == 400
+
 
 @patch('routes.requests.get')
 def test_test_server_exception(mock_get, client):
@@ -193,11 +214,13 @@ def test_test_server_exception(mock_get, client):
     assert response.status_code == 400
     assert "Connection error" in response.get_json()["message"]
 
+
 @pytest.mark.usefixtures("temp_config")
 def test_get_jellyfin_metadata_no_config(client):
     # Config is empty by default in temp_config if we don't save anything
     response = client.get('/api/jellyfin/metadata')
     assert response.status_code == 400
+
 
 @patch('routes.requests.get')
 @pytest.mark.usefixtures("temp_config")
@@ -207,13 +230,16 @@ def test_get_jellyfin_metadata_error(mock_get, client):
     response = client.get('/api/jellyfin/metadata')
     assert response.status_code == 400
 
+
 def test_upload_cover_invalid_json(client):
     response = client.post('/api/upload_cover', data="bad")
     assert response.status_code == 400
 
+
 def test_upload_cover_bad_format(client):
     response = client.post('/api/upload_cover', json={"group_name": "G", "image": "not-data-uri"})
     assert response.status_code == 400
+
 
 @patch('routes.save_config')
 @pytest.mark.usefixtures("temp_config")
@@ -222,17 +248,20 @@ def test_update_config_error(mock_save, client):
     response = client.post('/api/config', json={"jellyfin_url": "http://u"})
     assert response.status_code == 500
 
+
 @pytest.mark.usefixtures("temp_config")
 def test_preview_grouping_missing_type(client):
     save_config({"jellyfin_url": "http://t", "api_key": "k"})
     response = client.post('/api/grouping/preview', json={"value": "V"})
     assert response.status_code == 400
 
+
 @pytest.mark.usefixtures("temp_config")
 def test_preview_grouping_invalid_type(client):
     save_config({"jellyfin_url": "http://t", "api_key": "k"})
     response = client.post('/api/grouping/preview', json={"type": "invalid", "value": "V"})
     assert response.status_code == 400
+
 
 @patch('routes.preview_group')
 @pytest.mark.usefixtures("temp_config")
@@ -242,6 +271,7 @@ def test_preview_grouping_error(mock_preview, client):
     response = client.post('/api/grouping/preview', json={"type": "genre", "value": "Action"})
     assert response.status_code == 500
 
+
 @patch('routes.fetch_jellyfin_items')
 @pytest.mark.usefixtures("temp_config")
 def test_auto_detect_no_media(mock_fetch, client):
@@ -249,6 +279,7 @@ def test_auto_detect_no_media(mock_fetch, client):
     mock_fetch.return_value = []
     response = client.post('/api/jellyfin/auto-detect-paths')
     assert response.status_code == 400
+
 
 @patch('os.listdir')
 def test_browse_directory_oserror(mock_listdir, client):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,13 +1,12 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from scheduler import (
     update_scheduler_jobs,
     _run_global_sync_job,
     _run_group_sync_job,
     start_scheduler,
-    _scheduler,
     validate_cron,
 )
+
 
 @patch('scheduler._scheduler')
 @patch('scheduler.load_config')
@@ -15,6 +14,7 @@ def test_update_scheduler_jobs_clear(mock_load, mock_sched):
     mock_load.return_value = {"scheduler": {}, "groups": []}
     update_scheduler_jobs()
     mock_sched.remove_all_jobs.assert_called_once()
+
 
 @patch('scheduler._scheduler')
 @patch('scheduler.load_config')
@@ -35,6 +35,7 @@ def test_update_scheduler_jobs_global(mock_load, mock_sched):
     assert kwargs["id"] == "global_sync"
     assert kwargs["args"] == [["Excluded"]]
 
+
 @patch('scheduler._scheduler')
 @patch('scheduler.load_config')
 def test_update_scheduler_jobs_groups(mock_load, mock_sched):
@@ -54,6 +55,7 @@ def test_update_scheduler_jobs_groups(mock_load, mock_sched):
     assert kwargs["id"] == "group_sync_MyGroup"
     assert kwargs["args"] == ["MyGroup"]
 
+
 @patch('scheduler.run_sync')
 @patch('scheduler.load_config')
 def test_run_global_sync_job(mock_load, mock_sync):
@@ -68,6 +70,7 @@ def test_run_global_sync_job(mock_load, mock_sync):
     _args, kwargs = mock_sync.call_args
     assert kwargs["group_names"] == ["G1"]
 
+
 @patch('scheduler.run_sync')
 @patch('scheduler.load_config')
 def test_run_group_sync_job(mock_load, mock_sync):
@@ -76,6 +79,7 @@ def test_run_group_sync_job(mock_load, mock_sync):
     _args, kwargs = mock_sync.call_args
     assert kwargs["group_names"] == ["G1"]
 
+
 @patch('scheduler.load_config')
 @patch('scheduler._scheduler')
 def test_start_scheduler(mock_sched, mock_load):
@@ -83,6 +87,7 @@ def test_start_scheduler(mock_sched, mock_load):
     mock_sched.running = False
     start_scheduler()
     mock_sched.start.assert_called_once()
+
 
 @patch('scheduler.CronTrigger.from_crontab')
 @patch('scheduler._scheduler')
@@ -100,6 +105,7 @@ def test_update_scheduler_jobs_error(mock_load, mock_sched, mock_cron):
     update_scheduler_jobs()
     mock_sched.add_job.assert_not_called()
 
+
 @patch('scheduler._scheduler')
 @patch('scheduler.load_config')
 def test_update_scheduler_jobs_cleanup(mock_load, mock_sched):
@@ -114,11 +120,10 @@ def test_update_scheduler_jobs_cleanup(mock_load, mock_sched):
     mock_sched.add_job.assert_called_once()
     _args, kwargs = mock_sched.add_job.call_args
     assert kwargs["id"] == "cleanup_sync"
-
-
 # ---------------------------------------------------------------------------
 # validate_cron tests
 # ---------------------------------------------------------------------------
+
 
 def test_validate_cron_valid():
     assert validate_cron("0 0 * * *") is None
@@ -145,4 +150,3 @@ def test_validate_cron_invalid_values():
     assert err is not None
     err = validate_cron("not a cron expr")
     assert err is not None
-

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,12 +1,11 @@
-import pytest
 import os
 import hashlib
 from unittest.mock import patch
 from sync import (
-    _translate_path, 
+    _translate_path,
     get_cover_path,
-    parse_complex_query, 
-    _match_condition, 
+    parse_complex_query,
+    _match_condition,
     _eval_item,
     _sort_items_in_memory,
     _match_jellyfin_items_by_provider,
@@ -15,21 +14,23 @@ from sync import (
     _is_in_season
 )
 
+
 def test_translate_path():
     assert _translate_path("/jf/movie.mkv", "/jf", "/host") == "/host/movie.mkv"
     assert _translate_path("/other/movie.mkv", "/jf", "/host") == "/other/movie.mkv"
     assert _translate_path("/jf/sub/movie.mkv", "/jf", "/host") == "/host/sub/movie.mkv"
+
 
 def test_parse_complex_query():
     rules = parse_complex_query("Action AND NOT Comedy", "genre")
     assert len(rules) == 2
     assert rules[0] == {"operator": "AND", "type": "genre", "value": "Action"}
     assert rules[1] == {"operator": "AND NOT", "type": "genre", "value": "Comedy"}
-
     rules = parse_complex_query("actor:Tom Hanks OR genre:Drama", "tag")
     assert len(rules) == 2
     assert rules[0] == {"operator": "AND", "type": "actor", "value": "Tom Hanks"}
     assert rules[1] == {"operator": "OR", "type": "genre", "value": "Drama"}
+
 
 def test_match_condition():
     item = {
@@ -39,7 +40,6 @@ def test_match_condition():
         "Tags": ["UHD"],
         "ProductionYear": 2022
     }
-    
     assert _match_condition(item, "genre", "action") is True
     assert _match_condition(item, "genre", "comedy") is False
     assert _match_condition(item, "actor", "tom cruise") is True
@@ -47,85 +47,78 @@ def test_match_condition():
     assert _match_condition(item, "tag", "uhd") is True
     assert _match_condition(item, "year", "2022") is True
 
+
 def test_sort_items_in_memory():
     items = [
         {"Name": "B", "SortName": "B", "ProductionYear": 2020, "CommunityRating": 8.0},
         {"Name": "A", "SortName": "A", "ProductionYear": 2021, "CommunityRating": 7.0},
         {"Name": "C", "SortName": "C", "ProductionYear": 2019, "CommunityRating": 9.0}
     ]
-    
     sorted_name = _sort_items_in_memory(items, "SortName")
     assert sorted_name[0]["Name"] == "A"
-    
     sorted_year = _sort_items_in_memory(items, "ProductionYear")
     assert sorted_year[0]["ProductionYear"] == 2021
-    
     # Descending sorts in SORT_MAP
     sorted_rating = _sort_items_in_memory(items, "CommunityRating")
     assert sorted_rating[0]["CommunityRating"] == 9.0
 
+
 def test_eval_item():
     item = {"Genres": ["Action"], "ProductionYear": 2020}
-    
     # Simple AND
     rules = [{"operator": "AND", "type": "genre", "value": "action"}]
     assert _eval_item(item, rules) is True
-    
     # AND NOT
     rules = [
         {"operator": "AND", "type": "genre", "value": "action"},
         {"operator": "AND NOT", "type": "year", "value": "2021"}
     ]
     assert _eval_item(item, rules) is True
-    
     rules = [
         {"operator": "AND", "type": "genre", "value": "action"},
         {"operator": "AND NOT", "type": "year", "value": "2020"}
     ]
     assert _eval_item(item, rules) is False
-    
     # OR
     rules = [
         {"operator": "AND", "type": "genre", "value": "comedy"},
         {"operator": "OR", "type": "year", "value": "2020"}
     ]
     assert _eval_item(item, rules) is True
-
     # Inverted first rule (NOT)
     rules = [{"operator": "NOT", "type": "genre", "value": "comedy"}]
     assert _eval_item(item, rules) is True
-    
     rules = [{"operator": "NOT", "type": "genre", "value": "action"}]
     assert _eval_item(item, rules) is False
+
 
 def test_library_cache():
     _LIBRARY_CACHE.clear()
     key = ("http://test", "key")
     _LIBRARY_CACHE[key] = [{"Id": "1"}]
-    
     # This is just verifying the global variable is used
     assert key in _LIBRARY_CACHE
     assert _LIBRARY_CACHE[key][0]["Id"] == "1"
+
 
 def test_get_cover_path(tmp_path):
     # Setup dummy paths
     target_base = str(tmp_path / "target")
     os.makedirs(os.path.join(target_base, ".covers"), exist_ok=True)
-    
     # Mock __file__ to control legacy path? A bit hard.
     # Let's just test the logic for check_exists=False
     path = get_cover_path("My Group", target_base, check_exists=False)
     assert ".covers" in path
     assert path.endswith(".jpg")
-    
     # Test non-existent with check_exists=True
     assert get_cover_path("Missing Group", target_base, check_exists=True) is None
-    
     # Test existent in lib
-    lib_path = os.path.join(target_base, ".covers", hashlib.md5(b"Existent", usedforsecurity=False).hexdigest() + ".jpg")
+    lib_path = os.path.join(target_base, ".covers", hashlib.md5(
+        b"Existent", usedforsecurity=False).hexdigest() + ".jpg")
     with open(lib_path, "w") as f:
         f.write("test")
     assert get_cover_path("Existent", target_base, check_exists=True) == lib_path
+
 
 @patch('sync.fetch_jellyfin_items')
 def test_match_jellyfin_items_by_provider(mock_jf):
@@ -140,6 +133,7 @@ def test_match_jellyfin_items_by_provider(mock_jf):
     assert len(items) == 1
     assert items[0]["Name"] == "M1"
 
+
 @patch('sync.fetch_jellyfin_items')
 def test_match_jellyfin_items_with_watch_state(mock_jf):
     _LIBRARY_CACHE.clear()
@@ -147,20 +141,17 @@ def test_match_jellyfin_items_with_watch_state(mock_jf):
         {"Id": "1", "Name": "Played", "ProviderIds": {"Tmdb": "101"}, "UserData": {"Played": True}},
         {"Id": "2", "Name": "Unplayed", "ProviderIds": {"Tmdb": "102"}, "UserData": {"Played": False}}
     ]
-    
     # All
     items, _, _ = _match_jellyfin_items_by_provider(
         ["101", "102"], "Tmdb", "SortName", "SortName", "http://jf", "key", "Group", ""
     )
     assert len(items) == 2
-    
     # Unwatched
     items, _, _ = _match_jellyfin_items_by_provider(
         ["101", "102"], "Tmdb", "SortName", "SortName", "http://jf", "key", "Group", "unwatched"
     )
     assert len(items) == 1
     assert items[0]["Name"] == "Unplayed"
-    
     # Watched
     items, _, _ = _match_jellyfin_items_by_provider(
         ["101", "102"], "Tmdb", "SortName", "SortName", "http://jf", "key", "Group", "watched"
@@ -168,41 +159,39 @@ def test_match_jellyfin_items_with_watch_state(mock_jf):
     assert len(items) == 1
     assert items[0]["Name"] == "Played"
 
+
 @patch('sync.fetch_jellyfin_items')
 def test_preview_group(mock_jf):
     _LIBRARY_CACHE.clear()
     mock_jf.return_value = [{"Name": "M1", "Genres": ["Action"]}]
-    
     # Metadata group
     items, _err, code = preview_group("genre", "Action", "http://jf", "key")
     assert code == 200
     assert len(items) == 1
-    
     # Complex group (AND)
-    _LIBRARY_CACHE.clear() # Ensure _fetch_full_library calls mock
+    _LIBRARY_CACHE.clear()  # Ensure _fetch_full_library calls mock
     items, _err, code = preview_group("genre", "Action AND NOT Comedy", "http://jf", "key")
     assert code == 200
     assert len(items) == 1
+
 
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_items_for_metadata_group_with_watch_state(mock_jf):
     from sync import _fetch_items_for_metadata_group
     mock_jf.return_value = [{"Name": "M1"}]
-    
     # Test 'unwatched' calls fetch with Filters=IsUnplayed
     _fetch_items_for_metadata_group("Group", "genre", "Action", "SortName", "http://jf", "key", "unwatched")
     args, _ = mock_jf.call_args
     assert args[2]["Filters"] == "IsUnplayed"
-    
     # Test 'watched' calls fetch with Filters=IsPlayed
     _fetch_items_for_metadata_group("Group", "genre", "Action", "SortName", "http://jf", "key", "watched")
     args, _ = mock_jf.call_args
     assert args[2]["Filters"] == "IsPlayed"
-    
     # Test default doesn't have Filters
     _fetch_items_for_metadata_group("Group", "genre", "Action", "SortName", "http://jf", "key", "")
     args, _ = mock_jf.call_args
     assert "Filters" not in args[2]
+
 
 @patch('sync.fetch_jellyfin_items')
 def test_preview_group_fetch_error(mock_jf):
@@ -212,12 +201,14 @@ def test_preview_group_fetch_error(mock_jf):
     assert code == 500
     assert "Internal error" in err
 
+
 def test_parse_complex_query_with_prefixes():
     # Mix of default and specific types
     rules = parse_complex_query("Action AND actor:Tom Hanks AND studio:Marvel", "genre")
     assert rules[0] == {"operator": "AND", "type": "genre", "value": "Action"}
     assert rules[1] == {"operator": "AND", "type": "actor", "value": "Tom Hanks"}
     assert rules[2] == {"operator": "AND", "type": "studio", "value": "Marvel"}
+
 
 def test_eval_item_multiple_or():
     item = {"Genres": ["Comedy"]}
@@ -227,6 +218,7 @@ def test_eval_item_multiple_or():
         {"operator": "OR", "type": "genre", "value": "comedy"}
     ]
     assert _eval_item(item, rules) is True
+
 
 def test_match_condition_variants():
     item = {
@@ -243,6 +235,7 @@ def test_match_condition_variants():
     assert _match_condition(item, "unknown", "val") is False
     assert _match_condition(item, "actor", "b") is False
 
+
 @patch('sync.fetch_jellyfin_items')
 def test_match_by_provider_empty_library(mock_jf):
     _LIBRARY_CACHE.clear()
@@ -253,17 +246,20 @@ def test_match_by_provider_empty_library(mock_jf):
     assert items == []
     assert code == 200
 
+
 def test_translate_path_edge_cases():
     # Paths that share a string prefix but are completely different directories
     assert _translate_path("/jelly/movie", "/jell", "/mnt/host") == "/jelly/movie"
     # Root path (normpath strips trailing slash)
     assert _translate_path("/jf/", "/jf", "/host") == "/host"
 
+
 def test_sort_items_missing_field():
     items = [{"Name": "A"}, {"Name": "B"}]
     # Sorting by missing field should use Name as fallback
     sorted_items = _sort_items_in_memory(items, "ProductionYear")
     assert len(sorted_items) == 2
+
 
 @patch('sync.fetch_jellyfin_items')
 def test_match_jellyfin_items_no_match(mock_jf):
@@ -277,6 +273,7 @@ def test_match_jellyfin_items_no_match(mock_jf):
     )
     assert len(items) == 0
 
+
 def test_sort_items_rating():
     items = [
         {"Name": "A", "CommunityRating": 5.0},
@@ -285,11 +282,13 @@ def test_sort_items_rating():
     sorted_items = _sort_items_in_memory(items, "CommunityRating")
     assert sorted_items[0]["CommunityRating"] == 9.0
 
+
 def test_sort_items_unknown():
     items = [{"Name": "B"}, {"Name": "A"}]
     # Should return as-is (B then A)
     sorted_items = _sort_items_in_memory(items, "UnknownField")
     assert sorted_items[0]["Name"] == "B"
+
 
 def test_sort_items_missing_values_logic():
     items = [
@@ -300,7 +299,6 @@ def test_sort_items_missing_values_logic():
     res_asc = _sort_items_in_memory(items, "SortName")
     assert res_asc[0]["SortName"] == "A"
     assert res_asc[1]["SortName"] is None
-
     items_year = [
         {"ProductionYear": 2020},
         {"ProductionYear": None}
@@ -310,28 +308,23 @@ def test_sort_items_missing_values_logic():
     assert res_desc[0]["ProductionYear"] == 2020
     assert res_desc[1]["ProductionYear"] is None
 
+
 def test_is_in_season():
     from unittest.mock import MagicMock
     with patch('sync.datetime') as mock_datetime:
         mock_now = MagicMock()
         mock_datetime.now.return_value = mock_now
-        
         # Case 1: Within year window
         mock_now.strftime.return_value = "07-15"
         assert _is_in_season("06-01", "09-01") is True
-        
         mock_now.strftime.return_value = "05-15"
         assert _is_in_season("06-01", "09-01") is False
-        
         # Case 2: Crossing year window
         mock_now.strftime.return_value = "12-15"
         assert _is_in_season("12-01", "01-01") is True
-        
         mock_now.strftime.return_value = "01-15"
         assert _is_in_season("12-01", "01-01") is False
-        
         mock_now.strftime.return_value = "01-01"
-        assert _is_in_season("12-01", "01-01") is False # Exclusive end
-        
+        assert _is_in_season("12-01", "01-01") is False  # Exclusive end
         # Case 3: Invalid types
-        assert _is_in_season(None, "01-01") is True # Defaults to True
+        assert _is_in_season(None, "01-01") is True  # Defaults to True

--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -1,7 +1,6 @@
-import pytest
-import os
-from unittest.mock import patch, MagicMock
-from sync import run_sync, preview_group, _fetch_items_for_recommendations_group
+from unittest.mock import patch
+from sync import run_sync, preview_group
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -28,12 +27,12 @@ def test_run_sync_tmdb(mock_tmdb, mock_jf_fetch, _mock_symlink, _mock_exists, _m
     mock_jf_fetch.return_value = [
         {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}}
     ]
-    _mock_exists.return_value = True # Host path exists
-    
+    _mock_exists.return_value = True  # Host path exists
     results = run_sync(config)
     assert len(results) > 0
     assert results[0]["links"] == 1
     _mock_symlink.assert_called_once()
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -60,9 +59,9 @@ def test_run_sync_anilist(mock_anilist, mock_jf_fetch, _mock_symlink, _mock_exis
         {"Name": "A1", "Path": "/p1", "ProviderIds": {"AniList": "12345"}}
     ]
     _mock_exists.return_value = True
-    
     results = run_sync(config)
     assert results[0]["links"] == 1
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -71,7 +70,9 @@ def test_run_sync_anilist(mock_anilist, mock_jf_fetch, _mock_symlink, _mock_exis
 @patch('sync.os.symlink')
 @patch('sync.fetch_jellyfin_items')
 @patch('sync.fetch_trakt_list')
-def test_run_sync_trakt(mock_trakt, mock_jf_fetch, _mock_symlink, _mock_isdir, _mock_exists, _mock_makedirs, _mock_rmtree):
+def test_run_sync_trakt(
+    mock_trakt, mock_jf_fetch, _mock_symlink, _mock_isdir, _mock_exists, _mock_makedirs, _mock_rmtree
+):
     config = {
         "jellyfin_url": "http://jf",
         "api_key": "key",
@@ -92,9 +93,9 @@ def test_run_sync_trakt(mock_trakt, mock_jf_fetch, _mock_symlink, _mock_isdir, _
     ]
     _mock_exists.return_value = True
     _mock_isdir.return_value = True
-    
     results = run_sync(config)
     assert results[0]["links"] == 1
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -122,9 +123,9 @@ def test_run_sync_mal(mock_mal, mock_jf_fetch, _mock_symlink, _mock_exists, _moc
         {"Name": "M1", "Path": "/p1", "ProviderIds": {"Mal": "54321"}}
     ]
     _mock_exists.return_value = True
-    
     results = run_sync(config)
     assert results[0]["links"] == 1
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -151,9 +152,9 @@ def test_run_sync_letterboxd(mock_lb, mock_jf_fetch, _mock_symlink, _mock_exists
         {"Name": "L1", "Path": "/p1", "ProviderIds": {"Imdb": "tt111"}}
     ]
     _mock_exists.return_value = True
-    
     results = run_sync(config)
     assert results[0]["links"] == 1
+
 
 def test_run_sync_invalid_group():
     config = {
@@ -164,8 +165,9 @@ def test_run_sync_invalid_group():
     }
     # Should skip the string and continue
     with patch('sync.os.path.exists', return_value=True):
-         results = run_sync(config)
+        results = run_sync(config)
     assert results == []
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -189,9 +191,9 @@ def test_run_sync_complex(mock_jf_fetch, _mock_symlink, _mock_exists, _mock_make
         {"Name": "C1", "Path": "/p1", "Genres": ["Action"]}
     ]
     _mock_exists.return_value = True
-    
     results = run_sync(config)
     assert results[0]["links"] == 1
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -215,12 +217,12 @@ def test_run_sync_dry_run(mock_jf_fetch, _mock_symlink, _mock_exists, _mock_make
         {"Name": "M1", "Path": "/p1", "Genres": ["Action"]}
     ]
     _mock_exists.return_value = True
-    
     results = run_sync(config, dry_run=True)
     assert results[0]["links"] == 1
     _mock_symlink.assert_not_called()
     _mock_makedirs.assert_not_called()
     _mock_rmtree.assert_not_called()
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -239,11 +241,11 @@ def test_run_sync_selective(mock_jf_fetch, _mock_symlink, _mock_exists, _mock_ma
     }
     mock_jf_fetch.return_value = [{"Name": "M1", "Path": "/p1", "Genres": ["Action"]}]
     _mock_exists.return_value = True
-    
     # Sync only G1
     results = run_sync(config, group_names=["G1"])
     assert len(results) == 1
     assert results[0]["group"] == "G1"
+
 
 def test_run_sync_missing_group(tmp_path):
     target = tmp_path / "target"
@@ -255,6 +257,7 @@ def test_run_sync_missing_group(tmp_path):
     }
     results = run_sync(config, group_names=["NonExistent"])
     assert results == []
+
 
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
@@ -272,6 +275,7 @@ def test_run_sync_tmdb_error(mock_tmdb, _mock_makedirs, _mock_rmtree):
         results = run_sync(config)
     assert results[0]["error"] is not None
 
+
 @patch('sync._fetch_full_library')
 def test_preview_group_complex_error(mock_full):
     mock_full.return_value = (None, "Some error", 500)
@@ -279,12 +283,14 @@ def test_preview_group_complex_error(mock_full):
     assert code == 500
     assert err == "Some error"
 
+
 @patch('sync.fetch_tmdb_list')
 def test_fetch_items_tmdb_no_key(mock_tmdb):
     from sync import _fetch_items_for_tmdb_group
     _items, err, code = _fetch_items_for_tmdb_group("G", "val", "order", "url", "key", "")
     assert code == 400
     assert "TMDb API Key not set" in err
+
 
 @patch('sync.fetch_tmdb_list')
 def test_fetch_items_tmdb_empty(mock_tmdb):
@@ -294,6 +300,7 @@ def test_fetch_items_tmdb_empty(mock_tmdb):
     assert code == 200
     assert items == []
 
+
 @patch('sync.fetch_anilist_list')
 def test_fetch_items_anilist_error(mock_ani):
     from sync import _fetch_items_for_anilist_group
@@ -302,12 +309,14 @@ def test_fetch_items_anilist_error(mock_ani):
     assert code == 400
     assert "AniList fetch error" in err
 
+
 @patch('sync.fetch_mal_list')
 def test_fetch_items_mal_no_id(mock_mal):
     from sync import _fetch_items_for_mal_group
     _items, err, code = _fetch_items_for_mal_group("G", "val", "order", "url", "key", "")
     assert code == 400
     assert "MyAnimeList Client ID not set" in err
+
 
 @patch('sync.fetch_mal_list')
 @patch('sync._fetch_full_library')
@@ -321,6 +330,7 @@ def test_fetch_items_mal_with_status(mock_full, mock_mal):
     args = mock_mal.call_args[0]
     assert args[2] == "completed"
 
+
 @patch('sync.fetch_mal_list')
 def test_fetch_items_mal_error(mock_mal):
     from sync import _fetch_items_for_mal_group
@@ -328,6 +338,7 @@ def test_fetch_items_mal_error(mock_mal):
     _items, err, code = _fetch_items_for_mal_group("G", "user", "order", "url", "key", "id")
     assert code == 400
     assert "MAL fetch error" in err
+
 
 @patch('sync.fetch_mal_list')
 def test_fetch_items_mal_empty(mock_mal):
@@ -337,6 +348,7 @@ def test_fetch_items_mal_empty(mock_mal):
     assert code == 200
     assert items == []
 
+
 @patch('sync.fetch_trakt_list')
 def test_fetch_items_trakt_error(mock_trakt):
     from sync import _fetch_items_for_trakt_group
@@ -344,6 +356,7 @@ def test_fetch_items_trakt_error(mock_trakt):
     _items, err, code = _fetch_items_for_trakt_group("G", "val", "order", "http://jf", "key", "cli")
     assert code == 400
     assert "Trakt fetch error" in err
+
 
 @patch('sync.fetch_trakt_list')
 def test_fetch_items_trakt_empty(mock_trakt):
@@ -362,7 +375,9 @@ def test_fetch_items_trakt_empty(mock_trakt):
 @patch('sync.fetch_jellyfin_items')
 @patch('sync.get_libraries')
 @patch('sync.add_virtual_folder')
-def test_run_sync_with_library_creation(mock_add_lib, mock_get_libs, mock_jf_fetch, _mock_symlink, _mock_isdir, _mock_exists, _mock_makedirs, _mock_rmtree):
+def test_run_sync_with_library_creation(
+    mock_add_lib, mock_get_libs, mock_jf_fetch, _mock_symlink, _mock_isdir, _mock_exists, _mock_makedirs, _mock_rmtree
+):
     config = {
         "jellyfin_url": "http://jf",
         "api_key": "key",
@@ -379,27 +394,24 @@ def test_run_sync_with_library_creation(mock_add_lib, mock_get_libs, mock_jf_fet
             }
         ]
     }
-    
     # Mock items to sync
-    mock_get_libs.return_value = [] # No libraries yet
+    mock_get_libs.return_value = []  # No libraries yet
     mock_jf_fetch.return_value = [
         {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}}
     ]
     _mock_exists.return_value = True
     _mock_isdir.return_value = True
-    
     # Force _process_group to think there's 1 link created
     with patch('sync.fetch_tmdb_list', return_value=["101"]):
         results = run_sync(config)
-        
     assert results[0]["group"] == "NewGroup"
     assert results[0]["links"] == 1
-    
     # Verify library creation was called
     mock_get_libs.assert_called_once()
     mock_add_lib.assert_called_once_with(
         "http://jf", "key", "NewGroup", ["/virtual/NewGroup"], collection_type="mixed"
     )
+
 
 @patch('sync.shutil.copy2')
 @patch('sync.set_virtual_folder_image')
@@ -410,7 +422,10 @@ def test_run_sync_with_library_creation(mock_add_lib, mock_get_libs, mock_jf_fet
 @patch('sync.os.path.isdir')
 @patch('sync.os.symlink')
 @patch('sync.fetch_jellyfin_items')
-def test_run_sync_with_auto_set_library_covers(mock_jf_fetch, _mock_symlink, _mock_isdir, _mock_exists, _mock_makedirs, _mock_rmtree, mock_get_cover, mock_set_image, mock_copy2):
+def test_run_sync_with_auto_set_library_covers(
+    mock_jf_fetch, _mock_symlink, _mock_isdir, _mock_exists, _mock_makedirs, _mock_rmtree,
+    mock_get_cover, mock_set_image, mock_copy2
+):
     config = {
         "jellyfin_url": "http://jf",
         "api_key": "key",
@@ -426,23 +441,18 @@ def test_run_sync_with_auto_set_library_covers(mock_jf_fetch, _mock_symlink, _mo
             }
         ]
     }
-    
     # Mock items to sync
     mock_jf_fetch.return_value = [
         {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}}
     ]
-    
     # Mock cover existence
     _mock_exists.side_effect = lambda path: True if path == "/target/CoverGroup_cover.jpg" or path == "/p1" else False
     _mock_isdir.return_value = True
     mock_get_cover.return_value = "/target/CoverGroup_cover.jpg"
-    
     with patch('sync.fetch_tmdb_list', return_value=["101"]):
         results = run_sync(config)
-        
     assert results[0]["group"] == "CoverGroup"
     assert results[0]["links"] == 1
-    
     # Verify image setting was called
     mock_set_image.assert_called_once_with("http://jf", "key", "CoverGroup", "/target/CoverGroup_cover.jpg")
     mock_copy2.assert_called_once_with("/target/CoverGroup_cover.jpg", "/target/CoverGroup/poster.jpg")
@@ -455,7 +465,9 @@ def test_run_sync_with_auto_set_library_covers(mock_jf_fetch, _mock_symlink, _mo
 @patch('sync.fetch_jellyfin_items')
 @patch('sync.get_tmdb_recommendations')
 @patch('sync.get_user_recent_items')
-def test_run_sync_recommendations(mock_recent, mock_tmdb_rec, mock_jf_fetch, _mock_symlink, _mock_exists, _mock_makedirs, _mock_rmtree):
+def test_run_sync_recommendations(
+    mock_recent, mock_tmdb_rec, mock_jf_fetch, _mock_symlink, _mock_exists, _mock_makedirs, _mock_rmtree
+):
     config = {
         "jellyfin_url": "http://jf",
         "api_key": "key",
@@ -474,10 +486,8 @@ def test_run_sync_recommendations(mock_recent, mock_tmdb_rec, mock_jf_fetch, _mo
     mock_jf_fetch.return_value = [
         {"Name": "R1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}}
     ]
-    _mock_exists.return_value = True # Host path exists
-    
+    _mock_exists.return_value = True  # Host path exists
     results = run_sync(config)
     assert len(results) > 0
     assert results[0]["links"] == 1
     _mock_symlink.assert_called_once()
-

--- a/tests/test_sync_integration.py
+++ b/tests/test_sync_integration.py
@@ -1,6 +1,6 @@
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from sync import run_sync
+
 
 @patch('sync.os.makedirs')
 @patch('sync.os.path.exists')
@@ -24,7 +24,6 @@ def test_run_sync_basic(mock_fetch, mock_symlink, mock_rmtree, mock_exists, mock
             }
         ]
     }
-    
     # Mock items returned by Jellyfin
     mock_fetch.return_value = [
         {
@@ -34,19 +33,17 @@ def test_run_sync_basic(mock_fetch, mock_symlink, mock_rmtree, mock_exists, mock
         }
     ]
     mock_exists.return_value = True
-    
     results = run_sync(config)
-    
     assert len(results) == 1
     assert results[0]["group"] == "Action Movies"
     assert results[0]["links"] == 1
-    
     # Verify symlink was called with correctly translated path
     # and numbered name
     mock_symlink.assert_called_once()
     src, dst = mock_symlink.call_args[0]
     assert src == "/host/movies/Action Film 1/file.mkv"
     assert "0001 - file.mkv" in dst
+
 
 @patch('sync.os.path.exists')
 @patch('sync.fetch_jellyfin_items')
@@ -67,11 +64,8 @@ def test_run_sync_imdb(mock_imdb_fetch, mock_jf_fetch, mock_exists):
             }
         ]
     }
-    
     mock_imdb_fetch.return_value = ([{"Name": "M", "Path": "/p", "Id": "i"}], None, 200)
-    
     # Dry run to avoid filesystem mocks
     results = run_sync(config, dry_run=True)
-    
     assert results[0]["links"] == 1
     mock_imdb_fetch.assert_called_once()

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -3,11 +3,13 @@ from unittest.mock import patch, MagicMock
 from tmdb import fetch_tmdb_list, get_tmdb_recommendations
 import requests
 
+
 def test_fetch_tmdb_list_missing_args():
     with pytest.raises(ValueError, match="A TMDb API Key is required"):
         fetch_tmdb_list("123", "")
     with pytest.raises(ValueError, match="A TMDb List ID is required"):
         fetch_tmdb_list("", "api_key")
+
 
 @patch('requests.get')
 def test_fetch_tmdb_list_success(mock_get):
@@ -29,6 +31,7 @@ def test_fetch_tmdb_list_success(mock_get):
     assert ids == ["101", "102", "103"]
     assert mock_get.call_count == 2
 
+
 @patch('requests.get')
 def test_fetch_tmdb_list_url_parsing(mock_get):
     mock_resp = MagicMock()
@@ -44,15 +47,18 @@ def test_fetch_tmdb_list_url_parsing(mock_get):
     args, kwargs = mock_get.call_args
     assert "/list/456" in args[0]
 
+
 @patch('requests.get')
 def test_fetch_tmdb_list_failure(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Network Error")
     with pytest.raises(RuntimeError, match="Failed to fetch TMDb list page 1"):
         fetch_tmdb_list("123", "test_key")
 
+
 def test_get_tmdb_recommendations_missing_key():
     with pytest.raises(ValueError, match="A TMDb API Key is required"):
         get_tmdb_recommendations([("101", "movie")], "")
+
 
 @patch('requests.get')
 def test_get_tmdb_recommendations_success(mock_get):
@@ -61,24 +67,25 @@ def test_get_tmdb_recommendations_success(mock_get):
     mock_resp_movie.json.return_value = {
         "results": [{"id": 201}, {"id": 202}]
     }
-    
+
     mock_resp_tv = MagicMock()
     mock_resp_tv.status_code = 200
     mock_resp_tv.json.return_value = {
         "results": [{"id": 202}, {"id": 203}]
     }
-    
+
     mock_get.side_effect = [mock_resp_movie, mock_resp_tv]
-    
+
     # "movie" returns 201, 202
     # "tv" returns 202, 203
     # 202 gets score from both, so it should be the highest
     recs = get_tmdb_recommendations([("101", "movie"), ("102", "tv")], "test_key")
-    
+
     # 201 score: 1.0/1 = 1.0
     # 202 score: 1.0/2 + 1.0/1 = 1.5
     # 203 score: 1.0/2 = 0.5
     assert recs == ["202", "201", "203"]
+
 
 @patch('requests.get')
 def test_get_tmdb_recommendations_failure_skipped(mock_get):
@@ -87,8 +94,8 @@ def test_get_tmdb_recommendations_failure_skipped(mock_get):
     mock_resp_movie.json.return_value = {
         "results": [{"id": 201}]
     }
-    
+
     mock_get.side_effect = [requests.exceptions.RequestException("Error"), mock_resp_movie]
-    
+
     recs = get_tmdb_recommendations([("error_id", "movie"), ("101", "movie")], "test_key")
     assert recs == ["201"]

--- a/tests/test_virtual_jellyfin_api.py
+++ b/tests/test_virtual_jellyfin_api.py
@@ -1,18 +1,19 @@
 import pytest
-import requests
 from jellyfin import (
-    get_libraries, 
-    add_virtual_folder, 
-    delete_virtual_folder, 
-    get_library_id, 
-    set_virtual_folder_image, 
-    get_users, 
+    get_libraries,
+    add_virtual_folder,
+    delete_virtual_folder,
+    get_library_id,
+    set_virtual_folder_image,
+    get_users,
     get_user_recent_items
 )
+
 
 @pytest.fixture
 def jellyfin_url(virtual_jellyfin):
     return virtual_jellyfin
+
 
 def test_get_libraries(jellyfin_url):
     libs = get_libraries(jellyfin_url, "test_key")
@@ -20,45 +21,47 @@ def test_get_libraries(jellyfin_url):
     assert "Movies" in libs
     assert "TV Shows" in libs
 
+
 def test_add_virtual_folder_success(jellyfin_url):
     name = "NewLib"
     add_virtual_folder(jellyfin_url, "test_key", name, ["/tmp/path1"])
-    
     libs = get_libraries(jellyfin_url, "test_key")
     assert name in libs
 
+
 def test_add_virtual_folder_already_exists(jellyfin_url):
-    name = "Movies" # Already exists in virtual_jellyfin
+    name = "Movies"  # Already exists in virtual_jellyfin
     # add_virtual_folder should handle 409 and not raise
     add_virtual_folder(jellyfin_url, "test_key", name, ["/tmp/path2"])
+
 
 def test_delete_virtual_folder(jellyfin_url):
     name = "ToStore"
     add_virtual_folder(jellyfin_url, "test_key", name, ["/tmp/path"])
-    
     delete_virtual_folder(jellyfin_url, "test_key", name)
-    
     libs = get_libraries(jellyfin_url, "test_key")
     assert name not in libs
+
 
 def test_get_library_id(jellyfin_url):
     item_id = get_library_id(jellyfin_url, "test_key", "Movies")
     assert item_id == "movies_id"
-    
     item_id_none = get_library_id(jellyfin_url, "test_key", "NonExistent")
     assert item_id_none is None
+
 
 def test_set_virtual_folder_image(jellyfin_url, tmp_path):
     img_path = tmp_path / "test.jpg"
     img_path.write_bytes(b"fake_image_data")
-    
     # This should not raise
     set_virtual_folder_image(jellyfin_url, "test_key", "Movies", str(img_path))
+
 
 def test_get_users(jellyfin_url):
     users = get_users(jellyfin_url, "test_key")
     assert len(users) >= 1
     assert users[0]["Name"] == "Admin"
+
 
 def test_get_user_recent_items(jellyfin_url):
     items = get_user_recent_items(jellyfin_url, "test_key", "admin_id", limit=10)

--- a/tests/test_virtual_jellyfin_exhaustive.py
+++ b/tests/test_virtual_jellyfin_exhaustive.py
@@ -1,36 +1,41 @@
 import json
 import logging
-import os
+
 
 import pytest
 import requests
 from jellyfin import (
     fetch_jellyfin_items,
-    get_libraries, 
-    add_virtual_folder, 
-    delete_virtual_folder, 
-    get_library_id, 
-    set_virtual_folder_image, 
-    get_users, 
+    get_libraries,
+    add_virtual_folder,
+    delete_virtual_folder,
+    get_library_id,
+    set_virtual_folder_image,
+    get_users,
     get_user_recent_items
 )
 
 pytestmark = pytest.mark.exhaustive
+
 
 @pytest.fixture
 def jellyfin_url(virtual_jellyfin):
     return virtual_jellyfin
 
 # 1. Authentication & Network Failures
+
+
 def test_401_unauthorized(jellyfin_url):
     with pytest.raises(requests.exceptions.HTTPError) as excinfo:
         fetch_jellyfin_items(jellyfin_url, "BAD_KEY")
     assert excinfo.value.response.status_code == 401
 
+
 def test_timeout(jellyfin_url):
     with pytest.raises(requests.exceptions.Timeout):
         # The endpoint sleeps for 3s, timeout is 1s
         fetch_jellyfin_items(jellyfin_url, "TIMEOUT_KEY", timeout=1)
+
 
 def test_connection_error():
     # Attempt connecting to an invalid port/host
@@ -38,17 +43,22 @@ def test_connection_error():
         fetch_jellyfin_items("http://localhost:12345", "test_key", timeout=1)
 
 # 2. fetch_jellyfin_items Exhaustive
+
+
 def test_fetch_empty_items(jellyfin_url):
     items = fetch_jellyfin_items(jellyfin_url, "EMPTY_ITEMS_KEY")
     assert items == []
+
 
 def test_fetch_missing_items_list(jellyfin_url):
     items = fetch_jellyfin_items(jellyfin_url, "MISSING_ITEMS_KEY")
     assert items == []
 
+
 def test_fetch_malformed_json(jellyfin_url):
     with pytest.raises(json.JSONDecodeError):
         fetch_jellyfin_items(jellyfin_url, "MALFORMED_JSON_KEY")
+
 
 def test_fetch_extra_query_params(jellyfin_url):
     # The server ignores it, but we test requests is passing it
@@ -56,31 +66,39 @@ def test_fetch_extra_query_params(jellyfin_url):
     assert len(items) >= 2
 
 # 3. get_libraries Exhaustive
+
+
 def test_get_libraries_500(jellyfin_url):
     with pytest.raises(requests.exceptions.HTTPError) as excinfo:
         get_libraries(jellyfin_url, "LIB_GET_500")
     assert excinfo.value.response.status_code == 500
+
 
 def test_get_libraries_missing_name(jellyfin_url):
     libs = get_libraries(jellyfin_url, "LIB_GET_MISSING_NAME")
     # Missing names should result in empty strings as per get_libraries list comprehension
     assert libs == [""]
 
+
 def test_get_libraries_empty(jellyfin_url):
     libs = get_libraries(jellyfin_url, "LIB_GET_EMPTY")
     assert libs == []
 
 # 4. add_virtual_folder Exhaustive
+
+
 def test_add_virtual_folder_409_conflict(jellyfin_url):
     # Movies already exists, add_virtual_folder silent recovery (returns 409 but caught in 200 checks for path/refresh)
     # The current code in add_virtual_folder expects 409 to not be raised, and proceed
     add_virtual_folder(jellyfin_url, "test_key", "Movies", ["/tmp/safe"])
     # If no exception, it passes
 
+
 def test_add_virtual_folder_500_create(jellyfin_url):
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder(jellyfin_url, "test_key", "FAIL_CREATE", ["/tmp/safe"])
     assert "Failed to create virtual folder 'FAIL_CREATE'" in str(excinfo.value)
+
 
 def test_add_virtual_folder_400_paths(jellyfin_url):
     with pytest.raises(RuntimeError) as excinfo:
@@ -88,39 +106,49 @@ def test_add_virtual_folder_400_paths(jellyfin_url):
     assert "Failed to add path" in str(excinfo.value)
     assert "Status 400" in str(excinfo.value)
 
+
 def test_add_virtual_folder_502_refresh(jellyfin_url):
     with pytest.raises(RuntimeError) as excinfo:
         add_virtual_folder(jellyfin_url, "FAIL_REFRESH_KEY", "RefreshLib", ["/tmp/safe"])
     assert "Failed to trigger library refresh" in str(excinfo.value)
     assert "Status 502" in str(excinfo.value)
 
+
 def test_add_virtual_folder_invalid_collection(jellyfin_url):
     # Mixed should omit collectionType parameter.
     add_virtual_folder(jellyfin_url, "test_key", "MixedLib2", ["/tmp/safe"], collection_type="mixed")
     # if it doesn't fail, we consider it a success.
+
 
 def test_add_virtual_folder_empty_paths(jellyfin_url):
     # Should not fail.
     add_virtual_folder(jellyfin_url, "test_key", "EmptyLib", [])
 
 # 5. delete_virtual_folder Exhaustive
+
+
 def test_delete_virtual_folder_404(jellyfin_url, caplog):
     with pytest.raises(requests.exceptions.HTTPError):
         delete_virtual_folder(jellyfin_url, "test_key", "FAIL_DELETE_404")
     assert "Delete Virtual Folder Failed (404)" in caplog.text
+
 
 def test_delete_virtual_folder_500(jellyfin_url):
     with pytest.raises(requests.exceptions.HTTPError):
         delete_virtual_folder(jellyfin_url, "test_key", "FAIL_DELETE_500")
 
 # 6. get_library_id Exhaustive
+
+
 def test_get_library_id_missing(jellyfin_url):
     lib_id = get_library_id(jellyfin_url, "test_key", "DoesNotExist")
     assert lib_id is None
 
+
 def test_get_library_id_missing_itemid_key(jellyfin_url):
     lib_id = get_library_id(jellyfin_url, "LIB_GET_MISSING_ID", "Movies")
     assert lib_id is None
+
 
 def test_get_library_id_500(jellyfin_url, caplog):
     lib_id = get_library_id(jellyfin_url, "LIB_GET_500", "Movies")
@@ -128,6 +156,8 @@ def test_get_library_id_500(jellyfin_url, caplog):
     assert "Failed to get library ID" in caplog.text
 
 # 7. set_virtual_folder_image Exhaustive
+
+
 def test_set_virtual_folder_image_missing_id(jellyfin_url, tmp_path, caplog):
     caplog.set_level(logging.INFO)
     img_path = tmp_path / "test.jpg"
@@ -135,17 +165,20 @@ def test_set_virtual_folder_image_missing_id(jellyfin_url, tmp_path, caplog):
     set_virtual_folder_image(jellyfin_url, "test_key", "DoesNotExist", str(img_path))
     assert "not found or ID unknown" in caplog.text
 
+
 def test_set_virtual_folder_image_oserror(jellyfin_url, caplog):
     set_virtual_folder_image(jellyfin_url, "test_key", "Movies", "/does/not/exist.jpg")
     assert "Failed to read image file" in caplog.text
 
+
 def test_set_virtual_folder_image_unknown_mime(jellyfin_url, tmp_path, caplog):
     caplog.set_level(logging.INFO)
-    img_path = tmp_path / "testfile" # No extension
+    img_path = tmp_path / "testfile"  # No extension
     img_path.write_bytes(b"data")
     # Standard call should work and fallback to application/octet-stream
     set_virtual_folder_image(jellyfin_url, "test_key", "Movies", str(img_path))
     assert "Successfully updated cover image" in caplog.text
+
 
 def test_set_virtual_folder_image_400(jellyfin_url, tmp_path, caplog):
     caplog.set_level(logging.INFO)
@@ -165,14 +198,18 @@ def test_set_virtual_folder_image_400(jellyfin_url, tmp_path, caplog):
     assert "Failed to set image" in caplog.text
 
 # 8. get_users and get_user_recent_items Exhaustive
+
+
 def test_get_users_500(jellyfin_url):
     with pytest.raises(requests.exceptions.HTTPError):
         get_users(jellyfin_url, "USER_GET_500")
 
+
 def test_get_user_recent_items_bad_user(jellyfin_url):
     items = get_user_recent_items(jellyfin_url, "test_key", "BAD_USER")
     assert items == []
-    
+
+
 def test_get_user_recent_items_missing_data(jellyfin_url):
     items = get_user_recent_items(jellyfin_url, "test_key", "MISSING_DATA_USER")
     assert items == []

--- a/tests/virtual_jellyfin.py
+++ b/tests/virtual_jellyfin.py
@@ -439,13 +439,13 @@ def dashboard():
             <table>
                 <tr><th>Name</th><th>Id</th><th>Type</th><th>Year</th><th>Imdb</th></tr>
                 {''.join(
-                    f"<tr><td>{i.get('Name')}</td>"
-                    f"<td>{i.get('Id')}</td>"
-                    f"<td>{i.get('Type')}</td>"
-                    f"<td>{i.get('ProductionYear')}</td>"
-                    f"<td>{i.get('ProviderIds', {}).get('Imdb', '')}</td></tr>"
-                    for i in data['items']
-                )}
+        f"<tr><td>{i.get('Name')}</td>"
+        f"<td>{i.get('Id')}</td>"
+        f"<td>{i.get('Type')}</td>"
+        f"<td>{i.get('ProductionYear')}</td>"
+        f"<td>{i.get('ProviderIds', {}).get('Imdb', '')}</td></tr>"
+        for i in data['items']
+    )}
             </table>
         </div>
     </body>


### PR DESCRIPTION
## Summary
Bulk-fixes all remaining flake8 violations in the test suite.

### Changes
- Run autopep8 across tests/ to fix whitespace, blank-line, and trailing-whitespace issues
- Remove unused imports (pytest, json, os, requests, MagicMock, etc.) from ~15 test files
- Break over-long function signatures in test_sync_extended.py and test_jellyfin_api.py
- Remove unused variable assignments in test_api_client.py and test_routes.py

### Result
The entire test suite now passes flake8 cleanly.

Closes #119
Closes #120