### PR TITLE
chore: remove dead code and improve test coverage

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -123,14 +123,12 @@ def _request_or_raise(
     if json is not None:
         kwargs["json"] = json
     try:
-        if method == "GET":
-            response = requests.get(url, **kwargs)
-        elif method == "POST":
+        if method == "POST":
             response = requests.post(url, **kwargs)
         elif method == "DELETE":
             response = requests.delete(url, **kwargs)
         else:
-            response = requests.request(method, url, **kwargs)
+            raise ValueError(f"Unsupported HTTP method: {method}")
         response.raise_for_status()
         return response
     except requests.exceptions.RequestException as exc:

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -11,7 +11,7 @@ from jellyfin import fetch_jellyfin_items
 def test_fetch_jellyfin_items(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
-    mock_resp.json.return_value = {"Items": [{"Name": "M1"}]}
+    mock_resp.json.return_value = {"Items": [{"Name": "M1"}], "TotalRecordCount": 1}
     mock_get.return_value = mock_resp
     items = fetch_jellyfin_items("http://jf", "key", {"Type": "Movie"})
     assert items == [{"Name": "M1"}]

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -210,7 +210,7 @@ def test_get_users(mock_get):
 @patch('requests.get')
 def test_get_user_recent_items(mock_get):
     mock_response = MagicMock()
-    mock_response.json.return_value = {"Items": [{"Name": "Movie 1"}, {"Name": "Show 1"}]}
+    mock_response.json.return_value = {"Items": [{"Name": "Movie 1"}, {"Name": "Show 1"}], "TotalRecordCount": 2}
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
@@ -698,3 +698,30 @@ def test_set_collection_image_request_exception_no_response(mock_post, mock_open
 
     set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/img.jpg")
     assert "Failed to upload image for item 'col_1': Upload Error" in caplog.text
+
+
+@patch('requests.post')
+def test_post_or_raise_with_data(mock_post):
+    mock_post.return_value = MagicMock()
+    mock_post.return_value.raise_for_status.return_value = None
+    from jellyfin import _post_or_raise
+    _post_or_raise("http://test", headers={"X-Emby-Token": "key"}, data="payload", error_prefix="Test")
+    _args, kwargs = mock_post.call_args
+    assert kwargs["data"] == "payload"
+
+
+def test_request_or_raise_unsupported_method():
+    from jellyfin import _request_or_raise
+    with pytest.raises(ValueError, match="Unsupported HTTP method: PUT"):
+        _request_or_raise("PUT", "http://test")
+
+
+@patch('requests.get')
+def test_paginate_jellyfin_empty_page(mock_get):
+    mock_get.return_value = MagicMock()
+    mock_get.return_value.json.return_value = {"Items": [], "TotalRecordCount": 0}
+    mock_get.return_value.raise_for_status.return_value = None
+    from jellyfin import _paginate_jellyfin
+    pages = list(_paginate_jellyfin("http://test", "key", "Items"))
+    assert pages == [[]]
+

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -618,7 +618,7 @@ def test_update_config_invalid_cleanup_cron(client):
 def test_fetch_jellyfin_endpoint_partial_data(mock_get, client):
     resp1 = MagicMock()
     resp1.status_code = 200
-    resp1.json.return_value = {"Items": [{"Name": f"G{i}"} for i in range(200)]}
+    resp1.json.return_value = {"Items": [{"Name": f"G{i}"} for i in range(200)], "TotalRecordCount": 201}
     resp1.raise_for_status = MagicMock()
 
     resp2 = MagicMock()
@@ -635,7 +635,7 @@ def test_fetch_jellyfin_endpoint_partial_data(mock_get, client):
 def test_fetch_jellyfin_endpoint_pagination(mock_get, client):
     resp1 = MagicMock()
     resp1.status_code = 200
-    resp1.json.return_value = {"Items": [{"Name": f"G{i}"} for i in range(200)]}
+    resp1.json.return_value = {"Items": [{"Name": f"G{i}"} for i in range(200)], "TotalRecordCount": 201}
     resp1.raise_for_status = MagicMock()
 
     resp2 = MagicMock()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,5 @@
 import os
 import hashlib
-import requests
 import pytest
 from unittest.mock import patch
 from sync import (


### PR DESCRIPTION
## Summary
Removes unreachable code branches from `jellyfin._request_or_raise` and adds missing test coverage to reach 100% on `jellyfin.py`. Also adds `TotalRecordCount` to mock responses that were missing the pagination hint.

## Changes
- `jellyfin.py`: Remove unreachable GET and fallback branches from `_request_or_raise`; add guard for unsupported HTTP methods
- `tests/test_sync.py`: Remove unused `import requests`
- `tests/test_fetchers.py`, `tests/test_jellyfin_api.py`, `tests/test_routes.py`: Add `TotalRecordCount` to mock responses
- `tests/test_jellyfin_api.py`: Add tests for empty page break, data parameter, and unsupported method guard

Closes #266
Closes #267