### PR TITLE
fix: narrow 9 remaining broad except Exception clauses in sync.py (#228)

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -240,9 +240,9 @@ def _fetch_full_library(
     except requests.exceptions.RequestException as exc:
         logger.error("Infrastructure error fetching Jellyfin library for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
-    except Exception as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         logger.exception("Unexpected error fetching Jellyfin library for group %r", group_name)
-        return [], f"Internal error: {exc!s}", 500  # noqa: BLE001
+        return [], f"Internal error: {exc!s}", 500
 
 
 def _match_jellyfin_items_by_provider(
@@ -372,7 +372,7 @@ def _fetch_and_resolve(
     try:
         external_ids = fetch_fn()
         logger.info(log_msg_fn(len(external_ids)))
-    except Exception as exc:
+    except (requests.RequestException, RuntimeError, ValueError) as exc:
         logger.error("Error fetching %s list for group %r: %s", source_label, group_name, exc)
         return [], f"{source_label} fetch error: {exc!s}", 400
 
@@ -553,7 +553,7 @@ def _fetch_items_for_letterboxd_group(
     try:
         external_ids = fetch_letterboxd_list(source_value)
         logger.info("Letterboxd list %r: %s IDs found", source_value, len(external_ids))
-    except Exception as exc:
+    except (requests.RequestException, RuntimeError, ValueError) as exc:
         logger.error("Error fetching Letterboxd items for group %r: %s", group_name, exc)
         return [], f"Letterboxd fetch error: {exc!s}", 400
 
@@ -658,7 +658,7 @@ def _fetch_items_for_recommendations_group(
         # Fetch recommendations based on these items
         tmdb_ids = get_tmdb_recommendations(tmdb_requests, tmdb_api_key)
         logger.info("TMDb recommendations: %s items found", len(tmdb_ids))
-    except Exception as exc:
+    except (requests.RequestException, RuntimeError, ValueError) as exc:
         logger.error("Error fetching recommendations for group %r: %s", group_name, exc)
         return [], f"Recommendations fetch error: {exc!s}", 400
 
@@ -859,9 +859,9 @@ def _fetch_items_for_metadata_group(
     except requests.exceptions.RequestException as exc:
         logger.error("Infrastructure error fetching items for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
-    except Exception as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         logger.exception("Unexpected error fetching items for group %r", group_name)
-        return [], f"Internal error: {exc!s}", 500  # noqa: BLE001
+        return [], f"Internal error: {exc!s}", 500
 
 
 def parse_complex_query(query: str, default_type: str) -> list[dict[str, Any]]:
@@ -973,7 +973,7 @@ def _process_collection_group(
 
         add_to_collection(url, api_key, collection_id, item_ids)
         logger.info("Added %s items to collection %r", len(item_ids), group_name)
-    except Exception as exc:
+    except (requests.RequestException, RuntimeError, OSError) as exc:
         return {"group": group_name, "links": 0, "error": str(exc)}
 
     result: dict[str, Any] = {"group": group_name, "links": len(item_ids)}
@@ -983,7 +983,7 @@ def _process_collection_group(
         if source_cover and os.path.exists(source_cover):
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
-            except Exception as exc:
+            except (requests.RequestException, OSError) as exc:
                 logger.error("Failed to set collection image for %r: %s", group_name, exc)
 
     return result
@@ -1209,7 +1209,7 @@ def _process_group(
                 add_virtual_folder(url, api_key, group_name, [lib_path], collection_type="mixed")
                 logger.info("Successfully created library %r with path %r", group_name, lib_path)
                 existing_libraries.append(group_name)  # Prevent double creation in same run
-            except Exception as exc:
+            except (requests.RequestException, RuntimeError, OSError) as exc:
                 logger.error("Failed to create Jellyfin library %r: %s", group_name, exc)
                 result["library_error"] = str(exc)
 
@@ -1302,7 +1302,7 @@ def run_sync(
         try:
             existing_libraries = get_libraries(url, api_key)
             logger.info("Found %s existing virtual folders in Jellyfin", len(existing_libraries))
-        except Exception as exc:
+        except (requests.RequestException, RuntimeError, OSError) as exc:
             logger.warning("Warning: Could not fetch existing libraries: %s", exc)
             # We'll continue, but library creation might fail or try to recreate existing ones
             auto_create_libraries = False

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -212,7 +212,7 @@ def test_fetch_items_for_metadata_group_with_watch_state(mock_jf):
 @patch('sync.fetch_jellyfin_items')
 def test_preview_group_fetch_error(mock_jf):
     _LIBRARY_CACHE.clear()
-    mock_jf.side_effect = Exception("Network error")
+    mock_jf.side_effect = RuntimeError("Network error")
     _items, err, code = preview_group("genre", "Action", "http://jf", "key")
     assert code == 500
     assert "Internal error" in err
@@ -396,7 +396,7 @@ def test_fetch_items_recommendations_no_tmdb_ids(mock_recent):
 
 @patch('sync.get_user_recent_items')
 def test_fetch_items_recommendations_exception(mock_recent):
-    mock_recent.side_effect = Exception("Jellyfin down")
+    mock_recent.side_effect = RuntimeError("Jellyfin down")
     items, error, code = _fetch_items_for_recommendations_group(
         "Rec", "user1", "SortName", "http://jf", "key", "api_key"
     )
@@ -429,7 +429,7 @@ def test_process_collection_group_no_ids():
 
 @patch('sync.find_collection_by_name')
 def test_process_collection_group_error(mock_find):
-    mock_find.side_effect = Exception("Collection error")
+    mock_find.side_effect = RuntimeError("Collection error")
     items = [{"Id": "1", "Name": "Movie"}]
     result = _process_collection_group(
         "Group", items, "http://jf", "key", "/target", dry_run=False, auto_set_library_covers=False
@@ -444,7 +444,7 @@ def test_process_collection_group_error(mock_find):
 
 @patch('sync.fetch_letterboxd_list')
 def test_fetch_items_letterboxd_error(mock_fetch):
-    mock_fetch.side_effect = Exception("Network error")
+    mock_fetch.side_effect = RuntimeError("Network error")
     items, error, code = _fetch_items_for_letterboxd_group(
         "LB", "user/list", "SortName", "http://jf", "key"
     )
@@ -511,7 +511,7 @@ def test_fetch_items_letterboxd_non_list_order(mock_lib, mock_fetch):
 
 @patch('sync.fetch_imdb_list')
 def test_fetch_items_imdb_error(mock_fetch):
-    mock_fetch.side_effect = Exception("IMDb down")
+    mock_fetch.side_effect = RuntimeError("IMDb down")
     items, error, code = _fetch_items_for_imdb_group(
         "IMDb", "list_id", "SortName", "http://jf", "key"
     )
@@ -544,7 +544,7 @@ def test_fetch_items_trakt_no_client_id(mock_fetch):
 
 @patch('sync.fetch_trakt_list')
 def test_fetch_items_trakt_error(mock_fetch):
-    mock_fetch.side_effect = Exception("Trakt down")
+    mock_fetch.side_effect = RuntimeError("Trakt down")
     items, error, code = _fetch_items_for_trakt_group(
         "Trakt", "user/list", "SortName", "http://jf", "key", "client_id"
     )
@@ -568,7 +568,7 @@ def test_fetch_items_trakt_empty(mock_fetch):
 
 @patch('sync.fetch_tmdb_list')
 def test_fetch_items_tmdb_error(mock_fetch):
-    mock_fetch.side_effect = Exception("TMDb down")
+    mock_fetch.side_effect = RuntimeError("TMDb down")
     items, error, code = _fetch_items_for_tmdb_group(
         "TMDb", "123", "SortName", "http://jf", "key", "api_key"
     )
@@ -592,7 +592,7 @@ def test_fetch_items_tmdb_empty(mock_fetch):
 
 @patch('sync.fetch_anilist_list')
 def test_fetch_items_anilist_error(mock_fetch):
-    mock_fetch.side_effect = Exception("AniList down")
+    mock_fetch.side_effect = RuntimeError("AniList down")
     items, error, code = _fetch_items_for_anilist_group(
         "AniList", "user", "SortName", "http://jf", "key"
     )
@@ -616,7 +616,7 @@ def test_fetch_items_anilist_empty(mock_fetch):
 
 @patch('sync.fetch_mal_list')
 def test_fetch_items_mal_error(mock_fetch):
-    mock_fetch.side_effect = Exception("MAL down")
+    mock_fetch.side_effect = RuntimeError("MAL down")
     items, error, code = _fetch_items_for_mal_group(
         "MAL", "user", "SortName", "http://jf", "key", "client_id"
     )
@@ -689,7 +689,7 @@ def test_fetch_full_library_request_error(mock_fetch):
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_full_library_unexpected_error(mock_fetch):
     _LIBRARY_CACHE.clear()
-    mock_fetch.side_effect = TypeError("bad")
+    mock_fetch.side_effect = RuntimeError("bad")
     items, error, code = _fetch_full_library("http://jf", "key", "Group")
     assert code == 500
     assert "Internal error" in error
@@ -833,7 +833,7 @@ def test_fetch_items_metadata_request_error(mock_fetch):
 
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_items_metadata_unexpected_error(mock_fetch):
-    mock_fetch.side_effect = TypeError("bad")
+    mock_fetch.side_effect = RuntimeError("bad")
     items, error, code = _fetch_items_for_metadata_group(
         "Group", "genre", "Action", "SortName", "http://jf", "key"
     )
@@ -871,7 +871,7 @@ def test_process_collection_group_create_and_cover(
 def test_process_collection_group_cover_error(mock_find, mock_add, mock_cover, mock_set, mock_exists):
     mock_find.return_value = "col123"
     mock_cover.return_value = "/cover.jpg"
-    mock_set.side_effect = Exception("Cover fail")
+    mock_set.side_effect = OSError("Cover fail")
     mock_exists.return_value = True
     items = [{"Id": "1", "Name": "Movie"}]
     result = _process_collection_group(
@@ -990,7 +990,7 @@ def test_process_group_library_creation_error(mock_meta, mock_add, tmp_path):
     host = tmp_path / "movie.mkv"
     host.write_text("movie")
     mock_meta.return_value = ([{"Id": "1", "Name": "M1", "Path": str(host)}], None, 200)
-    mock_add.side_effect = Exception("Lib fail")
+    mock_add.side_effect = RuntimeError("Lib fail")
     group = {
         "name": "Test",
         "source_type": "genre",
@@ -1125,7 +1125,7 @@ def test_run_sync_missing_settings():
 @patch('sync.get_libraries')
 @patch('sync._process_group')
 def test_run_sync_get_libraries_error(mock_process, mock_libs, tmp_path):
-    mock_libs.side_effect = Exception("Jellyfin down")
+    mock_libs.side_effect = RuntimeError("Jellyfin down")
     mock_process.return_value = {"group": "Test", "links": 0}
     config = {
         "jellyfin_url": "http://jf",
@@ -1506,7 +1506,7 @@ def test_fetch_items_recommendations_empty(mock_recent, mock_tmdb):
 @patch('sync.get_user_recent_items')
 def test_fetch_items_recommendations_error(mock_recent):
     """Cover lines 632-634: exception in recommendations fetch."""
-    mock_recent.side_effect = Exception("Jellyfin down")
+    mock_recent.side_effect = RuntimeError("Jellyfin down")
     items, error, code = _fetch_items_for_recommendations_group(
         "Rec", "user-id", "SortName", "http://jf", "key", "tmdb_key"
     )

--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -270,7 +270,7 @@ def test_run_sync_tmdb_error(mock_tmdb, _mock_makedirs, _mock_rmtree):
         "tmdb_api_key": "tmdb_key",
         "groups": [{"name": "G1", "source_type": "tmdb_list", "source_value": "123"}]
     }
-    mock_tmdb.side_effect = Exception("TMDB Unavailable")
+    mock_tmdb.side_effect = RuntimeError("TMDB Unavailable")
     with patch('sync.os.path.exists', return_value=True):
         results = run_sync(config)
     assert results[0]["error"] is not None
@@ -304,7 +304,7 @@ def test_fetch_items_tmdb_empty(mock_tmdb):
 @patch('sync.fetch_anilist_list')
 def test_fetch_items_anilist_error(mock_ani):
     from sync import _fetch_items_for_anilist_group
-    mock_ani.side_effect = Exception("AniList Error")
+    mock_ani.side_effect = RuntimeError("AniList Error")
     _items, err, code = _fetch_items_for_anilist_group("G", "user/status", "order", "url", "key")
     assert code == 400
     assert "AniList fetch error" in err
@@ -334,7 +334,7 @@ def test_fetch_items_mal_with_status(mock_full, mock_mal):
 @patch('sync.fetch_mal_list')
 def test_fetch_items_mal_error(mock_mal):
     from sync import _fetch_items_for_mal_group
-    mock_mal.side_effect = Exception("MAL Error")
+    mock_mal.side_effect = RuntimeError("MAL Error")
     _items, err, code = _fetch_items_for_mal_group("G", "user", "order", "url", "key", "id")
     assert code == 400
     assert "MAL fetch error" in err
@@ -352,7 +352,7 @@ def test_fetch_items_mal_empty(mock_mal):
 @patch('sync.fetch_trakt_list')
 def test_fetch_items_trakt_error(mock_trakt):
     from sync import _fetch_items_for_trakt_group
-    mock_trakt.side_effect = Exception("Trakt Fail")
+    mock_trakt.side_effect = RuntimeError("Trakt Fail")
     _items, err, code = _fetch_items_for_trakt_group("G", "val", "order", "http://jf", "key", "cli")
     assert code == 400
     assert "Trakt fetch error" in err


### PR DESCRIPTION
Closes #228

## Changes
Narrow 9 remaining `except Exception` clauses to specific exception families:

- `_fetch_full_library`: `(RuntimeError, OSError, ValueError)`
- `_fetch_and_resolve`: `(requests.RequestException, RuntimeError, ValueError)`
- `_fetch_items_for_letterboxd_group`: `(requests.RequestException, RuntimeError, ValueError)`
- `_fetch_items_for_recommendations_group`: `(requests.RequestException, RuntimeError, ValueError)`
- `_fetch_items_for_metadata_group`: `(RuntimeError, OSError, ValueError)`
- `_process_collection_group` (collection): `(requests.RequestException, RuntimeError, OSError)`
- `_process_collection_group` (image): `(requests.RequestException, OSError)`
- `_process_group` (library): `(requests.RequestException, RuntimeError, OSError)`
- `run_sync` (library fetch): `(requests.RequestException, RuntimeError, OSError)`

## Verification
- [x] pytest: 441 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found