### PR TITLE
fix: propagate network errors from find_collection_by_name

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -444,40 +444,37 @@ def find_collection_by_name(
     limit = 200
     start_index = 0
 
-    try:
-        while True:
-            params: dict[str, str | int] = {
-                "IncludeItemTypes": "BoxSet",
-                "Recursive": "true",
-                "SearchTerm": name,
-                "Limit": limit,
-                "StartIndex": start_index,
-            }
+    while True:
+        params: dict[str, str | int] = {
+            "IncludeItemTypes": "BoxSet",
+            "Recursive": "true",
+            "SearchTerm": name,
+            "Limit": limit,
+            "StartIndex": start_index,
+        }
 
-            resp = requests.get(
-                f"{base_url}/Items",
-                params=params,
-                headers=headers,
-                timeout=timeout,
-            )
-            resp.raise_for_status()
-            data = _parse_json(resp)
-            items = data.get("Items", [])
+        resp = requests.get(
+            f"{base_url}/Items",
+            params=params,
+            headers=headers,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = _parse_json(resp)
+        items = data.get("Items", [])
 
-            for item in items:
-                if item.get("Name") == name:
-                    item_id: str | None = item.get("Id")
-                    if item_id:
-                        return item_id
+        for item in items:
+            if item.get("Name") == name:
+                item_id: str | None = item.get("Id")
+                if item_id:
+                    return item_id
 
-            total = data.get("TotalRecordCount", 0)
-            start_index += len(items)
-            if start_index >= total or not items:
-                break
+        total = data.get("TotalRecordCount", 0)
+        start_index += len(items)
+        if start_index >= total or not items:
+            break
 
-        return None
-    except requests.exceptions.RequestException:
-        return None
+    return None
 
 
 def add_to_collection(

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -469,8 +469,8 @@ def test_find_collection_by_name_missing_id(mock_get):
 def test_find_collection_by_name_request_exception(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Timeout")
 
-    result = find_collection_by_name("http://localhost:8096", "test_key", "Anything")
-    assert result is None
+    with pytest.raises(requests.exceptions.RequestException):
+        find_collection_by_name("http://localhost:8096", "test_key", "Anything")
 
 
 @patch('requests.get')

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1340,12 +1340,14 @@ def test_process_collection_group_auto_cover_off(mock_find, mock_add, tmp_path):
     assert result["links"] == 1
 
 
+@patch('sync.find_collection_by_name')
 @patch('sync.create_collection')
 @patch('sync.add_to_collection')
 @patch('sync._fetch_items_for_metadata_group')
-def test_process_group_create_collection(mock_meta, mock_add, mock_create, tmp_path):
+def test_process_group_create_collection(mock_meta, mock_add, mock_create, mock_find, tmp_path):
     host = tmp_path / "movie.mkv"
     host.write_text("movie")
+    mock_find.return_value = None
     mock_create.return_value = "col123"
     mock_meta.return_value = ([{"Id": "1", "Name": "M1", "Path": str(host)}], None, 200)
     group = {


### PR DESCRIPTION
## Summary

Closes #185.

`jellyfin.find_collection_by_name` previously caught `requests.exceptions.RequestException` and returned ``None``. This made transient network failures indistinguishable from "collection does not exist", causing the caller to try creating a new collection and potentially creating duplicates.

## Changes

- Remove the internal `except requests.exceptions.RequestException: return None` guard and let the exception propagate.
- The caller (`sync._process_collection_group`) already wraps the call in `try/except Exception`, so the error is now surfaced properly instead of being silently swallowed.

## Test updates

- `test_find_collection_by_name_request_exception` now asserts that the exception propagates instead of returning ``None``.
- `test_process_group_create_collection` now mocks `find_collection_by_name` (returning ``None``) so it still exercises the "create new collection" path without hitting the network.

## Test plan

- [x] Full test suite passes (431 passed, 17 skipped)
- [x] ruff clean
- [x] mypy clean