### PR TITLE
refactor: extract duplicated watch-state filtering into _filter_by_watch_state

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -139,6 +139,26 @@ _LIBRARY_CACHE: dict[tuple[str, str], list[dict[str, Any]]] = {}
 _LIBRARY_CACHE_LOCK = threading.RLock()
 
 
+def _filter_by_watch_state(
+    items: list[dict[str, Any]], watch_state: str
+) -> list[dict[str, Any]]:
+    """Filter *items* by Jellyfin watch state.
+
+    Args:
+        items: Jellyfin item dicts (must contain ``UserData.Played``).
+        watch_state: ``"unwatched"``, ``"watched"``, or any other value
+            (which returns the list unchanged).
+
+    Returns:
+        The filtered list.
+    """
+    if watch_state == "unwatched":
+        return [i for i in items if not i.get("UserData", {}).get("Played")]
+    if watch_state == "watched":
+        return [i for i in items if i.get("UserData", {}).get("Played")]
+    return items
+
+
 def _fetch_full_library(
     url: str,
     api_key: str,
@@ -246,10 +266,7 @@ def _match_jellyfin_items_by_provider(
         matched_ids = {str(eid).lower() if case_insensitive else str(eid) for eid in external_ids}
         items = [v for k, v in jf_by_provider.items() if k in matched_ids]
 
-    if watch_state == "unwatched":
-        items = [i for i in items if not i.get("UserData", {}).get("Played")]
-    elif watch_state == "watched":
-        items = [i for i in items if i.get("UserData", {}).get("Played")]
+    items = _filter_by_watch_state(items, watch_state)
 
     return items, None, 200
 
@@ -589,10 +606,7 @@ def _fetch_items_for_letterboxd_group(
                 items.append(match)
                 seen_jf_ids.add(match["Id"])
 
-    if watch_state == "unwatched":
-        items = [i for i in items if not i.get("UserData", {}).get("Played")]
-    elif watch_state == "watched":
-        items = [i for i in items if i.get("UserData", {}).get("Played")]
+    items = _filter_by_watch_state(items, watch_state)
 
     return items, None, 200
 
@@ -787,10 +801,7 @@ def _fetch_items_for_complex_group(
 
     filtered = [item for item in raw_items if _eval_item(item, valid_rules)]
 
-    if watch_state == "unwatched":
-        filtered = [i for i in filtered if not i.get("UserData", {}).get("Played")]
-    elif watch_state == "watched":
-        filtered = [i for i in filtered if i.get("UserData", {}).get("Played")]
+    filtered = _filter_by_watch_state(filtered, watch_state)
 
     # In-memory sorting because this is local filtering
     sorted_items = _sort_items_in_memory(filtered, sort_order)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -28,6 +28,7 @@ from sync import (
     _fetch_items_for_metadata_group,
     _process_group,
     run_sync,
+    _filter_by_watch_state,
 )
 
 
@@ -641,6 +642,16 @@ def test_fetch_items_mal_empty(mock_fetch):
 def test_translate_path_valueerror():
     # os.path.commonpath raises ValueError for mixed abs/relative paths
     assert _translate_path("/foo", ".", "/host") == "/foo"
+
+
+def test_filter_by_watch_state():
+    unwatched = {"UserData": {"Played": False}}
+    watched = {"UserData": {"Played": True}}
+    no_data = {}
+
+    assert _filter_by_watch_state([unwatched, watched, no_data], "unwatched") == [unwatched, no_data]
+    assert _filter_by_watch_state([unwatched, watched, no_data], "watched") == [watched]
+    assert _filter_by_watch_state([unwatched, watched, no_data], "all") == [unwatched, watched, no_data]
 
 
 def test_get_cover_path_no_target_base():


### PR DESCRIPTION
## Summary

Fixes #156.

Extracts the duplicated watch-state filtering logic from three locations in `sync.py` into a single helper `_filter_by_watch_state`.

## Changes

- Introduce `_filter_by_watch_state(items, watch_state)` helper with docstring.
- Replace inline filter blocks in `_match_jellyfin_items_by_provider`, `_fetch_items_for_letterboxd_group`, and `_fetch_items_for_complex_group` with one-line calls.
- Add `test_filter_by_watch_state` covering ``"unwatched"``, ``"watched"``, and pass-through.

## Test plan

- `python -m pytest tests/test_sync.py::test_filter_by_watch_state` passes.
- Full suite: 430 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)