### PR TITLE
chore: normalize requests exception naming across codebase

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -82,7 +82,7 @@ def _get_json(
     """GET *url* and return the parsed JSON response.
 
     Raises:
-        requests.HTTPError: If the server returns a non-2xx status code.
+        requests.exceptions.HTTPError: If the server returns a non-2xx status code.
         RuntimeError: If the response body is not valid JSON.
     """
     kwargs: dict[str, Any] = {"timeout": timeout}
@@ -125,7 +125,7 @@ def fetch_jellyfin_items(
         the response contained no ``Items`` key.
 
     Raises:
-        requests.HTTPError: If the server returns a non-2xx status code.
+        requests.exceptions.HTTPError: If the server returns a non-2xx status code.
         requests.exceptions.RequestException: For any other network-level error.
     """
     headers = _auth_headers(api_key)


### PR DESCRIPTION
## Summary
- Updates remaining docstrings in `jellyfin.py` to use the fully-qualified `requests.exceptions.HTTPError` form.
- All other occurrences were already standardized in previous PRs.

## Test plan
- [x] No behavioral change
- [x] grep confirms no unqualified `requests.HTTPError` / `requests.Timeout` / `requests.ConnectionError` remain in main modules

Closes #240