### PR TITLE
chore: narrow exception handlers for jellyfin helpers

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -82,16 +82,18 @@ def _get_json(
     """GET *url* and return the parsed JSON response.
 
     Raises:
-        requests.exceptions.HTTPError: If the server returns a non-2xx status code.
-        RuntimeError: If the response body is not valid JSON.
+        RuntimeError: If the request fails or the response body is not valid JSON.
     """
     kwargs: dict[str, Any] = {"timeout": timeout}
     if headers is not None:
         kwargs["headers"] = headers
     if params is not None:
         kwargs["params"] = params
-    response = requests.get(url, **kwargs)
-    response.raise_for_status()
+    try:
+        response = requests.get(url, **kwargs)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        _raise_request_error(exc, f"Failed to GET {url}")
     return _parse_json(response)
 
 
@@ -211,8 +213,7 @@ def fetch_jellyfin_items(
         the response contained no ``Items`` key.
 
     Raises:
-        requests.exceptions.HTTPError: If the server returns a non-2xx status code.
-        requests.exceptions.RequestException: For any other network-level error.
+        RuntimeError: If the request fails or the response is not valid JSON.
     """
     headers = _auth_headers(api_key)
     params: dict[str, str] = {}
@@ -531,8 +532,11 @@ def _upload_image(
     headers = _auth_headers(api_key)
     headers["Content-Type"] = mime_type or "application/octet-stream"
     url = f"{base_url}/Items/{item_id}/Images/Primary"
-    response = requests.post(url, data=image_bytes, headers=headers, timeout=timeout)
-    response.raise_for_status()
+    try:
+        response = requests.post(url, data=image_bytes, headers=headers, timeout=timeout)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        _raise_request_error(exc, f"Failed to upload image for item {item_id!r}")
 
 
 def set_virtual_folder_image(
@@ -557,10 +561,8 @@ def set_virtual_folder_image(
             logger.info("Cannot set image: Library %r not found or ID unknown.", name)
             return
         _upload_image(base_url, api_key, library_id, image_path, timeout=timeout)
-    except requests.exceptions.RequestException as exc:
-        logger.info(
-            _format_request_error(exc, f"Failed to set image for library {name!r}")
-        )
+    except RuntimeError as exc:
+        logger.info(str(exc))
     except OSError as exc:
         logger.error("Cannot set image: Failed to read image file %r: %s", image_path, exc)
     else:
@@ -748,12 +750,8 @@ def set_collection_image(
     """
     try:
         _upload_image(base_url, api_key, collection_id, image_path, timeout=timeout)
-    except requests.exceptions.RequestException as exc:
-        logger.info(
-            _format_request_error(
-                exc, f"Failed to set image for collection {collection_id!r}"
-            )
-        )
+    except RuntimeError as exc:
+        logger.info(str(exc))
     except OSError as exc:
         logger.error("Cannot set collection image: Failed to read %r: %s", image_path, exc)
     else:

--- a/routes.py
+++ b/routes.py
@@ -309,7 +309,7 @@ def _fetch_jellyfin_endpoint(
             base_url, api_key, endpoint, extra_params, limit=_JELLYFIN_PAGE_LIMIT, timeout=timeout
         ):
             items.extend(page)
-    except requests.exceptions.RequestException:
+    except RuntimeError:
         if items:
             return items
         raise
@@ -353,7 +353,7 @@ def get_jellyfin_metadata() -> ResponseReturnValue:
                     result[key] = [
                         item.get("Name", "") for item in items if item.get("Name")
                     ]
-                except (requests.exceptions.RequestException, ValueError):
+                except (RuntimeError, ValueError):
                     logger.warning("Failed to process metadata key %r", key, exc_info=True)
                     result[key] = []
                     failed += 1
@@ -387,7 +387,7 @@ def get_jellyfin_users() -> ResponseReturnValue:
             "",
             users=[{"id": u.get("Id"), "name": u.get("Name")} for u in users_list],
         )
-    except (requests.exceptions.RequestException, RuntimeError) as exc:
+    except RuntimeError as exc:
         return _error(str(exc), 400)
 
 
@@ -544,7 +544,7 @@ def preview_grouping() -> ResponseReturnValue:
         ]
 
         return _success("", count=len(items), preview_items=results)
