### PR TITLE
fix: propagate network errors from get_library_id

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -296,21 +296,18 @@ def get_library_id(base_url: str, api_key: str, name: str, timeout: int = 30) ->
     Returns:
         The string ItemId of the library if found, else None.
     """
-    try:
-        response = requests.get(
-            f"{base_url}/Library/VirtualFolders",
-            headers={"X-Emby-Token": api_key},
-            timeout=timeout,
-        )
-        response.raise_for_status()
+    response = requests.get(
+        f"{base_url}/Library/VirtualFolders",
+        headers={"X-Emby-Token": api_key},
+        timeout=timeout,
+    )
+    response.raise_for_status()
 
-        for folder in _parse_json(response):
-            if folder.get("Name") == name:
-                item_id = folder.get("ItemId")
-                if item_id is not None:
-                    return str(item_id)
-    except requests.exceptions.RequestException as exc:
-        logger.error("Failed to get library ID for %r: %s", name, exc)
+    for folder in _parse_json(response):
+        if folder.get("Name") == name:
+            item_id = folder.get("ItemId")
+            if item_id is not None:
+                return str(item_id)
 
     return None
 
@@ -359,12 +356,11 @@ def set_virtual_folder_image(
         image_path: Absolute path to the local image file to upload.
         timeout: HTTP request timeout.
     """
-    library_id = get_library_id(base_url, api_key, name, timeout=timeout)
-    if not library_id:
-        logger.info("Cannot set image: Library %r not found or ID unknown.", name)
-        return
-
     try:
+        library_id = get_library_id(base_url, api_key, name, timeout=timeout)
+        if not library_id:
+            logger.info("Cannot set image: Library %r not found or ID unknown.", name)
+            return
         _upload_image(base_url, api_key, library_id, image_path, timeout=timeout)
     except requests.exceptions.RequestException as exc:
         logger.info(

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -302,13 +302,11 @@ def test_delete_virtual_folder_not_ok(mock_delete, caplog):
 
 
 @patch('requests.get')
-def test_get_library_id_request_exception(mock_get, caplog):
+def test_get_library_id_request_exception(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Fetch Error")
 
-    result = get_library_id("http://localhost:8096", "test_key", "MyLib")
-    assert result is None
-
-    assert "Failed to get library ID for 'MyLib': Fetch Error" in caplog.text
+    with pytest.raises(requests.exceptions.RequestException):
+        get_library_id("http://localhost:8096", "test_key", "MyLib")
 
 
 @patch('jellyfin.get_library_id')

--- a/tests/test_virtual_jellyfin_exhaustive.py
+++ b/tests/test_virtual_jellyfin_exhaustive.py
@@ -149,10 +149,9 @@ def test_get_library_id_missing_itemid_key(jellyfin_url):
     assert lib_id is None
 
 
-def test_get_library_id_500(jellyfin_url, caplog):
-    lib_id = get_library_id(jellyfin_url, "LIB_GET_500", "Movies")
-    assert lib_id is None
-    assert "Failed to get library ID" in caplog.text
+def test_get_library_id_500(jellyfin_url):
+    with pytest.raises(requests.exceptions.HTTPError):
+        get_library_id(jellyfin_url, "LIB_GET_500", "Movies")
 
 # 7. set_virtual_folder_image Exhaustive
 


### PR DESCRIPTION
## Summary

Closes #187.

`jellyfin.get_library_id` previously caught `requests.exceptions.RequestException` and returned ``None``. This made transient network failures indistinguishable from "library does not exist", causing `set_virtual_folder_image` to log a misleading "not found" message.

## Changes

- Remove the internal `except` guard from `get_library_id` and let the exception propagate.
- Move the `get_library_id` call inside the existing `try` block in `set_virtual_folder_image` so network errors are caught by the existing `except requests.exceptions.RequestException` handler and logged correctly.

## Test updates

- `test_get_library_id_request_exception` now asserts that the exception propagates.
- `test_get_library_id_500` now asserts that `HTTPError` propagates.

## Test plan

- [x] Full test suite passes (431 passed, 17 skipped)
- [x] ruff clean
- [x] mypy clean