### PR TITLE
chore: restore mypy.ini and centralize type-checking configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         always_run: true
     -   id: mypy
         name: mypy type checking
-        entry: bash -c "mypy . --ignore-missing-imports --exclude '(venv|__pycache__|tests|node_modules)'"
+        entry: bash -c "mypy ."
         language: system
         pass_filenames: false
         always_run: true

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+exclude = (venv|__pycache__|tests|node_modules)
+warn_redundant_casts = True


### PR DESCRIPTION
## Summary
Restores the mypy.ini configuration file that was lost when PR #112 had merge conflicts, and cleans up the pre-commit hook.

### Changes
- Creates `mypy.ini` with `ignore_missing_imports`, `exclude` for tests/venv, and `warn_redundant_casts`
- Updates the pre-commit mypy hook to call `mypy .` without inline flags

### Why
Centralizing mypy configuration in a dedicated file makes it easier to maintain and keeps the pre-commit hook readable.

Closes #123