### PR TITLE
chore: module-level helpers and constants in jellyfin.py, sync.py, tmdb.py

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -17,6 +17,12 @@ import requests
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_COLLECTION_PAGE_LIMIT = 200
+
+# ---------------------------------------------------------------------------
 # Sort-order mapping
 # ---------------------------------------------------------------------------
 
@@ -32,6 +38,11 @@ SORT_MAP: dict[str, tuple[str, str]] = {
     "DateCreated": ("DateCreated", "Descending"),
     "Random": ("Random", "Ascending"),
 }
+
+
+def _auth_headers(api_key: str) -> dict[str, str]:
+    """Return Jellyfin authentication headers for *api_key*."""
+    return {"X-Emby-Token": api_key}
 
 
 def _format_request_error(exc: requests.exceptions.RequestException, prefix: str) -> str:
@@ -93,7 +104,7 @@ def fetch_jellyfin_items(
         requests.HTTPError: If the server returns a non-2xx status code.
         requests.RequestException: For any other network-level error.
     """
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
     params: dict[str, str] = {}
     if extra_params:
         params.update(extra_params)
@@ -200,7 +211,7 @@ def add_virtual_folder(
     # Strategy: Try to create with all info in query string first (most common for simple cases)
     # If it already exists, we skip creation.
 
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
 
     # Step 1: Create the virtual folder shell
     # We omit 'paths' here to avoid the 400 error.
@@ -272,7 +283,7 @@ def delete_virtual_folder(base_url: str, api_key: str, name: str, timeout: int =
         timeout: HTTP request timeout.
     """
     params = {"name": name}
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
     response = requests.delete(
         f"{base_url}/Library/VirtualFolders",
         params=params,
@@ -399,7 +410,7 @@ def create_collection(
     Raises:
         RuntimeError: If the API call fails.
     """
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
     params: dict[str, str] = {"Name": name, "Ids": ",".join(item_ids)}
 
     try:
@@ -436,8 +447,8 @@ def find_collection_by_name(
     Returns:
         The collection ``Id`` if found, ``None`` otherwise.
     """
-    headers = {"X-Emby-Token": api_key}
-    limit = 200
+    headers = _auth_headers(api_key)
+    limit = _COLLECTION_PAGE_LIMIT
     start_index = 0
 
     while True:
@@ -495,7 +506,7 @@ def add_to_collection(
     if not item_ids:
         return
 
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
     params: dict[str, str] = {"Ids": ",".join(item_ids)}
 
     try:
@@ -532,7 +543,7 @@ def remove_from_collection(
     if not item_ids:
         return
 
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
     params: dict[str, str] = {"Ids": ",".join(item_ids)}
 
     try:
@@ -564,7 +575,7 @@ def delete_collection(
     Raises:
         RuntimeError: If the API call fails.
     """
-    headers = {"X-Emby-Token": api_key}
+    headers = _auth_headers(api_key)
 
     try:
         resp = requests.delete(

--- a/sync.py
+++ b/sync.py
@@ -67,6 +67,23 @@ _LIST_ORDER_VALUES: frozenset[str] = frozenset(
     }
 )
 
+# Jellyfin API page size for full-library fetches
+_FULL_LIBRARY_PAGE_SIZE: int = 500
+
+# Maximum items to include in a dry-run preview
+_MAX_PREVIEW_ITEMS: int = 100
+
+# Minimum width for numbered symlink prefixes
+_MIN_PREFIX_WIDTH: int = 4
+
+# Jellyfin filter-parameter mapping for metadata group lookups
+_METADATA_FILTER_MAP: dict[str, str] = {
+    "genre": "Genres",
+    "actor": "Person",
+    "studio": "Studios",
+    "tag": "Tags",
+    "year": "years",
+}
 
 def _translate_path(
     jellyfin_path: str,
@@ -186,7 +203,7 @@ def _fetch_full_library(
     try:
         all_items: list[dict[str, Any]] = []
         start_index = 0
-        page_size = 500
+        page_size = _FULL_LIBRARY_PAGE_SIZE
 
         while True:
             page = fetch_jellyfin_items(
@@ -813,15 +830,8 @@ def _fetch_items_for_metadata_group(
         "IncludeItemTypes": "Movie,Series",
     }
 
-    filter_map: dict[str, str] = {
-        "genre": "Genres",
-        "actor": "Person",
-        "studio": "Studios",
-        "tag": "Tags",
-        "year": "years",
-    }
-    if source_type in filter_map and source_value:
-        params[filter_map[source_type]] = source_value
+    if source_type in _METADATA_FILTER_MAP and source_value:
+        params[_METADATA_FILTER_MAP[source_type]] = source_value
 
     if watch_state == "unwatched":
         params["Filters"] = "IsUnplayed"
@@ -880,7 +890,7 @@ def parse_complex_query(query: str, default_type: str) -> list[dict[str, Any]]:
     })
 
     for i in range(1, len(parts), 2):
-        op = parts[i].upper().replace('  ', ' ')
+        op = " ".join(parts[i].upper().split())
         ti, vi = _parse_item(parts[i+1])
         rules.append({
             "operator": op,
@@ -941,7 +951,7 @@ def _process_collection_group(
     if dry_run:
         preview_items = [
             {"Name": item.get("Name", "Unknown"), "Year": item.get("ProductionYear", "")}
-            for item in items[:100]
+            for item in items[:_MAX_PREVIEW_ITEMS]
         ]
         return {"group": group_name, "links": len(item_ids), "items": preview_items}
 
@@ -1123,7 +1133,7 @@ def _process_group(
 
     # --- Create symlinks ---
     use_prefix: bool = bool(sort_order)  # numbered prefix ↔ any sort order
-    width: int = max(len(str(len(items))) if items else 4, 4)
+    width: int = max(len(str(len(items))) if items else _MIN_PREFIX_WIDTH, _MIN_PREFIX_WIDTH)
     links_created: int = 0
     preview_items: list[dict[str, Any]] = []
 

--- a/tmdb.py
+++ b/tmdb.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
 logger = logging.getLogger(__name__)
 
 _TMDB_API_BASE: str = "https://api.themoviedb.org/3"
+_DEFAULT_TMDB_LANGUAGE: str = "en-US"
+_MAX_TMDB_PAGES: int = 50
 
 
 def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
@@ -40,7 +43,8 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
 
     # Handle full URL if provided (extracting ID from https://www.themoviedb.org/list/123)
     if "themoviedb.org/list/" in list_id:
-        list_id = list_id.split("/list/")[1].split("?")[0].split("#")[0].strip("/").split("/")[0]
+        parsed = urlparse(list_id)
+        list_id = parsed.path.strip("/").split("/")[-1]
 
     ids: list[str] = []
     page: int = 1
@@ -50,7 +54,7 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
         params = {
             "api_key": api_key,
             "page": str(page),
-            "language": "en-US"
+            "language": _DEFAULT_TMDB_LANGUAGE
         }
 
         try:
@@ -73,7 +77,7 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
                 ids.append(str(tmdb_id))
 
         total_pages: int = data.get("total_pages", 1)
-        if page >= total_pages or page >= 50:  # Safety cap
+        if page >= total_pages or page >= _MAX_TMDB_PAGES:  # Safety cap
             break
         page += 1
 
@@ -102,7 +106,7 @@ def get_tmdb_recommendations(items_with_type: list[tuple[str, str]], api_key: st
         url = f"{_TMDB_API_BASE}/{media_type}/{tmdb_id}/recommendations"
         params = {
             "api_key": api_key,
-            "language": "en-US",
+            "language": _DEFAULT_TMDB_LANGUAGE,
             "page": "1"
         }
         try:


### PR DESCRIPTION
Closes #222
Closes #223
Closes #224

## Changes

### jellyfin.py (#223)
- Extract `_auth_headers(api_key)` helper to replace 13 repeated auth header dicts
- Extract `_COLLECTION_PAGE_LIMIT = 200` constant

### sync.py (#222)
- Move `filter_map` to module-level `_METADATA_FILTER_MAP` constant
- Extract `_FULL_LIBRARY_PAGE_SIZE`, `_MAX_PREVIEW_ITEMS`, `_MIN_PREFIX_WIDTH` constants
- Fix whitespace normalization in complex query parsing (`replace('  ', ' ')` → `" ".join(...split())`)

### tmdb.py (#224)
- Replace brittle manual URL parsing with `urllib.parse.urlparse`
- Extract `_DEFAULT_TMDB_LANGUAGE` and `_MAX_TMDB_PAGES` constants

## Verification
- [x] pytest: 443 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated configuration constants and request helpers across Jellyfin, sync, and TMDb integration modules to improve code maintainability and reduce internal duplication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->