### PR TITLE
chore: narrow broad except Exception in tmdb.py recommendation loop

### DIFF
--- a/tmdb.py
+++ b/tmdb.py
@@ -113,7 +113,7 @@ def get_tmdb_recommendations(items_with_type: list[tuple[str, str]], api_key: st
                     rec_id = str(rec.get("id"))
                     score = 1.0 / (i + 1)  # Higher weight for top recommendations
                     recommendation_counts[rec_id] = recommendation_counts.get(rec_id, 0.0) + score
-        except Exception:
+        except (requests.exceptions.RequestException, ValueError):
             logger.debug("Skipping failed recommendation item", exc_info=True)
 
     # Sort items by their accumulated score


### PR DESCRIPTION
## Summary

Tightens the overly broad `except Exception` in `get_tmdb_recommendations` to `(requests.exceptions.RequestException, ValueValueError)`.

## Changes

- `tmdb.py`: narrow `except Exception` to `(requests.exceptions.RequestException, ValueError)` in the recommendation-fetching loop.

## Verification

- Full test suite: 442 passed, 17 skipped
- Statement coverage: 100% (1,601 statements, 0 misses)
- ruff: all checks passed
- mypy: no issues found

Closes #193