### PR TITLE
chore: consolidate tool configs into pyproject.toml

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-exclude = (venv|__pycache__|tests|node_modules)
-warn_redundant_casts = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jellyfin-groupings"
+version = "1.0.0"
+description = "Create virtual Jellyfin libraries by grouping media via symlinks"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.12"
+dependencies = [
+    "flask>=3.0.0",
+    "requests>=2.31.0",
+    "apscheduler>=3.10.4,<4.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+exclude = ["tests*", "e2e*", "unraid*"]
+
+[tool.mypy]
+ignore_missing_imports = true
+exclude = [
+    "venv",
+    "__pycache__",
+    "tests",
+    "node_modules",
+]
+warn_redundant_casts = true
+
+[tool.pytest.ini_options]
+markers = [
+    "exhaustive: marks tests as exhaustive/edge-case tests that run against the specifically formatted virtual Jellyfin server (deselect with '-m \"not exhaustive\"')",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    exhaustive: marks tests as exhaustive/edge-case tests that run against the specifically formatted virtual Jellyfin server (deselect with '-m "not exhaustive"')


### PR DESCRIPTION
## Summary

Consolidate `mypy.ini` and `pytest.ini` into a single `pyproject.toml` following modern Python packaging conventions.

## Changes

- **New**: `pyproject.toml` with:
  - `[build-system]` — setuptools build backend
  - `[project]` — package metadata (name, version, description, dependencies)
  - `[tool.mypy]` — migrated from `mypy.ini`
  - `[tool.pytest.ini_options]` — migrated from `pytest.ini`
- **Removed**: `mypy.ini`, `pytest.ini`

## Why

- Single source of truth for tool configuration
- Reduces root-directory clutter
- Follows PEP 518 / PEP 621 conventions
- Makes it easier to add other tool configs (black, ruff, etc.) in the future

## Test Plan

- [x] mypy still passes (15 source files, no issues)
- [x] pytest still passes
- [x] flake8 clean

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)