### PR TITLE
fix: propagate scheduler update failure in update_config

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -162,8 +162,18 @@ def update_config() -> ResponseReturnValue:
     # Update background jobs based on new config
     try:
         update_scheduler_jobs()
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to update scheduler jobs")
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": f"Config saved but scheduler could not be updated: {exc!s}",
+                    "config": new_config,
+                }
+            ),
+            500,
+        )
 
     return jsonify({"status": "success", "config": new_config})
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -185,8 +185,11 @@ def test_update_config_non_dict(client):
 def test_update_config_scheduler_fail(mock_sched, client):
     mock_sched.side_effect = Exception("Fail")
     response = client.post('/api/config', json={"jellyfin_url": "http://jf"})
-    assert response.status_code == 200  # Should not fail the whole request
-    assert response.get_json()["status"] == "success"
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["status"] == "error"
+    assert "scheduler could not be updated" in data["message"]
+    assert "config" in data
 
 
 @patch('routes.requests.get')


### PR DESCRIPTION
## Summary

Fixes #174.

When `update_scheduler_jobs()` fails after the config is saved, the route now returns HTTP 500 instead of silently succeeding.

## Changes

- Return 500 with ``status: "error"`` when scheduler update fails.
- Include the saved config in the error response for transparency.
- Update `test_update_config_scheduler_fail` to expect the new behavior.

## Test plan

- `python -m pytest tests/test_routes.py::test_update_config_scheduler_fail` passes.
- Full suite: 430 passed, 17 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)