### PR TITLE
chore: omit start_virtual_jellyfin.py from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ omit =
     run_tests_to_file.py
     parse_test.py
     app.py
+    start_virtual_jellyfin.py
 
 [report]
 show_missing = True


### PR DESCRIPTION
## Summary
`start_virtual_jellyfin.py` is a development helper script that starts the mock Jellyfin server. It is not intended to be unit-tested, yet it appears in coverage reports with 0% coverage, artificially dragging down the overall percentage.

## Changes
- Added `start_virtual_jellyfin.py` to the `omit` list in `.coveragerc`.

## Impact
- Overall coverage jumps from **96.28%** to **96.78%** (the 10-line script is no longer counted).
- Report now focuses on testable production code.

## Test plan
- [x] `pytest --cov` no longer includes `start_virtual_jellyfin.py`.
- [x] All existing tests still pass.

Closes #146