### PR TITLE
chore: add explicit utf-8 encoding to config.py file operations

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ def load_config() -> dict[str, Any]:
         cfg = DEFAULT_CONFIG.copy()
     else:
         try:
-            with open(CONFIG_FILE, "r") as fh:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as fh:
                 cfg = json.load(fh)
 
             # Fill in any keys added after initial creation
@@ -127,5 +127,5 @@ def save_config(config: dict[str, Any]) -> None:
         config: The configuration dictionary to write.
     """
     os.makedirs(CONFIG_DIR, exist_ok=True)
-    with open(CONFIG_FILE, "w") as fh:
+    with open(CONFIG_FILE, "w", encoding="utf-8") as fh:
         json.dump(config, fh, indent=4)


### PR DESCRIPTION
## Summary

config.py opened config.json without specifying an encoding. This PR adds encoding='utf-8' to both the read and write paths.

## Changes

- load_config: open(CONFIG_FILE, 'r') -> open(CONFIG_FILE, 'r', encoding='utf-8')
- save_config: open(CONFIG_FILE, 'w') -> open(CONFIG_FILE, 'w', encoding='utf-8')

## Verification

- Full test suite: 442 passed, 17 skipped
- Statement coverage: 100%
- ruff and mypy pass cleanly

Closes #199