### PR TITLE
chore: use cached regex in _fetch_items_for_source

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -1083,9 +1083,7 @@ def _process_group(
         val_str = str(source_value or "")
 
         # Determine if it's a complex textual rule that needs local parsing
-        if source_type in ["genre", "actor", "studio", "tag", "year"] and re.search(
-            r'\s+(AND NOT|OR NOT|AND|OR)\s+', val_str, re.IGNORECASE
-        ):
+        if source_type in ["genre", "actor", "studio", "tag", "year"] and _COMPLEX_QUERY_RE.search(val_str):
             rules = parse_complex_query(val_str, str(source_type))
             items, error, status_code = _fetch_items_for_complex_group(
                 group_name, rules, sort_order, url, api_key, watch_state


### PR DESCRIPTION
## Summary

Replaced the inline re.search in _fetch_items_for_source with the pre-compiled _COMPLEX_QUERY_RE.search.

## Changes

- Use _COMPLEX_QUERY_RE.search(val_str) instead of inline re.compile

## Verification

- Full test suite: 442 passed, 17 skipped
- Statement coverage: 100%
- ruff and mypy pass cleanly

Closes #212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance of query processing through optimization of internal pattern matching logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->