### PR TITLE
fix: narrow 4 remaining broad except Exception clauses in routes.py (#229)

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -218,7 +218,7 @@ def update_config() -> ResponseReturnValue:
     # Update background jobs based on new config
     try:
         update_scheduler_jobs()
-    except Exception as exc:
+    except (ValueError, KeyError, OSError, RuntimeError) as exc:
         logger.exception("Failed to update scheduler jobs")
         return (
             jsonify(
@@ -279,9 +279,6 @@ def test_server() -> ResponseReturnValue:
         )
     except requests.exceptions.RequestException as exc:
         return jsonify({"status": "error", "message": f"Connection error: {exc!s}"}), 400
-    except Exception as exc:
-        logger.exception("Unexpected error during connection test")
-        return jsonify({"status": "error", "message": f"Server error: {exc!s}"}), 500
 
 
 # ---------------------------------------------------------------------------
@@ -392,8 +389,9 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
             return jsonify({"status": "error", "message": "Failed to fetch metadata from Jellyfin"}), 400
 
         return jsonify({"status": "success", "metadata": result})
-    except Exception as exc:
-        return jsonify({"status": "error", "message": str(exc)}), 400
+    except (RuntimeError, OSError) as exc:
+        logger.exception("Unexpected error fetching Jellyfin metadata")
+        return jsonify({"status": "error", "message": str(exc)}), 500
 
 
 # ---------------------------------------------------------------------------
@@ -482,7 +480,7 @@ def upload_cover() -> ResponseReturnValue:
         return jsonify({"status": "success", "message": "Cover saved successfully"})
     except ValueError:
         return jsonify({"status": "error", "message": "Malformed image data"}), 400
-    except Exception as exc:
+    except (OSError, RuntimeError) as exc:
         logger.exception("Failed to save cover image")
         return jsonify({"status": "error", "message": f"Server error: {exc!s}"}), 500
 
@@ -592,9 +590,6 @@ def preview_grouping() -> ResponseReturnValue:
     except (ValueError, RuntimeError, requests.exceptions.RequestException) as exc:
         logger.exception("Failed to generate grouping preview")
         return jsonify({"status": "error", "message": f"Preview failed: {exc!s}"}), 500
-    except Exception as exc:
-        logger.exception("Unexpected error in grouping preview")
-        return jsonify({"status": "error", "message": f"Internal server error: {exc!s}"}), 500
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -184,21 +184,13 @@ def test_update_config_non_dict(client):
 @patch('routes.update_scheduler_jobs')
 @pytest.mark.usefixtures("temp_config")
 def test_update_config_scheduler_fail(mock_sched, client):
-    mock_sched.side_effect = Exception("Fail")
+    mock_sched.side_effect = RuntimeError("Fail")
     response = client.post('/api/config', json={"jellyfin_url": "http://jf"})
     assert response.status_code == 500
     data = response.get_json()
     assert data["status"] == "error"
     assert "scheduler could not be updated" in data["message"]
     assert "config" in data
-
-
-@patch('routes.requests.get')
-def test_test_server_unexpected_error(mock_get, client):
-    mock_get.side_effect = Exception("Big fail")
-    response = client.post('/api/test-server', json={"jellyfin_url": "http://jf", "api_key": "k"})
-    assert response.status_code == 500
-    assert "Server error" in response.get_json()["message"]
 
 
 def test_test_server_invalid_body(client):
@@ -384,7 +376,7 @@ def test_upload_cover_malformed_data_url(client):
 
 @patch('routes.get_cover_path')
 def test_upload_cover_server_error(mock_get_cover, client):
-    mock_get_cover.side_effect = Exception("Disk full")
+    mock_get_cover.side_effect = OSError("Disk full")
     img_data = (
         "data:image/png;base64,"
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
@@ -653,9 +645,9 @@ def test_fetch_jellyfin_endpoint_pagination(mock_get, client):
 @pytest.mark.usefixtures("temp_config")
 def test_get_jellyfin_metadata_exception(mock_pool, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_pool.side_effect = Exception("Pool fail")
+    mock_pool.side_effect = RuntimeError("Pool fail")
     response = client.get('/api/jellyfin/metadata')
-    assert response.status_code == 400
+    assert response.status_code == 500
 
 
 # Sync ValueError (lines 438-439)
@@ -743,15 +735,6 @@ def test_preview_grouping_no_config(client):
 def test_preview_grouping_runtime_error(mock_preview, client):
     save_config({"jellyfin_url": "http://t", "api_key": "k"})
     mock_preview.side_effect = RuntimeError("Preview failed")
-    response = client.post('/api/grouping/preview', json={"type": "genre", "value": "Action"})
-    assert response.status_code == 500
-
-
-@patch('routes.preview_group')
-@pytest.mark.usefixtures("temp_config")
-def test_preview_grouping_unexpected_error(mock_preview, client):
-    save_config({"jellyfin_url": "http://t", "api_key": "k"})
-    mock_preview.side_effect = TypeError("Unexpected")
     response = client.post('/api/grouping/preview', json={"type": "genre", "value": "Action"})
     assert response.status_code == 500
 


### PR DESCRIPTION
Closes #229

## Changes
- `update_config`: narrow to `(ValueError, KeyError, OSError, RuntimeError)`
- `test_server`: remove redundant `except Exception` fallback
- `get_jellyfin_metadata`: remove outer `except Exception`, add narrow `(RuntimeError, OSError)` fallback for ThreadPoolExecutor errors
- `upload_cover`: narrow to `(OSError, RuntimeError)`
- `preview_grouping`: remove redundant second `except Exception`
- Update tests to raise narrowed exception types
- Remove tests for removed fallback branches

## Verification
- [x] pytest: 441 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found