### PR TITLE
chore: normalize requests exception naming

### DIFF
--- a/imdb.py
+++ b/imdb.py
@@ -69,7 +69,7 @@ def fetch_imdb_list(list_id: str) -> list[str]:
         try:
             resp = requests.get(page_url, headers=_REQUEST_HEADERS, timeout=_REQUEST_TIMEOUT)
             resp.raise_for_status()
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             logger.error("HTTP error fetching IMDb list page %d: %s", page, exc)
             raise RuntimeError(f"Failed to fetch IMDb list page {page}: {exc}") from exc
 

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -102,7 +102,7 @@ def fetch_jellyfin_items(
 
     Raises:
         requests.HTTPError: If the server returns a non-2xx status code.
-        requests.RequestException: For any other network-level error.
+        requests.exceptions.RequestException: For any other network-level error.
     """
     headers = _auth_headers(api_key)
     params: dict[str, str] = {}

--- a/letterboxd.py
+++ b/letterboxd.py
@@ -90,7 +90,7 @@ def _fetch_id_for_slug(slug: str) -> str | None:
         if tmdb_attr:
             return tmdb_attr.group(1)
 
-    except requests.RequestException:
+    except requests.exceptions.RequestException:
         logger.warning("Failed to fetch Letterboxd film page for '%s'", slug, exc_info=True)
         return None
 
@@ -129,7 +129,7 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
             if resp.status_code == 404 and page > 1:
                 break
             resp.raise_for_status()
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             raise RuntimeError(f"Failed to fetch Letterboxd list page {page}: {exc}") from exc
 
         html = resp.text

--- a/routes.py
+++ b/routes.py
@@ -327,7 +327,7 @@ def _fetch_jellyfin_endpoint(
                 timeout=timeout,
             )
             resp.raise_for_status()
-        except requests.RequestException:
+        except requests.exceptions.RequestException:
             if items:
                 break  # partial data is better than nothing
             raise

--- a/sync.py
+++ b/sync.py
@@ -386,7 +386,7 @@ def _fetch_and_resolve(
     try:
         external_ids = fetch_fn()
         logger.info(log_msg_fn(len(external_ids)))
-    except (requests.RequestException, RuntimeError, ValueError) as exc:
+    except (requests.exceptions.RequestException, RuntimeError, ValueError) as exc:
         logger.error("Error fetching %s list for group %r: %s", source_label, group_name, exc)
         return [], f"{source_label} fetch error: {exc!s}", 400
 
@@ -567,7 +567,7 @@ def _fetch_items_for_letterboxd_group(
     try:
         external_ids = fetch_letterboxd_list(source_value)
         logger.info("Letterboxd list %r: %s IDs found", source_value, len(external_ids))
-    except (requests.RequestException, RuntimeError, ValueError) as exc:
+    except (requests.exceptions.RequestException, RuntimeError, ValueError) as exc:
         logger.error("Error fetching Letterboxd items for group %r: %s", group_name, exc)
         return [], f"Letterboxd fetch error: {exc!s}", 400
 
@@ -672,7 +672,7 @@ def _fetch_items_for_recommendations_group(
         # Fetch recommendations based on these items
         tmdb_ids = get_tmdb_recommendations(tmdb_requests, tmdb_api_key)
         logger.info("TMDb recommendations: %s items found", len(tmdb_ids))
-    except (requests.RequestException, RuntimeError, ValueError) as exc:
+    except (requests.exceptions.RequestException, RuntimeError, ValueError) as exc:
         logger.error("Error fetching recommendations for group %r: %s", group_name, exc)
         return [], f"Recommendations fetch error: {exc!s}", 400
 
@@ -987,7 +987,7 @@ def _process_collection_group(
 
         add_to_collection(url, api_key, collection_id, item_ids)
         logger.info("Added %s items to collection %r", len(item_ids), group_name)
-    except (requests.RequestException, RuntimeError, OSError) as exc:
+    except (requests.exceptions.RequestException, RuntimeError, OSError) as exc:
         return {"group": group_name, "links": 0, "error": str(exc)}
 
     result: dict[str, Any] = {"group": group_name, "links": len(item_ids)}
@@ -997,7 +997,7 @@ def _process_collection_group(
         if source_cover and os.path.exists(source_cover):
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
-            except (requests.RequestException, OSError) as exc:
+            except (requests.exceptions.RequestException, OSError) as exc:
                 logger.error("Failed to set collection image for %r: %s", group_name, exc)
 
     return result
@@ -1218,7 +1218,7 @@ def _process_group(
                 add_virtual_folder(url, api_key, group_name, [lib_path], collection_type="mixed")
                 logger.info("Successfully created library %r with path %r", group_name, lib_path)
                 existing_libraries.append(group_name)  # Prevent double creation in same run
-            except (requests.RequestException, RuntimeError, OSError) as exc:
+            except (requests.exceptions.RequestException, RuntimeError, OSError) as exc:
                 logger.error("Failed to create Jellyfin library %r: %s", group_name, exc)
                 result["library_error"] = str(exc)
 
@@ -1311,7 +1311,7 @@ def run_sync(
         try:
             existing_libraries = get_libraries(url, api_key)
             logger.info("Found %s existing virtual folders in Jellyfin", len(existing_libraries))
-        except (requests.RequestException, RuntimeError, OSError) as exc:
+        except (requests.exceptions.RequestException, RuntimeError, OSError) as exc:
             logger.warning("Warning: Could not fetch existing libraries: %s", exc)
             # We'll continue, but library creation might fail or try to recreate existing ones
             auto_create_libraries = False

--- a/tmdb.py
+++ b/tmdb.py
@@ -60,7 +60,7 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
         try:
             resp = requests.get(url, params=params, timeout=15)
             resp.raise_for_status()
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             raise RuntimeError(
                 f"Failed to fetch TMDb list page {page}: {exc}"
             ) from exc

--- a/trakt.py
+++ b/trakt.py
@@ -85,7 +85,7 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
         try:
             resp = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
             resp.raise_for_status()
-        except requests.RequestException as exc:
+        except requests.exceptions.RequestException as exc:
             raise RuntimeError(
                 f"Failed to fetch Trakt list page {page}: {exc}"
             ) from exc


### PR DESCRIPTION
Closes #240

Replace all `requests.RequestException` aliases with the fully-qualified `requests.exceptions.RequestException` for consistency across the codebase.

Files touched: imdb.py, jellyfin.py, letterboxd.py, routes.py, sync.py, tmdb.py, trakt.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal exception handling for consistency across the application. No changes to user-facing functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->