### PR TITLE
chore: standardize remaining inline auth headers in jellyfin.py (#235)

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -127,7 +127,7 @@ def get_libraries(base_url: str, api_key: str, timeout: int = 30) -> list[str]:
     """
     response = requests.get(
         f"{base_url}/Library/VirtualFolders",
-        headers={"X-Emby-Token": api_key},
+        headers=_auth_headers(api_key),
         timeout=timeout,
     )
     response.raise_for_status()
@@ -147,7 +147,7 @@ def get_users(base_url: str, api_key: str, timeout: int = 30) -> list[dict[str, 
     """
     response = requests.get(
         f"{base_url}/Users",
-        headers={"X-Emby-Token": api_key},
+        headers=_auth_headers(api_key),
         timeout=timeout,
     )
     response.raise_for_status()
@@ -180,7 +180,7 @@ def get_user_recent_items(
     }
     response = requests.get(
         f"{base_url}/Users/{user_id}/Items",
-        headers={"X-Emby-Token": api_key},
+        headers=_auth_headers(api_key),
         params=params,
         timeout=timeout,
     )
@@ -309,7 +309,7 @@ def get_library_id(base_url: str, api_key: str, name: str, timeout: int = 30) ->
     """
     response = requests.get(
         f"{base_url}/Library/VirtualFolders",
-        headers={"X-Emby-Token": api_key},
+        headers=_auth_headers(api_key),
         timeout=timeout,
     )
     response.raise_for_status()
@@ -342,10 +342,8 @@ def _upload_image(
     with open(image_path, "rb") as f:
         image_bytes = f.read()
     mime_type, _ = mimetypes.guess_type(image_path)
-    headers = {
-        "X-Emby-Token": api_key,
-        "Content-Type": mime_type or "application/octet-stream",
-    }
+    headers = _auth_headers(api_key)
+    headers["Content-Type"] = mime_type or "application/octet-stream"
     url = f"{base_url}/Items/{item_id}/Images/Primary"
     response = requests.post(url, data=image_bytes, headers=headers, timeout=timeout)
     response.raise_for_status()


### PR DESCRIPTION
Closes #235

## Changes
Replace 5 remaining inline `{"X-Emby-Token": api_key}` dicts with `_auth_headers(api_key)` helper:
- `get_libraries`
- `get_users`
- `get_user_recent_items`
- `get_library_id`
- `_upload_image`

## Verification
- [x] pytest: 441 passed, 100% statement coverage
- [x] ruff: all checks passed
- [x] mypy: no issues found