-    except (ValueError, RuntimeError, requests.exceptions.RequestException) as exc:
+    except (ValueError, RuntimeError) as exc:
         logger.exception("Failed to generate grouping preview")
         return _error(f"Preview failed: {exc!s}", 500)
 
@@ -729,7 +729,7 @@ def auto_detect_paths() -> ResponseReturnValue:
             },
             timeout=_AUTO_DETECT_JELLYFIN_TIMEOUT,
         )
-    except (requests.exceptions.RequestException, RuntimeError) as exc:
+    except RuntimeError as exc:
         return _error(str(exc), 400)
 
     if not items:

--- a/sync.py
+++ b/sync.py
@@ -240,12 +240,9 @@ def _fetch_full_library(
         with _LIBRARY_CACHE_LOCK:
             _LIBRARY_CACHE[cache_key] = all_items
         return all_items, None, 200
-    except requests.exceptions.RequestException as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         logger.error("Infrastructure error fetching Jellyfin library for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
-    except (RuntimeError, OSError, ValueError) as exc:
-        logger.exception("Unexpected error fetching Jellyfin library for group %r", group_name)
-        return [], f"Internal error: {exc!s}", 500
 
 
 def _match_jellyfin_items_by_provider(
@@ -859,12 +856,9 @@ def _fetch_items_for_metadata_group(
         items = fetch_jellyfin_items(url, api_key, params, timeout=_METADATA_FETCH_TIMEOUT)
         logger.info("Found %s potential items for group %r", len(items), group_name)
         return items, None, 200
-    except requests.exceptions.RequestException as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         logger.error("Infrastructure error fetching items for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
-    except (RuntimeError, OSError, ValueError) as exc:
-        logger.exception("Unexpected error fetching items for group %r", group_name)
-        return [], f"Internal error: {exc!s}", 500
 
 
 def parse_complex_query(query: str, default_type: str) -> list[dict[str, Any]]:
@@ -976,7 +970,7 @@ def _process_collection_group(
 
         add_to_collection(url, api_key, collection_id, item_ids)
         logger.info("Added %s items to collection %r", len(item_ids), group_name)
-    except (requests.exceptions.RequestException, RuntimeError, OSError) as exc:
+    except (RuntimeError, OSError) as exc:
         return {"group": group_name, "links": 0, "error": str(exc)}
 
     result: dict[str, Any] = {"group": group_name, "links": len(item_ids)}
@@ -986,7 +980,7 @@ def _process_collection_group(
         if source_cover and os.path.exists(source_cover):
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
-            except (requests.exceptions.RequestException, OSError) as exc:
+            except OSError as exc:
                 logger.error("Failed to set collection image for %r: %s", group_name, exc)
 
     return result
@@ -1017,7 +1011,7 @@ def _auto_create_library(
                 add_virtual_folder(url, api_key, group_name, [lib_path], collection_type="mixed")
                 logger.info("Successfully created library %r with path %r", group_name, lib_path)
                 existing_libraries.append(group_name)
-            except (requests.exceptions.RequestException, RuntimeError, OSError) as exc:
+            except (RuntimeError, OSError) as exc:
                 logger.error("Failed to create Jellyfin library %r: %s", group_name, exc)
                 result["library_error"] = str(exc)
     return result
@@ -1362,7 +1356,7 @@ def run_sync(
         try:
             existing_libraries = get_libraries(url, api_key)
             logger.info("Found %s existing virtual folders in Jellyfin", len(existing_libraries))
-        except (requests.exceptions.RequestException, RuntimeError, OSError) as exc:
+        except (RuntimeError, OSError) as exc:
             logger.warning("Warning: Could not fetch existing libraries: %s", exc)
             # We'll continue, but library creation might fail or try to recreate existing ones
             auto_create_libraries = False

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -73,15 +73,15 @@ class TestMetadataEndpoints:
             def mock_jellyfin(url, **kwargs):
                 m = MagicMock()
                 if "Genres" in url:
-                    m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Thriller"}]}
+                    m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Thriller"}], "TotalRecordCount": 2}
                 elif "Studios" in url:
-                    m.json.return_value = {"Items": [{"Name": "Studio A"}]}
+                    m.json.return_value = {"Items": [{"Name": "Studio A"}], "TotalRecordCount": 1}
                 elif "Persons" in url:
-                    m.json.return_value = {"Items": [{"Name": "Actor One"}]}
+                    m.json.return_value = {"Items": [{"Name": "Actor One"}], "TotalRecordCount": 1}
                 elif "Tags" in url:
-                    m.json.return_value = {"Items": [{"Name": "4K"}]}
+                    m.json.return_value = {"Items": [{"Name": "4K"}], "TotalRecordCount": 1}
                 else:
-                    m.json.return_value = {"Items": []}
+                    m.json.return_value = {"Items": [], "TotalRecordCount": 0}
                 m.raise_for_status = MagicMock()
                 return m
 

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -316,8 +316,9 @@ def test_delete_virtual_folder_not_ok(mock_delete, caplog):
 def test_get_library_id_request_exception(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Fetch Error")
 
-    with pytest.raises(requests.exceptions.RequestException):
+    with pytest.raises(RuntimeError) as excinfo:
         get_library_id("http://localhost:8096", "test_key", "MyLib")
+    assert "Failed to GET" in str(excinfo.value)
 
 
 @patch('jellyfin.get_library_id')
@@ -361,7 +362,7 @@ def test_set_virtual_folder_image_request_exception(mock_get_library_id, mock_po
 
     set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
 
-    assert "Failed to set image for library 'MyLib' (Status 400): Bad Request" in caplog.text
+    assert "Failed to upload image for item '123' (Status 400): Bad Request" in caplog.text
 
 
 @patch('mimetypes.guess_type')
@@ -379,7 +380,7 @@ def test_set_virtual_folder_image_request_exception_no_response(
 
     set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
 
-    assert "Failed to set image for library 'MyLib': Upload Error" in caplog.text
+    assert "Failed to upload image for item '123': Upload Error" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -443,7 +444,8 @@ def test_find_collection_by_name_found(mock_get):
         "Items": [
             {"Name": "Other", "Id": "other_id"},
             {"Name": "My Boxset", "Id": "boxset_42"},
-        ]
+        ],
+        "TotalRecordCount": 2,
     }
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
@@ -455,7 +457,7 @@ def test_find_collection_by_name_found(mock_get):
 @patch('requests.get')
 def test_find_collection_by_name_not_found(mock_get):
     mock_response = MagicMock()
-    mock_response.json.return_value = {"Items": [{"Name": "Other", "Id": "x"}]}
+    mock_response.json.return_value = {"Items": [{"Name": "Other", "Id": "x"}], "TotalRecordCount": 1}
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
@@ -466,7 +468,7 @@ def test_find_collection_by_name_not_found(mock_get):
 @patch('requests.get')
 def test_find_collection_by_name_missing_id(mock_get):
     mock_response = MagicMock()
-    mock_response.json.return_value = {"Items": [{"Name": "NoId"}]}
+    mock_response.json.return_value = {"Items": [{"Name": "NoId"}], "TotalRecordCount": 1}
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
@@ -478,8 +480,9 @@ def test_find_collection_by_name_missing_id(mock_get):
 def test_find_collection_by_name_request_exception(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Timeout")
 
-    with pytest.raises(requests.exceptions.RequestException):
+    with pytest.raises(RuntimeError) as excinfo:
         find_collection_by_name("http://localhost:8096", "test_key", "Anything")
+    assert "Failed to GET" in str(excinfo.value)
 
 
 @patch('requests.get')
@@ -682,7 +685,7 @@ def test_set_collection_image_http_error(mock_post, mock_open, mock_guess, caplo
     mock_post.return_value = mock_response
 
     set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/img.jpg")
-    assert "Failed to set image for collection 'col_1' (Status 400): Bad Image" in caplog.text
+    assert "Failed to upload image for item 'col_1' (Status 400): Bad Image" in caplog.text
 
 
 @patch('mimetypes.guess_type')
@@ -694,4 +697,4 @@ def test_set_collection_image_request_exception_no_response(mock_post, mock_open
     mock_post.side_effect = requests.exceptions.RequestException("Upload Error")
 
     set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/img.jpg")
-    assert "Failed to set image for collection 'col_1': Upload Error" in caplog.text
+    assert "Failed to upload image for item 'col_1': Upload Error" in caplog.text

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -67,15 +67,15 @@ def test_get_jellyfin_metadata(mock_get, client):
     def mock_genres(url, **kwargs):
         m = MagicMock()
         if "Genres" in url:
-            m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Comedy"}]}
+            m.json.return_value = {"Items": [{"Name": "Action"}, {"Name": "Comedy"}], "TotalRecordCount": 2}
         elif "Studios" in url:
-            m.json.return_value = {"Items": [{"Name": "Studio A"}]}
+            m.json.return_value = {"Items": [{"Name": "Studio A"}], "TotalRecordCount": 1}
         elif "Persons" in url:
-            m.json.return_value = {"Items": [{"Name": "Actor A"}]}
+            m.json.return_value = {"Items": [{"Name": "Actor A"}], "TotalRecordCount": 1}
         elif "Tags" in url:
-            m.json.return_value = {"Items": [{"Name": "4K"}]}
+            m.json.return_value = {"Items": [{"Name": "4K"}], "TotalRecordCount": 1}
         else:
-            m.json.return_value = {"Items": []}
+            m.json.return_value = {"Items": [], "TotalRecordCount": 0}
         m.raise_for_status = MagicMock()
         return m
 
@@ -330,7 +330,7 @@ def test_get_jellyfin_users_success(mock_get_users, client):
 @pytest.mark.usefixtures("temp_config")
 def test_get_jellyfin_users_exception(mock_get_users, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_get_users.side_effect = requests.exceptions.RequestException("Jellyfin down")
+    mock_get_users.side_effect = RuntimeError("Jellyfin down")
     response = client.get('/api/jellyfin/users')
     assert response.status_code == 400
     assert response.get_json()["status"] == "error"
@@ -520,7 +520,7 @@ def test_auto_detect_paths_no_config(client):
 @pytest.mark.usefixtures("temp_config")
 def test_auto_detect_paths_fetch_error(mock_fetch, client):
     save_config({"jellyfin_url": "http://test", "api_key": "key"})
-    mock_fetch.side_effect = requests.exceptions.RequestException("Connection refused")
+    mock_fetch.side_effect = RuntimeError("Connection refused")
     response = client.post('/api/jellyfin/auto-detect-paths')
     assert response.status_code == 400
 
@@ -782,7 +782,7 @@ def test_perform_cleanup_delete_virtual_folder_error(mock_exists, mock_delete, c
         "api_key": "key"
     })
     mock_exists.return_value = True
-    mock_delete.side_effect = requests.exceptions.RequestException("Jellyfin error")
+    mock_delete.side_effect = RuntimeError("Jellyfin error")
     response = client.post('/api/cleanup', json={"folders": ["Action"]})
     assert response.status_code == 200
     assert response.get_json()["deleted"] == 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -215,7 +215,7 @@ def test_preview_group_fetch_error(mock_jf):
     mock_jf.side_effect = RuntimeError("Network error")
     _items, err, code = preview_group("genre", "Action", "http://jf", "key")
     assert code == 500
-    assert "Internal error" in err
+    assert "Jellyfin connection error" in err
 
 
 def test_parse_complex_query_with_prefixes():
@@ -680,7 +680,7 @@ def test_fetch_full_library_pagination(mock_fetch):
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_full_library_request_error(mock_fetch):
     _LIBRARY_CACHE.clear()
-    mock_fetch.side_effect = requests.exceptions.ConnectionError("fail")
+    mock_fetch.side_effect = RuntimeError("fail")
     items, error, code = _fetch_full_library("http://jf", "key", "Group")
     assert code == 500
     assert "Jellyfin connection error" in error
@@ -692,7 +692,7 @@ def test_fetch_full_library_unexpected_error(mock_fetch):
     mock_fetch.side_effect = RuntimeError("bad")
     items, error, code = _fetch_full_library("http://jf", "key", "Group")
     assert code == 500
-    assert "Internal error" in error
+    assert "Jellyfin connection error" in error
 
 
 @patch('sync._fetch_full_library')
@@ -823,7 +823,7 @@ def test_complex_group_watch_state(mock_lib):
 
 @patch('sync.fetch_jellyfin_items')
 def test_fetch_items_metadata_request_error(mock_fetch):
-    mock_fetch.side_effect = requests.exceptions.ConnectionError("fail")
+    mock_fetch.side_effect = RuntimeError("fail")
     items, error, code = _fetch_items_for_metadata_group(
         "Group", "genre", "Action", "SortName", "http://jf", "key"
     )
@@ -838,7 +838,7 @@ def test_fetch_items_metadata_unexpected_error(mock_fetch):
         "Group", "genre", "Action", "SortName", "http://jf", "key"
     )
     assert code == 500
-    assert "Internal error" in error
+    assert "Jellyfin connection error" in error
 
 
 @patch('sync.os.path.exists')

--- a/tests/test_virtual_jellyfin_exhaustive.py
+++ b/tests/test_virtual_jellyfin_exhaustive.py
@@ -25,21 +25,23 @@ def jellyfin_url(virtual_jellyfin):
 
 
 def test_401_unauthorized(jellyfin_url):
-    with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         fetch_jellyfin_items(jellyfin_url, "BAD_KEY")
-    assert excinfo.value.response.status_code == 401
+    assert excinfo.value.__cause__.response.status_code == 401
 
 
 def test_timeout(jellyfin_url):
-    with pytest.raises(requests.exceptions.Timeout):
+    with pytest.raises(RuntimeError) as excinfo:
         # The endpoint sleeps for 3s, timeout is 1s
         fetch_jellyfin_items(jellyfin_url, "TIMEOUT_KEY", timeout=1)
+    assert isinstance(excinfo.value.__cause__, requests.exceptions.Timeout)
 
 
 def test_connection_error():
     # Attempt connecting to an invalid port/host
-    with pytest.raises(requests.exceptions.ConnectionError):
+    with pytest.raises(RuntimeError) as excinfo:
         fetch_jellyfin_items("http://localhost:12345", "test_key", timeout=1)
+    assert isinstance(excinfo.value.__cause__, requests.exceptions.ConnectionError)
 
 # 2. fetch_jellyfin_items Exhaustive
 
@@ -68,9 +70,9 @@ def test_fetch_extra_query_params(jellyfin_url):
 
 
 def test_get_libraries_500(jellyfin_url):
-    with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+    with pytest.raises(RuntimeError) as excinfo:
         get_libraries(jellyfin_url, "LIB_GET_500")
-    assert excinfo.value.response.status_code == 500
+    assert excinfo.value.__cause__.response.status_code == 500
 
 
 def test_get_libraries_missing_name(jellyfin_url):
@@ -150,8 +152,9 @@ def test_get_library_id_missing_itemid_key(jellyfin_url):
 
 
 def test_get_library_id_500(jellyfin_url):
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(RuntimeError) as excinfo:
         get_library_id(jellyfin_url, "LIB_GET_500", "Movies")
+    assert excinfo.value.__cause__.response.status_code == 500
 
 # 7. set_virtual_folder_image Exhaustive
 
@@ -193,14 +196,15 @@ def test_set_virtual_folder_image_400(jellyfin_url, tmp_path, caplog):
     finally:
         jellyfin.get_library_id = original_get_id
 
-    assert "Failed to set image" in caplog.text
+    assert "Failed to upload image for item" in caplog.text
 
 # 8. get_users and get_user_recent_items Exhaustive
 
 
 def test_get_users_500(jellyfin_url):
-    with pytest.raises(requests.exceptions.HTTPError):
+    with pytest.raises(RuntimeError) as excinfo:
         get_users(jellyfin_url, "USER_GET_500")
+    assert excinfo.value.__cause__.response.status_code == 500
 
 
 def test_get_user_recent_items_bad_user(jellyfin_url):


### PR DESCRIPTION
## Summary
Makes `_get_json` and `_upload_image` consistent with `_request_or_raise` by wrapping `requests.exceptions.RequestException` in `RuntimeError`. This allows callers to catch a single exception type instead of both.

## Changes
- `jellyfin.py`: `_get_json` and `_upload_image` now raise `RuntimeError`
- `jellyfin.py`: `set_virtual_folder_image`/`set_collection_image` catch `RuntimeError`
- `routes.py`: narrow `except` clauses that only call jellyfin helpers
- `sync.py`: narrow `except` clauses that only call jellyfin helpers
- `tests`: update mocks and assertions for `RuntimeError`
- `tests`: add `TotalRecordCount` to mock responses to fix pagination loops
- `tests`: update virtual jellyfin integration tests for `RuntimeError`

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized error handling across API operations with improved error messaging for request failures and Jellyfin connection issues.

* **Tests**
  * Updated test suites to reflect refined error handling and messaging improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->