### PR TITLE
refactor: replace runtime assert in routes.py error handler

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -39,7 +39,8 @@ bp = Blueprint("main", __name__)
 def _handle_config_error(exc: Exception) -> ResponseReturnValue:
     """Translate blueprint HTTP exceptions into JSON error responses."""
     if isinstance(exc, HTTPException):
-        assert exc.code is not None
+        if exc.code is None:
+            raise exc
         return jsonify({"status": "error", "message": exc.description}), exc.code
     raise exc
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -4,6 +4,7 @@ import requests
 from unittest.mock import patch, MagicMock
 from config import save_config
 from routes import _compute_common_root, _fetch_jellyfin_endpoint, _handle_config_error, MAX_B64_SIZE
+from werkzeug.exceptions import HTTPException
 
 
 @pytest.mark.usefixtures("temp_config")
@@ -908,6 +909,13 @@ def test_get_test_results_success(mock_open, mock_exists, client):
 def test_handle_config_error_non_http():
     with pytest.raises(Exception, match="not http"):
         _handle_config_error(Exception("not http"))
+
+
+def test_handle_config_error_http_none_code():
+    exc = HTTPException()
+    exc.code = None
+    with pytest.raises(HTTPException):
+        _handle_config_error(exc)
 
 
 # run_tests production mode (line 838-845)


### PR DESCRIPTION
Closes #241

Replace `assert exc.code is not None` with an explicit guard that re-raises
the exception when `code` is None. This makes the code safe under `python -O`
while preserving identical runtime behavior.

Add test coverage for the new `code is None` branch.