### PR TITLE
fix: narrow remaining broad except Exception clauses (#216)

### DIFF
--- a/letterboxd.py
+++ b/letterboxd.py
@@ -162,7 +162,7 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
                     slug = future_map[future]
                     try:
                         slug_results[slug] = future.result()
-                    except Exception:
+                    except (OSError, RuntimeError):
                         logger.debug("Unexpected error for '%s'", slug, exc_info=True)
                         slug_results[slug] = None
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -52,7 +52,7 @@ def update_scheduler_jobs() -> None:
                     args=[excluded_names]
                 )
                 logger.info("Scheduled global sync: %s (excluding: %s)", cron_expr, excluded_names)
-            except Exception:
+            except (ValueError, KeyError, OSError):
                 logger.exception("Failed to schedule global sync")
 
     # 2. Per-group Schedulers
@@ -75,7 +75,7 @@ def update_scheduler_jobs() -> None:
                     args=[group_name]
                 )
                 logger.info("Scheduled sync for group '%s': %s", group_name, cron_expr)
-            except Exception:
+            except (ValueError, KeyError, OSError):
                 logger.exception("Failed to schedule sync for group '%s'", group_name)
 
     # 3. Cleanup Scheduler
@@ -90,7 +90,7 @@ def update_scheduler_jobs() -> None:
                     name="Cleanup Broken Symlinks"
                 )
                 logger.info("Scheduled cleanup job: %s", cleanup_cron)
-            except Exception:
+            except (ValueError, KeyError, OSError):
                 logger.exception("Failed to schedule cleanup job")
 
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -271,7 +271,7 @@ def test_letterboxd_threadpool_exception(mock_get, mock_fetch_slug):
     resp.text = 'data-film-slug="film1"'
     mock_get.return_value = resp
 
-    mock_fetch_slug.side_effect = Exception("Unexpected")
+    mock_fetch_slug.side_effect = RuntimeError("Unexpected")
 
     ids = fetch_letterboxd_list("https://letterboxd.com/user/list/my-list")
     assert ids == []


### PR DESCRIPTION
Closes #216

## Changes
- scheduler.py: narrow three `except Exception` to `(ValueError, KeyError, OSError)`
- letterboxd.py: narrow `except Exception` to `(OSError, RuntimeError)`
- Update `test_letterboxd_threadpool_exception` to raise `RuntimeError`

## Verification
- [x] pytest: 442 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found