### PR TITLE
chore: switch pre-commit from flake8 to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 -   repo: local
     hooks:
-    -   id: flake8
-        name: flake8 linting
-        entry: bash -c "flake8 . --max-line-length=120 --exclude=venv,__pycache__,.git,node_modules"
+    -   id: ruff
+        name: ruff linting
+        entry: bash -c "ruff check ."
         language: system
         pass_filenames: false
         always_run: true
     -   id: mypy
         name: mypy type checking
-        entry: bash -c "mypy ."
+        entry: bash -c "mypy --ignore-missing-imports --exclude tests --exclude venv --exclude __pycache__ --exclude node_modules ."
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Summary

Fixes #179.

Updates `.pre-commit-config.yaml` to use ruff instead of flake8, and adds proper `--exclude` flags to the mypy hook.

## Changes

- Replace flake8 hook with ruff.
- Update mypy hook exclusions to match CI.

## Test plan

- `ruff check .` passes.
- `mypy --ignore-missing-imports --exclude tests --exclude venv --exclude __pycache__ --exclude node_modules .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)