### PR TITLE
fix: return 400 for malformed data URLs in upload_cover

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -420,6 +420,8 @@ def upload_cover() -> ResponseReturnValue:
             f.write(decoded)
 
         return jsonify({"status": "success", "message": "Cover saved successfully"})
+    except ValueError:
+        return jsonify({"status": "error", "message": "Malformed image data"}), 400
     except Exception as exc:
         logger.exception("Failed to save cover image")
         return jsonify({"status": "error", "message": f"Server error: {exc!s}"}), 500


### PR DESCRIPTION
## Summary

Fixes #168.

Adds an explicit ``except ValueError`` in `upload_cover` to catch malformed data URLs and return a 400 instead of an opaque 500.

## Changes

- Catch ``ValueError`` from ``image_data.split(\",\", 1)`` and return 400 with "Malformed image data".

## Test plan

- `python -m pytest tests/test_routes.py` passes.
- Full suite: 430 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)