### PR TITLE
chore: extract remaining hardcoded literals to named constants (#230)

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -8,6 +8,9 @@ import requests
 
 ANILIST_API_URL = "https://graphql.anilist.co"
 
+# Request timeout (seconds)
+_REQUEST_TIMEOUT: int = 15
+
 
 def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
     """
@@ -56,7 +59,7 @@ def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
     response = requests.post(
         ANILIST_API_URL,
         json={"query": query, "variables": variables},
-        timeout=15
+        timeout=_REQUEST_TIMEOUT
     )
     response.raise_for_status()
 

--- a/imdb.py
+++ b/imdb.py
@@ -14,6 +14,9 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Request timeout (seconds)
+_REQUEST_TIMEOUT: int = 15
+
 # Maximum number of pages to scrape (safety guard, ~2 000 items at 100/page)
 _MAX_PAGES: int = 20
 
@@ -64,7 +67,7 @@ def fetch_imdb_list(list_id: str) -> list[str]:
             f"?sort=list_order,asc&st_dt=&mode=detail&page={page}"
         )
         try:
-            resp = requests.get(page_url, headers=_REQUEST_HEADERS, timeout=15)
+            resp = requests.get(page_url, headers=_REQUEST_HEADERS, timeout=_REQUEST_TIMEOUT)
             resp.raise_for_status()
         except requests.RequestException as exc:
             logger.error("HTTP error fetching IMDb list page %d: %s", page, exc)

--- a/letterboxd.py
+++ b/letterboxd.py
@@ -16,6 +16,10 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Request timeouts (seconds)
+_FILM_PAGE_TIMEOUT: int = 10
+_LIST_PAGE_TIMEOUT: int = 15
+
 _MAX_PAGES: int = 10
 _MAX_WORKERS: int = 6
 
@@ -70,7 +74,7 @@ def _fetch_id_for_slug(slug: str) -> str | None:
     """
     film_url = f"https://letterboxd.com/film/{slug}/"
     try:
-        resp = requests.get(film_url, headers=_REQUEST_HEADERS, timeout=10)
+        resp = requests.get(film_url, headers=_REQUEST_HEADERS, timeout=_FILM_PAGE_TIMEOUT)
         resp.raise_for_status()
         html = resp.text
 
@@ -121,7 +125,7 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
         current_url = f"{list_url}/page/{page}/" if page > 1 else f"{list_url}/"
 
         try:
-            resp = requests.get(current_url, headers=_REQUEST_HEADERS, timeout=15)
+            resp = requests.get(current_url, headers=_REQUEST_HEADERS, timeout=_LIST_PAGE_TIMEOUT)
             if resp.status_code == 404 and page > 1:
                 break
             resp.raise_for_status()

--- a/mal.py
+++ b/mal.py
@@ -9,6 +9,9 @@ from typing import Any
 
 MAL_API_BASE_URL = "https://api.myanimelist.net/v2"
 
+# Request timeout (seconds)
+_REQUEST_TIMEOUT: int = 15
+
 
 def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> list[int]:
     """
@@ -61,7 +64,7 @@ def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> 
     ids = []
 
     while url:
-        response = requests.get(url, params=params, headers=headers, timeout=15)
+        response = requests.get(url, params=params, headers=headers, timeout=_REQUEST_TIMEOUT)
         response.raise_for_status()
 
         data = response.json()

--- a/routes.py
+++ b/routes.py
@@ -63,6 +63,22 @@ _ALLOWED_PREVIEW_TYPES: frozenset[str] = frozenset(
     {"genre", "studio", "tag", "year", "actor", "general", "complex"}
 )
 
+# Default filesystem search roots for auto-detect
+_DEFAULT_SEARCH_ROOTS: tuple[str, ...] = (
+    os.path.expanduser("~"),
+    "/media",
+    "/mnt",
+)
+
+# Server connection-test timeout (seconds)
+_TEST_SERVER_TIMEOUT: int = 5
+
+# Auto-detect sample fetch limit
+_AUTO_DETECT_SAMPLE_LIMIT: int = 10
+
+# Auto-detect Jellyfin API timeout (seconds)
+_AUTO_DETECT_JELLYFIN_TIMEOUT: int = 10
+
 # ---------------------------------------------------------------------------
 # CSRF protection
 # ---------------------------------------------------------------------------
@@ -94,8 +110,7 @@ def _is_valid_folder_name(name: str) -> bool:
 
 # Roots that the folder browser is allowed to expose.
 _BROWSE_ROOTS: tuple[str, ...] = tuple(
-    os.path.realpath(r)
-    for r in (os.path.expanduser("~"), "/media", "/mnt")
+    os.path.realpath(r) for r in _DEFAULT_SEARCH_ROOTS
 )
 
 
@@ -249,7 +264,7 @@ def test_server() -> ResponseReturnValue:
         response = requests.get(
             f"{url}/System/Info",
             headers={"X-Emby-Token": api_key},
-            timeout=5,
+            timeout=_TEST_SERVER_TIMEOUT,
         )
         if response.status_code == 200:
             return jsonify({"status": "success", "message": "Connected to Jellyfin successfully!"})
@@ -757,10 +772,10 @@ def auto_detect_paths() -> ResponseReturnValue:
             {
                 "Recursive": "true",
                 "IncludeItemTypes": "Movie",
-                "Limit": "10",
+                "Limit": str(_AUTO_DETECT_SAMPLE_LIMIT),
                 "Fields": "Path",
             },
-            timeout=10,
+            timeout=_AUTO_DETECT_JELLYFIN_TIMEOUT,
         )
     except (requests.exceptions.RequestException, RuntimeError) as exc:
         return jsonify({"status": "error", "message": str(exc)}), 400
@@ -784,7 +799,7 @@ def auto_detect_paths() -> ResponseReturnValue:
 
         match_found = _search_local_filesystem(
             os.path.basename(j_path),
-            [home_dir, "/media", "/mnt"],
+            list(_DEFAULT_SEARCH_ROOTS),
         )
         if match_found:
             detected_j_root, detected_h_root = _compute_common_root(j_path, match_found)

--- a/sync.py
+++ b/sync.py
@@ -85,6 +85,14 @@ _METADATA_FILTER_MAP: dict[str, str] = {
     "year": "years",
 }
 
+# Jellyfin Fields parameter for full-library fetches
+_FULL_LIBRARY_FIELDS: str = (
+    "Path,ProviderIds,Genres,Studios,Tags,People,ProductionYear,CommunityRating,UserData"
+)
+
+# Jellyfin API timeout for full-library fetches (seconds)
+_FULL_LIBRARY_TIMEOUT: int = 30
+
 def _translate_path(
     jellyfin_path: str,
     jellyfin_root: str,
@@ -211,12 +219,12 @@ def _fetch_full_library(
                 api_key,
                 {
                     "Recursive": "true",
-                    "Fields": "Path,ProviderIds,Genres,Studios,Tags,People,ProductionYear,CommunityRating,UserData",
+                    "Fields": _FULL_LIBRARY_FIELDS,
                     "IncludeItemTypes": "Movie,Series",
                     "StartIndex": str(start_index),
                     "Limit": str(page_size),
                 },
-                timeout=30,
+                timeout=_FULL_LIBRARY_TIMEOUT,
             )
             all_items.extend(page)
 
@@ -1160,7 +1168,7 @@ def _process_group(
 
         dest_path: str = os.path.join(group_dir, file_name)
         if dry_run:
-            if len(preview_items) < 100:
+            if len(preview_items) < _MAX_PREVIEW_ITEMS:
                 preview_items.append({
                     "Name": item.get("Name", "Unknown"),
                     "Year": item.get("ProductionYear", ""),

--- a/trakt.py
+++ b/trakt.py
@@ -15,6 +15,9 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Request timeout (seconds)
+_REQUEST_TIMEOUT: int = 15
+
 # Maximum pages to fetch (safety guard, 50 000 items at 1 000/page)
 _MAX_PAGES: int = 50
 _PAGE_LIMIT: int = 1_000
@@ -80,7 +83,7 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
             f"?page={page}&limit={_PAGE_LIMIT}"
         )
         try:
-            resp = requests.get(url, headers=headers, timeout=15)
+            resp = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
             resp.raise_for_status()
         except requests.RequestException as exc:
             raise RuntimeError(


### PR DESCRIPTION
Closes #230

## Changes

### sync.py
- Extract `_FULL_LIBRARY_FIELDS` constant for Jellyfin Fields parameter
- Use `_MAX_PREVIEW_ITEMS` constant instead of hardcoded 100
- Extract `_FULL_LIBRARY_TIMEOUT` constant

### routes.py
- Extract `_TEST_SERVER_TIMEOUT`, `_AUTO_DETECT_SAMPLE_LIMIT`, `_AUTO_DETECT_JELLYFIN_TIMEOUT`
- Extract `_DEFAULT_SEARCH_ROOTS` tuple shared with `_BROWSE_ROOTS`

### API modules
- imdb.py: `_REQUEST_TIMEOUT`
- trakt.py: `_REQUEST_TIMEOUT`
- letterboxd.py: `_FILM_PAGE_TIMEOUT`, `_LIST_PAGE_TIMEOUT`
- mal.py: `_REQUEST_TIMEOUT`
- anilist.py: `_REQUEST_TIMEOUT`

## Verification
- [x] pytest: 443 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found