### PR TITLE
refactor: rename get_cover_path to _get_cover_path

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -28,7 +28,7 @@ from werkzeug.exceptions import HTTPException
 from config import load_config, save_config
 from jellyfin import _paginate_jellyfin, delete_virtual_folder, fetch_jellyfin_items, get_users
 from scheduler import update_scheduler_jobs, validate_cron
-from sync import get_cover_path, preview_group, run_sync
+from sync import _get_cover_path, preview_group, run_sync
 
 logger = logging.getLogger(__name__)
 
@@ -402,11 +402,11 @@ def upload_cover() -> ResponseReturnValue:
 
     Expects a JSON body with ``group_name`` and ``image`` (data URL).
     Decodes and saves the image to a location determined by
-    :func:`sync.get_cover_path`: it saves to
+    :func:`sync._get_cover_path`: it saves to
     ``target_base/.covers/[md5(group_name)].jpg`` when the target directory
     exists, otherwise it falls back to ``config/covers/[md5(group_name)].jpg``.
     The file name used is md5(group_name) + .jpg. Reference
-    :func:`sync.get_cover_path` for the detailed storage precedence.
+    :func:`sync._get_cover_path` for the detailed storage precedence.
 
     Returns:
         JSON with ``status`` and ``message``.
@@ -435,7 +435,7 @@ def upload_cover() -> ResponseReturnValue:
         cfg = load_config()
         target_path = str(cfg.get("target_path", ""))
 
-        cover_path = get_cover_path(group_name, target_path, check_exists=False)
+        cover_path = _get_cover_path(group_name, target_path, check_exists=False)
         if cover_path is None:
             return _error("Could not resolve cover storage path", 500)
 

