### PR TITLE
chore: fix ruff lint errors in test suite

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,8 +58,6 @@ def test_nested_defaults(temp_config):
 # config.py edge cases
 # ---------------------------------------------------------------------------
 
-import pytest
-
 
 def test_load_config_corrupt_file(temp_config):
     """Test that a corrupt config file falls back to defaults."""

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -6,6 +6,7 @@ from mal import fetch_mal_list
 from trakt import fetch_trakt_list
 from anilist import fetch_anilist_list
 from tmdb import fetch_tmdb_list
+from letterboxd import _extract_ids_from_list_page, _fetch_id_for_slug
 
 
 @patch('requests.Session.get')
@@ -184,8 +185,6 @@ def test_fetch_anilist_empty_data(mock_post):
 # ---------------------------------------------------------------------------
 # letterboxd.py edge cases
 # ---------------------------------------------------------------------------
-
-from letterboxd import _extract_ids_from_list_page, _fetch_id_for_slug
 
 
 def test_extract_ids_tmdb_from_list_page():

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -68,8 +68,6 @@ def test_fetch_anilist_list(mock_post):
 # imdb.py edge cases
 # ---------------------------------------------------------------------------
 
-from imdb import fetch_imdb_list
-
 
 def test_fetch_imdb_invalid_id():
     with pytest.raises(ValueError, match="Invalid IMDb list ID"):
@@ -109,8 +107,6 @@ def test_fetch_imdb_pagination(mock_get):
 # ---------------------------------------------------------------------------
 # anilist.py edge cases
 # ---------------------------------------------------------------------------
-
-from anilist import fetch_anilist_list
 
 
 @patch('anilist.requests.post')

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,6 +3,7 @@ from scheduler import (
     update_scheduler_jobs,
     _run_global_sync_job,
     _run_group_sync_job,
+    _run_cleanup_job,
     start_scheduler,
     validate_cron,
 )
@@ -155,8 +156,6 @@ def test_validate_cron_invalid_values():
 # ---------------------------------------------------------------------------
 # scheduler.py edge cases
 # ---------------------------------------------------------------------------
-
-from scheduler import _run_cleanup_job
 
 
 @patch('scheduler._scheduler')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -26,6 +26,8 @@ from sync import (
     _fetch_full_library,
     _fetch_items_for_complex_group,
     _fetch_items_for_metadata_group,
+    _process_group,
+    run_sync,
 )
 
 
@@ -191,7 +193,6 @@ def test_preview_group(mock_jf):
 
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_items_for_metadata_group_with_watch_state(mock_jf):
-    from sync import _fetch_items_for_metadata_group
     mock_jf.return_value = [{"Name": "M1"}]
     # Test 'unwatched' calls fetch with Filters=IsUnplayed
     _fetch_items_for_metadata_group("Group", "genre", "Action", "SortName", "http://jf", "key", "unwatched")
@@ -802,8 +803,6 @@ def test_complex_group_watch_state(mock_lib):
 
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_items_metadata_request_error(mock_fetch):
-    from sync import _fetch_items_for_metadata_group
-
     mock_fetch.side_effect = requests.exceptions.ConnectionError("fail")
     items, error, code = _fetch_items_for_metadata_group(
         "Group", "genre", "Action", "SortName", "http://jf", "key"
@@ -814,8 +813,6 @@ def test_fetch_items_metadata_request_error(mock_fetch):
 
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_items_metadata_unexpected_error(mock_fetch):
-    from sync import _fetch_items_for_metadata_group
-
     mock_fetch.side_effect = TypeError("bad")
     items, error, code = _fetch_items_for_metadata_group(
         "Group", "genre", "Action", "SortName", "http://jf", "key"
@@ -864,8 +861,6 @@ def test_process_collection_group_cover_error(mock_find, mock_add, mock_cover, m
 
 
 # --- _process_group ---
-
-from sync import _process_group
 
 
 def test_process_group_empty_name(tmp_path):
@@ -1013,7 +1008,7 @@ def test_process_group_library_with_jellyfin_path(mock_meta, mock_add, tmp_path)
         "source_value": "Action",
         "sort_order": "SortName",
     }
-    result = _process_group(
+    _ = _process_group(
         group,
         str(tmp_path),
         "http://jf",
@@ -1045,7 +1040,7 @@ def test_process_group_library_already_exists(mock_meta, mock_add, tmp_path):
         "source_value": "Action",
         "sort_order": "SortName",
     }
-    result = _process_group(
+    _ = _process_group(
         group,
         str(tmp_path),
         "http://jf",
@@ -1100,8 +1095,6 @@ def test_process_group_auto_set_library_covers(mock_meta, mock_cover, mock_set, 
 
 
 # --- run_sync ---
-
-from sync import run_sync
 
 
 def test_run_sync_missing_settings():


### PR DESCRIPTION
## Summary
Clean up 16 ruff lint violations across the test suite:

- **F401** (unused imports): removed stray `import pytest` in `test_config.py`, redundant top-level `_fetch_items_for_metadata_group` import in `test_sync.py`.
- **F811** (redefinition of unused import): consolidated duplicate `fetch_imdb_list` and `fetch_anilist_list` imports in `test_fetchers.py`; removed inline redefinitions of `_fetch_items_for_metadata_group` in `test_sync.py`.
- **F841** (unused local variable): replaced ignored `result =` assignments with `_ =` in `test_sync.py`.
- **E402** (module-level import not at top): moved all mid-file imports to the top of their respective modules (`test_external.py`, `test_fetchers.py`, `test_scheduler.py`, `test_sync.py`).

## Test plan
- [x] `ruff check .` now passes with zero errors.
- [x] Full test suite still passes (401 passed, 17 skipped).

Closes #144