### PR TITLE
chore: narrow broad except Exception clauses and fix logging f-string

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -330,7 +331,7 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
                     result[key] = [
                         item.get("Name", "") for item in items if item.get("Name")
                     ]
-                except Exception:
+                except (requests.exceptions.RequestException, ValueError):
                     logger.warning("Failed to process metadata key %r", key, exc_info=True)
                     result[key] = []
                     failed += 1
@@ -368,7 +369,7 @@ def get_jellyfin_users() -> ResponseReturnValue:
                 "users": [{"id": u.get("Id"), "name": u.get("Name")} for u in users_list],
             }
         )
-    except Exception as exc:
+    except (requests.exceptions.RequestException, RuntimeError) as exc:
         return jsonify({"status": "error", "message": str(exc)}), 400
 
 
@@ -606,7 +607,6 @@ def perform_cleanup() -> ResponseReturnValue:
         path = os.path.join(target_base, name)
         if os.path.exists(path) and os.path.isdir(path):
             try:
-                import shutil
                 shutil.rmtree(path)
                 deleted += 1
 
@@ -617,7 +617,7 @@ def perform_cleanup() -> ResponseReturnValue:
                     if url and api_key:
                         try:
                             delete_virtual_folder(url, api_key, name)
-                        except Exception as e:
+                        except (requests.exceptions.RequestException, OSError) as e:
                             logger.warning("Failed to delete Jellyfin library '%s': %s", name, e)
             except OSError as exc:
                 errors.append(f"Failed to delete {name}: {exc}")
@@ -735,7 +735,7 @@ def auto_detect_paths() -> ResponseReturnValue:
             },
             timeout=10,
         )
-    except Exception as exc:
+    except (requests.exceptions.RequestException, RuntimeError) as exc:
         return jsonify({"status": "error", "message": str(exc)}), 400
 
     if not items:
@@ -850,7 +850,7 @@ def get_test_results() -> ResponseReturnValue:
             try:
                 with open(filename, "r", encoding="utf-8") as f:
                     results[filename] = f.read()
-            except Exception:
+            except (OSError, UnicodeDecodeError):
                 results[filename] = "Error reading file."
         else:
             results[filename] = "No output found."

--- a/scheduler.py
+++ b/scheduler.py
@@ -76,7 +76,7 @@ def update_scheduler_jobs() -> None:
                 )
                 logger.info("Scheduled sync for group '%s': %s", group_name, cron_expr)
             except Exception:
-                logger.exception(f"Failed to schedule sync for group '{group_name}'")
+                logger.exception("Failed to schedule sync for group '%s'", group_name)
 
     # 3. Cleanup Scheduler
     if sched_cfg.get("cleanup_enabled", True):  # Default to true

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -337,7 +337,7 @@ def test_get_jellyfin_users_success(mock_get_users, client):
 @pytest.mark.usefixtures("temp_config")
 def test_get_jellyfin_users_exception(mock_get_users, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_get_users.side_effect = Exception("Jellyfin down")
+    mock_get_users.side_effect = requests.exceptions.RequestException("Jellyfin down")
     response = client.get('/api/jellyfin/users')
     assert response.status_code == 400
     assert response.get_json()["status"] == "error"
@@ -520,7 +520,7 @@ def test_auto_detect_paths_no_config(client):
 @pytest.mark.usefixtures("temp_config")
 def test_auto_detect_paths_fetch_error(mock_fetch, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_fetch.side_effect = Exception("Connection refused")
+    mock_fetch.side_effect = requests.exceptions.RequestException("Connection refused")
     response = client.post('/api/jellyfin/auto-detect-paths')
     assert response.status_code == 400
 
@@ -793,7 +793,7 @@ def test_perform_cleanup_delete_virtual_folder_error(mock_exists, mock_delete, c
         "api_key": "key"
     })
     mock_exists.return_value = True
-    mock_delete.side_effect = Exception("Jellyfin error")
+    mock_delete.side_effect = requests.exceptions.RequestException("Jellyfin error")
     response = client.post('/api/cleanup', json={"folders": ["Action"]})
     assert response.status_code == 200
     assert response.get_json()["deleted"] == 1


### PR DESCRIPTION
## Summary

Tightens overly broad `except Exception` clauses across routes.py and fixes an f-string inside `logger.exception()` in scheduler.py.

## Changes

- scheduler.py: replace f-string in `logger.exception` with lazy `%` formatting
- routes.py: move inline `import shutil` to module level
- routes.py: narrow `except Exception` in `delete_virtual_folder` call to `(RequestException, OSError)`
- routes.py: narrow `except Exception` in `auto_detect_paths` to `(RequestException, RuntimeError)`
- routes.py: narrow `except Exception` in `get_jellyfin_users` to `(RequestException, RuntimeError)`
- routes.py: narrow `except Exception` in `get_jellyfin_metadata` future handling to `(RequestException, ValueError)`
- routes.py: narrow `except Exception` in `get_test_results` file reading to `(OSError, UnicodeDecodeError)`
- tests: update affected tests to raise specific exception types instead of generic `Exception`

## Verification

- Full test suite: 442 passed, 17 skipped
- Statement coverage: 100% (1,601 statements, 0 misses)
- ruff: all checks passed
- mypy: no issues found

Closes #191