--- a/sync.py
+++ b/sync.py
@@ -139,7 +139,7 @@ def _translate_path(
     return jellyfin_path
 
 
-def get_cover_path(group_name: str, target_base: str, check_exists: bool = True) -> str | None:
+def _get_cover_path(group_name: str, target_base: str, check_exists: bool = True) -> str | None:
     """Compute the expected cover image path for a group, resolving storage priority.
 
     Priority:
@@ -982,7 +982,7 @@ def _process_collection_group(
     result: dict[str, Any] = {"group": group_name, "links": len(item_ids)}
 
     if auto_set_library_covers:
-        source_cover = get_cover_path(group_name, target_base)
+        source_cover = _get_cover_path(group_name, target_base)
         if source_cover and os.path.exists(source_cover):
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
@@ -1052,7 +1052,7 @@ def _process_group(
             return {"group": group_name, "links": 0, "error": f"Directory error: {exc!s}"}
 
         # Check if there is an auto-generated cover to copy
-        source_cover = get_cover_path(group_name, target_base)
+        source_cover = _get_cover_path(group_name, target_base)
 
         if source_cover:
             poster_dest = os.path.join(group_dir, "poster.jpg")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -108,7 +108,7 @@ def test_upload_cover_security_check(client):
     assert response.status_code == 413
 
 
-@patch('routes.get_cover_path')
+@patch('routes._get_cover_path')
 def test_upload_cover_success(mock_get_path, client, tmp_path):
     mock_get_path.return_value = str(tmp_path / "test.jpg")
     # Base64 for a tiny transparent pixel
@@ -382,7 +382,7 @@ def test_upload_cover_invalid_base64(client):
     assert "Malformed image data" in response.get_json()["message"]
 
 
-@patch('routes.get_cover_path')
+@patch('routes._get_cover_path')
 def test_upload_cover_server_error(mock_get_cover, client):
     mock_get_cover.side_effect = OSError("Disk full")
     img_data = (
@@ -394,7 +394,7 @@ def test_upload_cover_server_error(mock_get_cover, client):
     assert response.get_json()["status"] == "error"
 
 
-@patch('routes.get_cover_path')
+@patch('routes._get_cover_path')
 def test_upload_cover_unresolvable_path(mock_get_cover, client):
     mock_get_cover.return_value = None
     img_data = (

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import patch
 from sync import (
     _translate_path,
-    get_cover_path,
+    _get_cover_path,
     parse_complex_query,
     _match_condition,
     _eval_item,
@@ -124,17 +124,17 @@ def test_get_cover_path(tmp_path):
     os.makedirs(os.path.join(target_base, ".covers"), exist_ok=True)
     # Mock __file__ to control legacy path? A bit hard.
     # Let's just test the logic for check_exists=False
-    path = get_cover_path("My Group", target_base, check_exists=False)
+    path = _get_cover_path("My Group", target_base, check_exists=False)
     assert ".covers" in path
     assert path.endswith(".jpg")
     # Test non-existent with check_exists=True
-    assert get_cover_path("Missing Group", target_base, check_exists=True) is None
+    assert _get_cover_path("Missing Group", target_base, check_exists=True) is None
     # Test existent in lib
     lib_path = os.path.join(target_base, ".covers", hashlib.md5(
         b"Existent", usedforsecurity=False).hexdigest() + ".jpg")
     with open(lib_path, "w") as f:
         f.write("test")
-    assert get_cover_path("Existent", target_base, check_exists=True) == lib_path
+    assert _get_cover_path("Existent", target_base, check_exists=True) == lib_path
 
 
 @patch('sync.fetch_jellyfin_items')
@@ -655,14 +655,14 @@ def test_filter_by_watch_state():
 
 
 def test_get_cover_path_no_target_base():
-    path = get_cover_path("Group", "", check_exists=False)
+    path = _get_cover_path("Group", "", check_exists=False)
     assert "config/covers" in path
 
 
 @patch('sync.os.path.exists')
 def test_get_cover_path_legacy_exists(mock_exists):
     mock_exists.side_effect = lambda p: "config/covers" in p
-    path = get_cover_path("LegacyGroup", "/some/target", check_exists=True)
+    path = _get_cover_path("LegacyGroup", "/some/target", check_exists=True)
     assert "config/covers" in path
 
 
@@ -843,7 +843,7 @@ def test_fetch_items_metadata_unexpected_error(mock_fetch):
 
 @patch('sync.os.path.exists')
 @patch('sync.set_collection_image')
-@patch('sync.get_cover_path')
+@patch('sync._get_cover_path')
 @patch('sync.add_to_collection')
 @patch('sync.create_collection')
 @patch('sync.find_collection_by_name')
@@ -865,7 +865,7 @@ def test_process_collection_group_create_and_cover(
 
 @patch('sync.os.path.exists')
 @patch('sync.set_collection_image')
-@patch('sync.get_cover_path')
+@patch('sync._get_cover_path')
 @patch('sync.add_to_collection')
 @patch('sync.find_collection_by_name')
 def test_process_collection_group_cover_error(mock_find, mock_add, mock_cover, mock_set, mock_exists):
@@ -1079,7 +1079,7 @@ def test_process_group_library_already_exists(mock_meta, mock_add, tmp_path):
 
 
 @patch('sync.set_virtual_folder_image')
-@patch('sync.get_cover_path')
+@patch('sync._get_cover_path')
 @patch('sync._fetch_items_for_metadata_group')
 def test_process_group_auto_set_library_covers(mock_meta, mock_cover, mock_set, tmp_path):
     host = tmp_path / "movie.mkv"
@@ -1379,7 +1379,7 @@ def test_process_group_missing_host_path(mock_meta, tmp_path):
     assert result["links"] == 0
 
 
-@patch('sync.get_cover_path')
+@patch('sync._get_cover_path')
 @patch('sync._fetch_items_for_metadata_group')
 def test_process_group_auto_cover_missing(mock_meta, mock_cover, tmp_path):
     host = tmp_path / "movie.mkv"

--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -415,7 +415,7 @@ def test_run_sync_with_library_creation(
 
 @patch('sync.shutil.copy2')
 @patch('sync.set_virtual_folder_image')
-@patch('sync.get_cover_path')
+@patch('sync._get_cover_path')
 @patch('sync.shutil.rmtree')
 @patch('sync.os.makedirs')
 @patch('sync.os.path.exists')


### PR DESCRIPTION
## Summary
- Renames `get_cover_path` to `_get_cover_path` in `sync.py` to indicate it is an internal helper.
- Updates all imports in `routes.py` and all patches/usages in tests.

## Test plan
- [x] All sync tests pass
- [x] All cover-related routes tests pass

Closes #253