### PR TITLE
chore: fix inconsistent logging in sync.py

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -212,7 +212,7 @@ def _fetch_full_library(
         logger.error("Infrastructure error fetching Jellyfin library for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
     except Exception as exc:
-        logging.exception("Unexpected error fetching Jellyfin library for group %r", group_name)
+        logger.exception("Unexpected error fetching Jellyfin library for group %r", group_name)
         return [], f"Internal error: {exc!s}", 500  # noqa: BLE001
 
 
@@ -838,7 +838,7 @@ def _fetch_items_for_metadata_group(
         logger.error("Infrastructure error fetching items for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
     except Exception as exc:
-        logging.exception("Unexpected error fetching items for group %r", group_name)
+        logger.exception("Unexpected error fetching items for group %r", group_name)
         return [], f"Internal error: {exc!s}", 500  # noqa: BLE001
 
 


### PR DESCRIPTION
## Summary

Two places in sync.py were using logging.exception (root logger) instead of logger.exception (module logger).

## Changes

- _fetch_full_library: logging.exception -> logger.exception
- _fetch_items_for_general_group: logging.exception -> logger.exception

## Verification

- Full test suite: 442 passed, 17 skipped
- Statement coverage: 100%
- ruff and mypy pass cleanly

Closes #195