### PR TITLE
fix: catch binascii.Error and filter empty library names

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -229,7 +229,7 @@ def get_libraries(base_url: str, api_key: str, timeout: int = 30) -> list[str]:
         timeout=timeout,
     )
     response.raise_for_status()
-    return [folder.get("Name", "") for folder in _parse_json(response)]
+    return [name for folder in _parse_json(response) if (name := folder.get("Name"))]
 
 
 def get_users(base_url: str, api_key: str, timeout: int = 30) -> list[dict[str, Any]]:

--- a/routes.py
+++ b/routes.py
@@ -10,6 +10,7 @@ other modules, and serialise results back to JSON.
 from __future__ import annotations
 
 import base64
+import binascii
 import logging
 import os
 import shutil
@@ -443,7 +444,7 @@ def upload_cover() -> ResponseReturnValue:
             f.write(decoded)
 
         return _success("Cover saved successfully")
-    except ValueError:
+    except (ValueError, binascii.Error):
         return _error("Malformed image data", 400)
     except (OSError, RuntimeError) as exc:
         logger.exception("Failed to save cover image")

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -26,6 +26,17 @@ def test_get_libraries(mock_get):
     )
 
 
+@patch('requests.get')
+def test_get_libraries_filters_empty_names(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = [{"Name": "Movies"}, {"Name": None}, {"Name": ""}, {"Name": "TV Shows"}]
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    libs = get_libraries("http://localhost:8096", "test_key")
+    assert libs == ["Movies", "TV Shows"]
+
+
 @patch('requests.post')
 def test_add_virtual_folder_success(mock_post):
     mock_response = MagicMock()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -375,6 +375,13 @@ def test_upload_cover_malformed_data_url(client):
     assert "Malformed image data" in response.get_json()["message"]
 
 
+def test_upload_cover_invalid_base64(client):
+    # Invalid base64 characters trigger binascii.Error
+    response = client.post('/api/upload_cover', json={"group_name": "G", "image": "data:image/png;base64,!!!invalid!!!"})
+    assert response.status_code == 400
+    assert "Malformed image data" in response.get_json()["message"]
+
+
 @patch('routes.get_cover_path')
 def test_upload_cover_server_error(mock_get_cover, client):
     mock_get_cover.side_effect = OSError("Disk full")


### PR DESCRIPTION
Closes #248
Closes #252

- routes.py: add `binascii.Error` to the upload_cover except clause so
  malformed base64 data returns 400 instead of leaking as an unhandled 500.
  Add test coverage for invalid base64 characters.

- jellyfin.py: filter out empty/None library names in `get_libraries`
  instead of returning phantom empty strings.
  Add test coverage for empty name filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed library listings to exclude entries with missing or empty names, ensuring only valid libraries appear in the list
  * Improved error handling for image uploads to properly detect and report malformed image data formats with clearer user feedback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->