### PR TITLE
chore: use cached regex for complex query detection

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -912,7 +912,7 @@ def preview_group(
     Returns:
         A ``(items, error, status_code)`` tuple.
     """
-    if re.search(r"\s+(AND NOT|OR NOT|AND|OR)\s+", val, re.IGNORECASE):
+    if _COMPLEX_QUERY_RE.search(val):
         rules = parse_complex_query(val, type_name)
         return _fetch_items_for_complex_group("preview", rules, "", url, api_key, watch_state)
     else:


### PR DESCRIPTION
## Summary

Replaced the inline re.search in preview_group with the pre-compiled _COMPLEX_QUERY_RE.search.

## Changes

- Use _COMPLEX_QUERY_RE.search(val) instead of inline re.compile

## Verification

- Full test suite: 442 passed, 17 skipped
- Statement coverage: 100%
- ruff and mypy pass cleanly

Closes #209