### PR TITLE
chore: module-level constants and __main__ guard (#217)

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,6 +14,14 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Environment-variable overrides for sensitive config keys
+_ENV_OVERRIDES: dict[str, str] = {
+    "api_key": "JELLYFIN_API_KEY",
+    "trakt_client_id": "TRAKT_CLIENT_ID",
+    "tmdb_api_key": "TMDB_API_KEY",
+    "mal_client_id": "MAL_CLIENT_ID",
+}
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -69,13 +77,6 @@ def load_config() -> dict[str, Any]:
     Returns:
         The (possibly migrated) configuration dictionary.
     """
-    _env_overrides = {
-        "api_key": "JELLYFIN_API_KEY",
-        "trakt_client_id": "TRAKT_CLIENT_ID",
-        "tmdb_api_key": "TMDB_API_KEY",
-        "mal_client_id": "MAL_CLIENT_ID",
-    }
-
     cfg: dict[str, Any]
     if not os.path.exists(CONFIG_FILE):
         save_config(DEFAULT_CONFIG.copy())
@@ -112,7 +113,7 @@ def load_config() -> dict[str, Any]:
             cfg = DEFAULT_CONFIG.copy()
 
     # Apply environment-variable overrides (additive, never persisted)
-    for cfg_key, env_var in _env_overrides.items():
+    for cfg_key, env_var in _ENV_OVERRIDES.items():
         env_val = os.environ.get(env_var)
         if env_val:
             cfg[cfg_key] = env_val

--- a/network.py
+++ b/network.py
@@ -18,6 +18,7 @@ import logging
 
 import requests
 from requests.adapters import HTTPAdapter
+from urllib3.exceptions import MaxRetryError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
@@ -58,8 +59,6 @@ _original_delete = requests.delete
 def _reraise_timeout(exc: requests.ConnectionError) -> None:
     """If *exc* wraps a read-timeout from the retry adapter, re-raise as
     :class:`requests.Timeout` so callers see the expected exception type."""
-    from urllib3.exceptions import MaxRetryError, ReadTimeoutError
-
     inner = exc.args[0] if exc.args else None
     if not isinstance(inner, MaxRetryError):
         return

--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -2,18 +2,24 @@ import subprocess
 import os
 import sys
 
-existing = os.environ.get('PYTHONPATH')
-os.environ['PYTHONPATH'] = f"{existing}:." if existing else "."
-with open('test_results.txt', 'w', encoding='utf-8') as f:
-    try:
-        # Running all tests with coverage
-        f.write("Starting test run...\n")
-        f.flush()
-        subprocess.run(
-            [sys.executable, '-m', 'pytest', '--cov=.', 'tests/'],
-            stdout=f,
-            stderr=subprocess.STDOUT,
-            timeout=120
-        )
-    except (subprocess.TimeoutExpired, OSError) as e:
-        f.write(f"\nERROR: {e!s}")
+def main() -> None:
+    existing = os.environ.get('PYTHONPATH')
+    os.environ['PYTHONPATH'] = f"{existing}:." if existing else "."
+    with open('test_results.txt', 'w', encoding='utf-8') as f:
+        try:
+            # Running all tests with coverage
+            f.write("Starting test run...\n")
+            f.flush()
+            subprocess.run(
+                [sys.executable, '-m', 'pytest', '--cov=.', 'tests/'],
+                stdout=f,
+                stderr=subprocess.STDOUT,
+                timeout=120
+            )
+        except (subprocess.TimeoutExpired, OSError) as e:
+            f.write(f"\nERROR: {e!s}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Closes #217

## Changes
- Move urllib3 imports to module level in network.py
- Move `_env_overrides` to module-level constant `_ENV_OVERRIDES` in config.py
- Wrap run_tests_to_file.py in `main()` with `__main__` guard

## Verification
- [x] pytest: 442 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found