### PR TITLE
test: cover letterboxd 404-on-page-two and _compute_common_root

### DIFF
--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -226,15 +226,19 @@ def test_fetch_id_for_slug_request_exception(mock_get):
 def test_letterboxd_404_on_page_two(mock_get):
     resp1 = MagicMock()
     resp1.status_code = 200
-    resp1.text = 'data-film-slug="film1"'
+    resp1.text = 'data-film-slug="film1" class="next"'
 
     resp2 = MagicMock()
-    resp2.status_code = 404
+    resp2.status_code = 200
+    resp2.text = 'href="https://www.imdb.com/title/tt1234567/"'
 
-    mock_get.side_effect = [resp1, resp2]
+    resp3 = MagicMock()
+    resp3.status_code = 404
+
+    mock_get.side_effect = [resp1, resp2, resp3]
 
     ids = fetch_letterboxd_list("https://letterboxd.com/user/list/my-list")
-    assert ids == []
+    assert ids == ["tt1234567"]
 
 
 @patch('requests.Session.get')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1040,3 +1040,17 @@ def test_run_tests_success(mock_run, client, app):
     response = client.post('/api/test/run')
     assert response.status_code == 200
     assert "Tests executed successfully." in response.get_json()["message"]
+
+
+from routes import _compute_common_root
+
+def test_compute_common_root_no_match():
+    assert _compute_common_root("/a/b/c", "/x/y/z") == (None, None)
+
+
+def test_compute_common_root_single_match():
+    assert _compute_common_root("/a/b/c", "/x/b/c") == ("/a", "/x")
+
+
+def test_compute_common_root_full_match():
+    assert _compute_common_root("/a/b/c", "/a/b/c") == (os.sep, os.sep)


### PR DESCRIPTION
## Summary

Brings `letterboxd.py` and `routes.py` to 100% statement coverage with targeted test additions.

## Changes

- Fix `test_letterboxd_404_on_page_two` so it actually exercises the page-2 404 early-exit path. The original test never reached page 2 because the mocked HTML lacked a `class=\"next\"` pagination link.
- Add direct unit tests for `_compute_common_root` covering no-match, single-match, and full-match paths.

## Test plan

- [x] Full test suite passes (434 passed, 17 skipped)
- [x] Coverage: `letterboxd.py` 100%, `routes.py` 100%
- [x] ruff clean
- [x] mypy clean