### PR TITLE
fix: resolve mypy type errors

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -8,7 +8,7 @@ Jellyfin ``/Items`` endpoint.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, NoReturn
 
 import mimetypes
 import logging
@@ -44,7 +44,7 @@ def _format_request_error(exc: requests.exceptions.RequestException, prefix: str
     return msg
 
 
-def _raise_request_error(exc: requests.exceptions.RequestException, prefix: str) -> None:
+def _raise_request_error(exc: requests.exceptions.RequestException, prefix: str) -> NoReturn:
     """Format *exc* into a ``RuntimeError`` with response details if available."""
     raise RuntimeError(_format_request_error(exc, prefix)) from exc
 

--- a/routes.py
+++ b/routes.py
@@ -294,7 +294,7 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
     """
     config_result = _get_jellyfin_config()
     if len(config_result) == 2 and isinstance(config_result[1], int):
-        return config_result
+        return config_result  # type: ignore[return-value]
     url, api_key = config_result
 
     result: dict[str, list[str]] = {}
@@ -347,7 +347,7 @@ def get_jellyfin_users() -> ResponseReturnValue:
     """
     config_result = _get_jellyfin_config()
     if len(config_result) == 2 and isinstance(config_result[1], int):
-        return config_result
+        return config_result  # type: ignore[return-value]
     url, api_key = config_result
 
     try:
@@ -492,7 +492,7 @@ def preview_grouping() -> ResponseReturnValue:
 
     config_result = _get_jellyfin_config()
     if len(config_result) == 2 and isinstance(config_result[1], int):
-        return config_result
+        return config_result  # type: ignore[return-value]
     url, api_key = config_result
 
     # Validate and normalize "type"
@@ -641,7 +641,7 @@ def auto_detect_paths() -> ResponseReturnValue:
         missing_msg="Server settings required for detection"
     )
     if len(config_result) == 2 and isinstance(config_result[1], int):
-        return config_result
+        return config_result  # type: ignore[return-value]
     url, api_key = config_result
 
     try:


### PR DESCRIPTION
## Summary

Fixes #172.

Resolves the mypy type errors introduced by recent refactors.

## Changes

- Annotate `_raise_request_error` with `NoReturn`.
- Add `# type: ignore[return-value]` at `_get_jellyfin_config` caller return sites.

## Test plan

- `mypy --ignore-missing-imports --exclude tests .` passes.
- Full suite: 430 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)