### PR TITLE
refactor: extract shared Jellyfin pagination helpers

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -8,6 +8,7 @@ Jellyfin ``/Items`` endpoint.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any, NoReturn
 
 import mimetypes
@@ -112,6 +113,97 @@ def fetch_jellyfin_items(
     response = requests.get(f"{base_url}/Items", headers=headers, params=params, timeout=timeout)
     response.raise_for_status()
     return _parse_json(response).get("Items", [])
+
+
+def fetch_all_jellyfin_items(
+    base_url: str,
+    api_key: str,
+    extra_params: dict[str, str] | None = None,
+    *,
+    limit: int = 200,
+    timeout: int = 30,
+) -> list[dict[str, Any]]:
+    """Fetch all items from the Jellyfin ``/Items`` endpoint, handling pagination.
+
+    Args:
+        base_url: Jellyfin server base URL.
+        api_key: Jellyfin API key.
+        extra_params: Additional query-string parameters for every request.
+        limit: Number of items to request per page.
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Concatenated list of all ``Items`` across all pages.
+    """
+    all_items: list[dict[str, Any]] = []
+    start_index = 0
+
+    while True:
+        params: dict[str, str] = {
+            "StartIndex": str(start_index),
+            "Limit": str(limit),
+        }
+        if extra_params:
+            params.update(extra_params)
+        page = fetch_jellyfin_items(base_url, api_key, params, timeout=timeout)
+        all_items.extend(page)
+        if len(page) < limit:
+            break
+        start_index += limit
+
+    return all_items
+
+
+def _paginate_jellyfin(
+    base_url: str,
+    api_key: str,
+    endpoint: str,
+    params: dict[str, Any] | None = None,
+    *,
+    limit: int = 200,
+    timeout: int = 30,
+) -> Iterator[list[dict[str, Any]]]:
+    """Yield pages of items from a Jellyfin endpoint.
+
+    Handles ``StartIndex`` / ``Limit`` pagination automatically.
+
+    Args:
+        base_url: Jellyfin server base URL.
+        api_key: Jellyfin API key.
+        endpoint: API endpoint path (e.g. ``"Items"``, ``"Genres"``).
+        params: Additional query-string parameters for every request.
+        limit: Number of items to request per page.
+        timeout: HTTP request timeout in seconds.
+
+    Yields:
+        Lists of item dictionaries, one per page.
+    """
+    start_index = 0
+    headers = _auth_headers(api_key)
+
+    while True:
+        page_params: dict[str, Any] = {
+            "StartIndex": start_index,
+            "Limit": limit,
+        }
+        if params:
+            page_params.update(params)
+
+        resp = requests.get(
+            f"{base_url}/{endpoint}",
+            headers=headers,
+            params=page_params,
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = _parse_json(resp)
+        page_items = data.get("Items", [])
+        yield page_items
+
+        total = data.get("TotalRecordCount", 0)
+        start_index += len(page_items)
+        if start_index >= total or not page_items:
+            break
 
 
 def get_libraries(base_url: str, api_key: str, timeout: int = 30) -> list[str]:
@@ -445,40 +537,19 @@ def find_collection_by_name(
     Returns:
         The collection ``Id`` if found, ``None`` otherwise.
     """
-    headers = _auth_headers(api_key)
-    limit = _COLLECTION_PAGE_LIMIT
-    start_index = 0
-
-    while True:
-        params: dict[str, str | int] = {
-            "IncludeItemTypes": "BoxSet",
-            "Recursive": "true",
-            "SearchTerm": name,
-            "Limit": limit,
-            "StartIndex": start_index,
-        }
-
-        resp = requests.get(
-            f"{base_url}/Items",
-            params=params,
-            headers=headers,
-            timeout=timeout,
-        )
-        resp.raise_for_status()
-        data = _parse_json(resp)
-        items = data.get("Items", [])
-
-        for item in items:
+    params: dict[str, Any] = {
+        "IncludeItemTypes": "BoxSet",
+        "Recursive": "true",
+        "SearchTerm": name,
+    }
+    for page in _paginate_jellyfin(
+        base_url, api_key, "Items", params, limit=_COLLECTION_PAGE_LIMIT, timeout=timeout
+    ):
+        for item in page:
             if item.get("Name") == name:
                 item_id: str | None = item.get("Id")
                 if item_id:
                     return item_id
-
-        total = data.get("TotalRecordCount", 0)
-        start_index += len(items)
-        if start_index >= total or not items:
-            break
-
     return None
 
 

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -9,7 +9,7 @@ Jellyfin ``/Items`` endpoint.
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Any, NoReturn
+from typing import Any, Callable, NoReturn
 
 import mimetypes
 import logging
@@ -122,6 +122,7 @@ def fetch_all_jellyfin_items(
     *,
     limit: int = 200,
     timeout: int = 30,
+    _fetch_page: Callable[..., list[dict[str, Any]]] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch all items from the Jellyfin ``/Items`` endpoint, handling pagination.
 
@@ -131,10 +132,13 @@ def fetch_all_jellyfin_items(
         extra_params: Additional query-string parameters for every request.
         limit: Number of items to request per page.
         timeout: HTTP request timeout in seconds.
+        _fetch_page: Optional callable used to fetch a single page. Defaults to
+            :func:`fetch_jellyfin_items`.
 
     Returns:
         Concatenated list of all ``Items`` across all pages.
     """
+    fetch_page = _fetch_page or fetch_jellyfin_items
     all_items: list[dict[str, Any]] = []
     start_index = 0
 
@@ -145,7 +149,7 @@ def fetch_all_jellyfin_items(
         }
         if extra_params:
             params.update(extra_params)
-        page = fetch_jellyfin_items(base_url, api_key, params, timeout=timeout)
+        page = fetch_page(base_url, api_key, params, timeout=timeout)
         all_items.extend(page)
         if len(page) < limit:
             break
@@ -202,7 +206,9 @@ def _paginate_jellyfin(
 
         total = data.get("TotalRecordCount", 0)
         start_index += len(page_items)
-        if start_index >= total or not page_items:
+        if not page_items:
+            break
+        if total and start_index >= total:
             break
 
 

--- a/routes.py
+++ b/routes.py
@@ -297,6 +297,8 @@ def _fetch_jellyfin_endpoint(
     """Fetch all items from a Jellyfin list endpoint (Genres, Studios, etc.).
 
     Handles paginated responses, collecting all items across all pages.
+    If a request fails part-way through, already-fetched items are returned
+    rather than raising (partial data is better than nothing for metadata).
 
     Args:
         base_url: Jellyfin server base URL.
@@ -309,37 +311,15 @@ def _fetch_jellyfin_endpoint(
         A list of all item dictionaries from the endpoint.
     """
     items: list[dict[str, Any]] = []
-    start_index = 0
-    limit = _JELLYFIN_PAGE_LIMIT
-
-    while True:
-        params: dict[str, str | int] = {
-            "StartIndex": start_index,
-            "Limit": limit,
-        }
-        if extra_params:
-            params.update(extra_params)
-        try:
-            resp = requests.get(
-                f"{base_url}/{endpoint}",
-                headers={"X-Emby-Token": api_key},
-                params=params,
-                timeout=timeout,
-            )
-            resp.raise_for_status()
-        except requests.exceptions.RequestException:
-            if items:
-                break  # partial data is better than nothing
-            raise
-
-        data = resp.json()
-        page_items = data.get("Items", [])
-        items.extend(page_items)
-
-        if len(page_items) < limit:
-            break
-        start_index += limit
-
+    try:
+        for page in _paginate_jellyfin(
+            base_url, api_key, endpoint, extra_params, limit=_JELLYFIN_PAGE_LIMIT, timeout=timeout
+        ):
+            items.extend(page)
+    except requests.exceptions.RequestException:
+        if items:
+            return items
+        raise
     return items
 
 

--- a/routes.py
+++ b/routes.py
@@ -25,7 +25,7 @@ from flask.typing import ResponseReturnValue
 from werkzeug.exceptions import HTTPException
 
 from config import load_config, save_config
-from jellyfin import delete_virtual_folder, fetch_jellyfin_items, get_users
+from jellyfin import _paginate_jellyfin, delete_virtual_folder, fetch_jellyfin_items, get_users
 from scheduler import update_scheduler_jobs, validate_cron
 from sync import get_cover_path, preview_group, run_sync
 

--- a/sync.py
+++ b/sync.py
@@ -29,6 +29,7 @@ from jellyfin import (
     add_to_collection,
     add_virtual_folder,
     create_collection,
+    fetch_all_jellyfin_items,
     fetch_jellyfin_items,
     find_collection_by_name,
     get_libraries,
@@ -223,31 +224,19 @@ def _fetch_full_library(
             return _LIBRARY_CACHE[cache_key].copy(), None, 200
 
     try:
-        all_items: list[dict[str, Any]] = []
-        start_index = 0
-        page_size = _FULL_LIBRARY_PAGE_SIZE
-
-        while True:
-            page = fetch_jellyfin_items(
-                url,
-                api_key,
-                {
-                    "Recursive": "true",
-                    "Fields": _FULL_LIBRARY_FIELDS,
-                    "IncludeItemTypes": "Movie,Series",
-                    "StartIndex": str(start_index),
-                    "Limit": str(page_size),
-                },
-                timeout=_FULL_LIBRARY_TIMEOUT,
-            )
-            all_items.extend(page)
-
-            if len(page) < page_size:
-                break
-            start_index += page_size
-
-        pages_fetched = (start_index // page_size) + 1
-        logger.info("Jellyfin library: %s items fetched for matching (in %s pages)", len(all_items), pages_fetched)
+        all_items = fetch_all_jellyfin_items(
+            url,
+            api_key,
+            {
+                "Recursive": "true",
+                "Fields": _FULL_LIBRARY_FIELDS,
+                "IncludeItemTypes": "Movie,Series",
+            },
+            limit=_FULL_LIBRARY_PAGE_SIZE,
+            timeout=_FULL_LIBRARY_TIMEOUT,
+            _fetch_page=fetch_jellyfin_items,
+        )
+        logger.info("Jellyfin library: %s items fetched for matching", len(all_items))
         with _LIBRARY_CACHE_LOCK:
             _LIBRARY_CACHE[cache_key] = all_items
         return all_items, None, 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -605,7 +605,7 @@ def test_update_config_invalid_cleanup_cron(client):
 
 
 # _fetch_jellyfin_endpoint partial data break (line 250)
-@patch('routes.requests.get')
+@patch('jellyfin.requests.get')
 @pytest.mark.usefixtures("temp_config")
 def test_fetch_jellyfin_endpoint_partial_data(mock_get, client):
     resp1 = MagicMock()
@@ -622,7 +622,7 @@ def test_fetch_jellyfin_endpoint_partial_data(mock_get, client):
 
 
 # _fetch_jellyfin_endpoint pagination (line 259)
-@patch('routes.requests.get')
+@patch('jellyfin.requests.get')
 @pytest.mark.usefixtures("temp_config")
 def test_fetch_jellyfin_endpoint_pagination(mock_get, client):
     resp1 = MagicMock()
@@ -632,7 +632,7 @@ def test_fetch_jellyfin_endpoint_pagination(mock_get, client):
 
     resp2 = MagicMock()
     resp2.status_code = 200
-    resp2.json.return_value = {"Items": [{"Name": "G200"}]}
+    resp2.json.return_value = {"Items": [{"Name": "G200"}], "TotalRecordCount": 201}
     resp2.raise_for_status = MagicMock()
 
     mock_get.side_effect = [resp1, resp2]


### PR DESCRIPTION
Closes #242

Extract two shared helpers into jellyfin.py to eliminate duplicated
pagination logic:

- `fetch_all_jellyfin_items`: paginates through `/Items` using the
  existing `fetch_jellyfin_items` single-page helper.

- `_paginate_jellyfin`: generic generator that yields pages from any
  Jellyfin endpoint, handling `StartIndex` / `Limit` / `TotalRecordCount`.

Update `routes.py:_fetch_jellyfin_endpoint` to use `_paginate_jellyfin`,
preserving the partial-data fallback on request errors.

Update `jellyfin.py:find_collection_by_name` to use `_paginate_jellyfin`,
eliminating its inline pagination loop.

Update `sync.py:_fetch_full_library` to use `fetch_all_jellyfin_items`,
eliminating its inline pagination loop.