### PR TITLE
refactor: extract common Jellyfin API query constants

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 _COLLECTION_PAGE_LIMIT = 200
 
+# Default Jellyfin item types used across the application.
+DEFAULT_ITEM_TYPES = "Movie,Series"
+
+# String boolean values expected by the Jellyfin query API.
+RECURSIVE_TRUE = "true"
+
 # ---------------------------------------------------------------------------
 # Sort-order mapping
 # ---------------------------------------------------------------------------
@@ -377,8 +383,8 @@ def get_user_recent_items(
         "Filters": "IsPlayed",
         "SortBy": "DatePlayed",
         "SortOrder": "Descending",
-        "IncludeItemTypes": "Movie,Series",
-        "Recursive": "true",
+        "IncludeItemTypes": DEFAULT_ITEM_TYPES,
+        "Recursive": RECURSIVE_TRUE,
         "Limit": str(limit),
         "Fields": "ProviderIds",
     }
@@ -627,7 +633,7 @@ def find_collection_by_name(
     """
     params: dict[str, Any] = {
         "IncludeItemTypes": "BoxSet",
-        "Recursive": "true",
+        "Recursive": RECURSIVE_TRUE,
         "SearchTerm": name,
     }
     for page in _paginate_jellyfin(

--- a/routes.py
+++ b/routes.py
@@ -26,7 +26,7 @@ from flask.typing import ResponseReturnValue
 from werkzeug.exceptions import HTTPException
 
 from config import load_config, save_config
-from jellyfin import _paginate_jellyfin, delete_virtual_folder, fetch_jellyfin_items, get_users
+from jellyfin import RECURSIVE_TRUE, _paginate_jellyfin, delete_virtual_folder, fetch_jellyfin_items, get_users
 from scheduler import update_scheduler_jobs, validate_cron
 from sync import _get_cover_path, preview_group, run_sync
 
@@ -722,7 +722,7 @@ def auto_detect_paths() -> ResponseReturnValue:
             url,
             api_key,
             {
-                "Recursive": "true",
+                "Recursive": RECURSIVE_TRUE,
                 "IncludeItemTypes": "Movie",
                 "Limit": str(_AUTO_DETECT_SAMPLE_LIMIT),
                 "Fields": "Path",

--- a/sync.py
+++ b/sync.py
@@ -25,6 +25,8 @@ from typing import Any, Callable
 from anilist import fetch_anilist_list
 from imdb import fetch_imdb_list
 from jellyfin import (
+    DEFAULT_ITEM_TYPES,
+    RECURSIVE_TRUE,
     SORT_MAP,
     add_to_collection,
     add_virtual_folder,
@@ -228,9 +230,9 @@ def _fetch_full_library(
             url,
             api_key,
             {
-                "Recursive": "true",
+                "Recursive": RECURSIVE_TRUE,
                 "Fields": _FULL_LIBRARY_FIELDS,
-                "IncludeItemTypes": "Movie,Series",
+                "IncludeItemTypes": DEFAULT_ITEM_TYPES,
             },
             limit=_FULL_LIBRARY_PAGE_SIZE,
             timeout=_FULL_LIBRARY_TIMEOUT,
@@ -833,9 +835,9 @@ def _fetch_items_for_metadata_group(
         A ``(items, error, status_code)`` tuple.
     """
     params: dict[str, str] = {
-        "Recursive": "true",
+        "Recursive": RECURSIVE_TRUE,
         "Fields": "Path",
-        "IncludeItemTypes": "Movie,Series",
+        "IncludeItemTypes": DEFAULT_ITEM_TYPES,
     }
 
     if source_type in _METADATA_FILTER_MAP and source_value:


### PR DESCRIPTION
## Summary
Extracts repeated Jellyfin API query parameter values to module-level constants in `jellyfin.py` and imports them from `sync.py` and `routes.py`.

## Changes
- `jellyfin.py`: Add `DEFAULT_ITEM_TYPES` and `RECURSIVE_TRUE` constants
- `sync.py`: Import and use constants
- `routes.py`: Import and use `RECURSIVE_TRUE`

Closes #269