### PR TITLE
chore: extract hardcoded test fixtures to module-level constants

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3,10 +3,8 @@
 from unittest.mock import MagicMock, patch
 import requests as requests_lib
 
-
-def _make_app():
-    from app import app as flask_app
-    return flask_app
+TEST_URL = "http://localhost:8096"
+TEST_API_KEY = "test-key"
 
 
 class TestServerConnection:
@@ -20,8 +18,8 @@ class TestServerConnection:
             mock_get.return_value = mock_resp
 
             resp = client.post("/api/test-server", json={
-                "jellyfin_url": "http://localhost:8096",
-                "api_key": "test-key"
+                "jellyfin_url": TEST_URL,
+                "api_key": TEST_API_KEY
             })
             data = resp.get_json()
             assert resp.status_code == 200
@@ -43,7 +41,7 @@ class TestServerConnection:
             mock_get.side_effect = requests_lib.exceptions.RequestException("Unauthorized")
 
             resp = client.post("/api/test-server", json={
-                "jellyfin_url": "http://localhost:8096",
+                "jellyfin_url": TEST_URL,
                 "api_key": "bad-key"
             })
             data = resp.get_json()
@@ -66,8 +64,8 @@ class TestMetadataEndpoints:
         with patch("routes.load_config") as mock_load, \
                 patch("routes.requests.get") as mock_get:
             mock_load.return_value = {
-                "jellyfin_url": "http://localhost:8096",
-                "api_key": "test-key"
+                "jellyfin_url": TEST_URL,
+                "api_key": TEST_API_KEY
             }
 
             def mock_jellyfin(url, **kwargs):
@@ -110,8 +108,8 @@ class TestPreviewEndpoint:
         with patch("routes.load_config") as mock_load, \
                 patch("routes.preview_group") as mock_preview:
             mock_load.return_value = {
-                "jellyfin_url": "http://localhost:8096",
-                "api_key": "test-key"
+                "jellyfin_url": TEST_URL,
+                "api_key": TEST_API_KEY
             }
             mock_preview.return_value = (
                 [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,9 @@ import json
 from config import load_config, save_config, DEFAULT_CONFIG
 
 
+TEST_URL = "http://localhost:8096"
+
+
 def test_load_config_defaults(temp_config):
     """Test that loading a non-existent config returns defaults."""
     cfg = load_config()
@@ -15,11 +18,11 @@ def test_save_and_load_config(temp_config):
     """Test saving and then loading configuration."""
     import copy
     new_cfg = copy.deepcopy(DEFAULT_CONFIG)
-    new_cfg["jellyfin_url"] = "http://localhost:8096"
+    new_cfg["jellyfin_url"] = TEST_URL
     save_config(new_cfg)
 
     loaded_cfg = load_config()
-    assert loaded_cfg["jellyfin_url"] == "http://localhost:8096"
+    assert loaded_cfg["jellyfin_url"] == TEST_URL
 
 
 def test_config_migration(temp_config):

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -9,6 +9,9 @@ from jellyfin import (
     remove_from_collection, delete_collection, set_collection_image,
 )
 
+TEST_URL = "http://localhost:8096"
+TEST_KEY = "test_key"
+
 
 @patch('requests.get')
 def test_get_libraries(mock_get):
@@ -17,7 +20,7 @@ def test_get_libraries(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    libs = get_libraries("http://localhost:8096", "test_key")
+    libs = get_libraries(TEST_URL, TEST_KEY)
     assert libs == ["Movies", "TV Shows"]
     mock_get.assert_called_with(
         "http://localhost:8096/Library/VirtualFolders",
@@ -33,7 +36,7 @@ def test_get_libraries_filters_empty_names(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    libs = get_libraries("http://localhost:8096", "test_key")
+    libs = get_libraries(TEST_URL, TEST_KEY)
     assert libs == ["Movies", "TV Shows"]
 
 
@@ -44,7 +47,7 @@ def test_add_virtual_folder_success(mock_post):
     mock_response.status_code = 200
     mock_post.return_value = mock_response
 
-    add_virtual_folder("http://localhost:8096", "test_key", "NewLib", ["/path1"])
+    add_virtual_folder(TEST_URL, TEST_KEY, "NewLib", ["/path1"])
 
     # 1 for creation, 1 for path addition, 1 for refresh
     assert mock_post.call_count == 3
@@ -63,7 +66,7 @@ def test_add_virtual_folder_already_exists(mock_post):
     # 409 on create, then 200 on path and refresh
     mock_post.side_effect = [mock_response_409, mock_response_200, mock_response_200]
 
-    add_virtual_folder("http://localhost:8096", "test_key", "Exists", ["/path1"])
+    add_virtual_folder(TEST_URL, TEST_KEY, "Exists", ["/path1"])
     assert mock_post.call_count == 3
 
 
@@ -80,7 +83,7 @@ def test_add_virtual_folder_creation_failure(mock_post):
     mock_post.return_value = mock_response
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder("http://localhost:8096", "test_key", "FailLib", ["/path1"])
+        add_virtual_folder(TEST_URL, TEST_KEY, "FailLib", ["/path1"])
 
     assert "Failed to create virtual folder 'FailLib'" in str(excinfo.value)
     assert "Status 500" in str(excinfo.value)
@@ -105,7 +108,7 @@ def test_add_virtual_folder_path_failure(mock_post):
     mock_post.side_effect = [mock_response_ok, mock_response_fail]
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder("http://localhost:8096", "test_key", "PathFail", ["/bad/path"])
+        add_virtual_folder(TEST_URL, TEST_KEY, "PathFail", ["/bad/path"])
 
     assert "Failed to add path '/bad/path' to library 'PathFail'" in str(excinfo.value)
     assert "Status 400" in str(excinfo.value)
@@ -118,7 +121,7 @@ def test_delete_virtual_folder(mock_delete):
     mock_response.ok = True
     mock_delete.return_value = mock_response
 
-    delete_virtual_folder("http://localhost:8096", "test_key", "ToDelete")
+    delete_virtual_folder(TEST_URL, TEST_KEY, "ToDelete")
     assert mock_delete.called
     mock_delete.assert_called_with(
         "http://localhost:8096/Library/VirtualFolders",
@@ -135,7 +138,7 @@ def test_add_virtual_folder_mixed(mock_post):
     mock_response.status_code = 200
     mock_post.return_value = mock_response
 
-    add_virtual_folder("http://localhost:8096", "test_key", "MixedLib", ["/path1"], collection_type="mixed")
+    add_virtual_folder(TEST_URL, TEST_KEY, "MixedLib", ["/path1"], collection_type="mixed")
 
     # Check the first call (creation) parameters
     args, kwargs = mock_post.call_args_list[0]
@@ -157,11 +160,11 @@ def test_get_library_id(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    item_id = get_library_id("http://localhost:8096", "test_key", "Movies")
+    item_id = get_library_id(TEST_URL, TEST_KEY, "Movies")
     assert item_id == "12345"
-    item_id_none = get_library_id("http://localhost:8096", "test_key", "NonExistent")
+    item_id_none = get_library_id(TEST_URL, TEST_KEY, "NonExistent")
     assert item_id_none is None
-    item_id_orphans = get_library_id("http://localhost:8096", "test_key", "Orphans")
+    item_id_orphans = get_library_id(TEST_URL, TEST_KEY, "Orphans")
     assert item_id_orphans is None
 
 
@@ -178,7 +181,7 @@ def test_set_virtual_folder_image(mock_get_library_id, mock_post, mock_open, moc
     mock_response.ok = True
     mock_post.return_value = mock_response
 
-    set_virtual_folder_image("http://localhost:8096", "test_key", "Movies", "/path/to/image.jpg")
+    set_virtual_folder_image(TEST_URL, TEST_KEY, "Movies", "/path/to/image.jpg")
 
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
@@ -195,7 +198,7 @@ def test_get_users(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    users = get_users("http://localhost:8096", "test_key")
+    users = get_users(TEST_URL, TEST_KEY)
     assert len(users) == 2
     assert users[0]["Id"] == "u1"
     assert users[0]["Name"] == "Alice"
@@ -214,7 +217,7 @@ def test_get_user_recent_items(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    items = get_user_recent_items("http://localhost:8096", "test_key", "u1", limit=10)
+    items = get_user_recent_items(TEST_URL, TEST_KEY, "u1", limit=10)
     assert len(items) == 2
     assert items[0]["Name"] == "Movie 1"
 
@@ -240,7 +243,7 @@ def test_add_virtual_folder_creation_failure_no_response(mock_post):
     mock_post.side_effect = requests.exceptions.RequestException("Network Error")
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder("http://localhost:8096", "test_key", "FailLib", ["/path1"])
+        add_virtual_folder(TEST_URL, TEST_KEY, "FailLib", ["/path1"])
 
     assert "Failed to create virtual folder 'FailLib': Network Error" in str(excinfo.value)
 
@@ -255,7 +258,7 @@ def test_add_virtual_folder_path_failure_no_response(mock_post):
     mock_post.side_effect = [mock_response_ok, requests.exceptions.RequestException("Path Network Error")]
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder("http://localhost:8096", "test_key", "FailLib", ["/path1"])
+        add_virtual_folder(TEST_URL, TEST_KEY, "FailLib", ["/path1"])
 
     assert "Failed to add path '/path1' to library 'FailLib': Path Network Error" in str(excinfo.value)
 
@@ -277,7 +280,7 @@ def test_add_virtual_folder_refresh_failure(mock_post):
     mock_post.side_effect = [mock_response_ok, mock_response_ok, mock_response_fail]
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder("http://localhost:8096", "test_key", "RefreshFail", ["/path1"])
+        add_virtual_folder(TEST_URL, TEST_KEY, "RefreshFail", ["/path1"])
 
     assert "Failed to trigger library refresh for 'RefreshFail' (Status 502): Bad Gateway" in str(excinfo.value)
 
@@ -293,7 +296,7 @@ def test_add_virtual_folder_refresh_failure_no_response(mock_post):
                              requests.exceptions.RequestException("Refresh Network Error")]
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder("http://localhost:8096", "test_key", "RefreshFail", ["/path1"])
+        add_virtual_folder(TEST_URL, TEST_KEY, "RefreshFail", ["/path1"])
 
     assert "Failed to trigger library refresh for 'RefreshFail': Refresh Network Error" in str(excinfo.value)
 
@@ -307,7 +310,7 @@ def test_delete_virtual_folder_not_ok(mock_delete, caplog):
     mock_delete.return_value = mock_response
 
     with caplog.at_level(logging.WARNING):
-        delete_virtual_folder("http://localhost:8096", "test_key", "ToDelete")
+        delete_virtual_folder(TEST_URL, TEST_KEY, "ToDelete")
 
     assert "Delete Virtual Folder Failed (404): Not Found" in caplog.text
 
@@ -317,7 +320,7 @@ def test_get_library_id_request_exception(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Fetch Error")
 
     with pytest.raises(RuntimeError) as excinfo:
-        get_library_id("http://localhost:8096", "test_key", "MyLib")
+        get_library_id(TEST_URL, TEST_KEY, "MyLib")
     assert "Failed to GET" in str(excinfo.value)
 
 
@@ -325,7 +328,7 @@ def test_get_library_id_request_exception(mock_get):
 def test_set_virtual_folder_image_no_library_id(mock_get_library_id, caplog):
     mock_get_library_id.return_value = None
 
-    set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
+    set_virtual_folder_image(TEST_URL, TEST_KEY, "MyLib", "/path/to/img.jpg")
 
     assert "Cannot set image: Library 'MyLib' not found or ID unknown." in caplog.text
 
@@ -335,7 +338,7 @@ def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
     mock_get_library_id.return_value = "123"
 
     with patch('builtins.open', side_effect=OSError("Permission Denied")):
-        set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
+        set_virtual_folder_image(TEST_URL, TEST_KEY, "MyLib", "/path/to/img.jpg")
 
     assert "Cannot set image: Failed to read image file '/path/to/img.jpg': Permission Denied" in caplog.text
 
@@ -360,7 +363,7 @@ def test_set_virtual_folder_image_request_exception(mock_get_library_id, mock_po
     fail_exc.response = mock_response_fail
     mock_post.side_effect = fail_exc
 
-    set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
+    set_virtual_folder_image(TEST_URL, TEST_KEY, "MyLib", "/path/to/img.jpg")
 
     assert "Failed to upload image for item '123' (Status 400): Bad Request" in caplog.text
 
@@ -378,7 +381,7 @@ def test_set_virtual_folder_image_request_exception_no_response(
 
     mock_post.side_effect = requests.exceptions.RequestException("Upload Error")
 
-    set_virtual_folder_image("http://localhost:8096", "test_key", "MyLib", "/path/to/img.jpg")
+    set_virtual_folder_image(TEST_URL, TEST_KEY, "MyLib", "/path/to/img.jpg")
 
     assert "Failed to upload image for item '123': Upload Error" in caplog.text
 
@@ -395,7 +398,7 @@ def test_create_collection_success(mock_post):
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
-    col_id = create_collection("http://localhost:8096", "test_key", "My Collection", ["item_1", "item_2"])
+    col_id = create_collection(TEST_URL, TEST_KEY, "My Collection", ["item_1", "item_2"])
     assert col_id == "col_123"
     mock_post.assert_called_once_with(
         "http://localhost:8096/Collections",
@@ -413,7 +416,7 @@ def test_create_collection_no_id(mock_post):
     mock_post.return_value = mock_response
 
     with pytest.raises(RuntimeError, match="Collection created but no Id returned for 'Bad'"):
-        create_collection("http://localhost:8096", "test_key", "Bad", ["item_1"])
+        create_collection(TEST_URL, TEST_KEY, "Bad", ["item_1"])
 
 
 @patch('requests.post')
@@ -425,7 +428,7 @@ def test_create_collection_http_error(mock_post):
     mock_post.return_value = mock_response
 
     with pytest.raises(RuntimeError) as excinfo:
-        create_collection("http://localhost:8096", "test_key", "Fail", ["item_1"])
+        create_collection(TEST_URL, TEST_KEY, "Fail", ["item_1"])
     assert "Failed to create collection 'Fail' (Status 500): Server Error" in str(excinfo.value)
 
 
@@ -434,7 +437,7 @@ def test_create_collection_request_exception_no_response(mock_post):
     mock_post.side_effect = requests.exceptions.RequestException("Network down")
 
     with pytest.raises(RuntimeError, match="Failed to create collection 'Fail': Network down"):
-        create_collection("http://localhost:8096", "test_key", "Fail", ["item_1"])
+        create_collection(TEST_URL, TEST_KEY, "Fail", ["item_1"])
 
 
 @patch('requests.get')
@@ -450,7 +453,7 @@ def test_find_collection_by_name_found(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    result = find_collection_by_name("http://localhost:8096", "test_key", "My Boxset")
+    result = find_collection_by_name(TEST_URL, TEST_KEY, "My Boxset")
     assert result == "boxset_42"
 
 
@@ -461,7 +464,7 @@ def test_find_collection_by_name_not_found(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    result = find_collection_by_name("http://localhost:8096", "test_key", "Missing")
+    result = find_collection_by_name(TEST_URL, TEST_KEY, "Missing")
     assert result is None
 
 
@@ -472,7 +475,7 @@ def test_find_collection_by_name_missing_id(mock_get):
     mock_response.raise_for_status.return_value = None
     mock_get.return_value = mock_response
 
-    result = find_collection_by_name("http://localhost:8096", "test_key", "NoId")
+    result = find_collection_by_name(TEST_URL, TEST_KEY, "NoId")
     assert result is None
 
 
@@ -481,7 +484,7 @@ def test_find_collection_by_name_request_exception(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Timeout")
 
     with pytest.raises(RuntimeError) as excinfo:
-        find_collection_by_name("http://localhost:8096", "test_key", "Anything")
+        find_collection_by_name(TEST_URL, TEST_KEY, "Anything")
     assert "Failed to GET" in str(excinfo.value)
 
 
@@ -506,7 +509,7 @@ def test_find_collection_by_name_on_second_page(mock_get):
 
     mock_get.side_effect = [page1, page2]
 
-    result = find_collection_by_name("http://localhost:8096", "test_key", "Marvel")
+    result = find_collection_by_name(TEST_URL, TEST_KEY, "Marvel")
     assert result == "exact_match"
     assert mock_get.call_count == 2
 
@@ -517,7 +520,7 @@ def test_add_to_collection_success(mock_post):
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
-    add_to_collection("http://localhost:8096", "test_key", "col_1", ["a", "b"])
+    add_to_collection(TEST_URL, TEST_KEY, "col_1", ["a", "b"])
     mock_post.assert_called_once_with(
         "http://localhost:8096/Collections/col_1/Items",
         params={"Ids": "a,b"},
@@ -527,7 +530,7 @@ def test_add_to_collection_success(mock_post):
 
 
 def test_add_to_collection_empty_ids():
-    add_to_collection("http://localhost:8096", "test_key", "col_1", [])
+    add_to_collection(TEST_URL, TEST_KEY, "col_1", [])
 
 
 @patch('requests.post')
@@ -539,7 +542,7 @@ def test_add_to_collection_http_error(mock_post):
     mock_post.return_value = mock_response
 
     with pytest.raises(RuntimeError) as excinfo:
-        add_to_collection("http://localhost:8096", "test_key", "col_1", ["bad"])
+        add_to_collection(TEST_URL, TEST_KEY, "col_1", ["bad"])
     assert "Failed to add items to collection 'col_1' (Status 400): Bad item" in str(excinfo.value)
 
 
@@ -548,7 +551,7 @@ def test_add_to_collection_request_exception(mock_post):
     mock_post.side_effect = requests.exceptions.RequestException("Net fail")
 
     with pytest.raises(RuntimeError, match="Failed to add items to collection 'col_1': Net fail"):
-        add_to_collection("http://localhost:8096", "test_key", "col_1", ["x"])
+        add_to_collection(TEST_URL, TEST_KEY, "col_1", ["x"])
 
 
 @patch('requests.delete')
@@ -557,7 +560,7 @@ def test_remove_from_collection_success(mock_delete):
     mock_response.raise_for_status.return_value = None
     mock_delete.return_value = mock_response
 
-    remove_from_collection("http://localhost:8096", "test_key", "col_1", ["a", "b"])
+    remove_from_collection(TEST_URL, TEST_KEY, "col_1", ["a", "b"])
     mock_delete.assert_called_once_with(
         "http://localhost:8096/Collections/col_1/Items",
         params={"Ids": "a,b"},
@@ -567,7 +570,7 @@ def test_remove_from_collection_success(mock_delete):
 
 
 def test_remove_from_collection_empty_ids():
-    remove_from_collection("http://localhost:8096", "test_key", "col_1", [])
+    remove_from_collection(TEST_URL, TEST_KEY, "col_1", [])
 
 
 @patch('requests.delete')
@@ -579,7 +582,7 @@ def test_remove_from_collection_http_error(mock_delete):
     mock_delete.return_value = mock_response
 
     with pytest.raises(RuntimeError) as excinfo:
-        remove_from_collection("http://localhost:8096", "test_key", "col_1", ["x"])
+        remove_from_collection(TEST_URL, TEST_KEY, "col_1", ["x"])
     assert "Failed to remove items from collection 'col_1' (Status 404): Not found" in str(excinfo.value)
 
 
@@ -588,7 +591,7 @@ def test_remove_from_collection_request_exception(mock_delete):
     mock_delete.side_effect = requests.exceptions.RequestException("Timeout")
 
     with pytest.raises(RuntimeError, match="Failed to remove items from collection 'col_1': Timeout"):
-        remove_from_collection("http://localhost:8096", "test_key", "col_1", ["x"])
+        remove_from_collection(TEST_URL, TEST_KEY, "col_1", ["x"])
 
 
 @patch('requests.delete')
@@ -597,7 +600,7 @@ def test_delete_collection_success(mock_delete):
     mock_response.raise_for_status.return_value = None
     mock_delete.return_value = mock_response
 
-    delete_collection("http://localhost:8096", "test_key", "col_1")
+    delete_collection(TEST_URL, TEST_KEY, "col_1")
     mock_delete.assert_called_once_with(
         "http://localhost:8096/Items/col_1",
         headers={"X-Emby-Token": "test_key"},
@@ -614,7 +617,7 @@ def test_delete_collection_http_error(mock_delete):
     mock_delete.return_value = mock_response
 
     with pytest.raises(RuntimeError) as excinfo:
-        delete_collection("http://localhost:8096", "test_key", "col_1")
+        delete_collection(TEST_URL, TEST_KEY, "col_1")
     assert "Failed to delete collection 'col_1' (Status 403): Forbidden" in str(excinfo.value)
 
 
@@ -623,7 +626,7 @@ def test_delete_collection_request_exception(mock_delete):
     mock_delete.side_effect = requests.exceptions.RequestException("Gone")
 
     with pytest.raises(RuntimeError, match="Failed to delete collection 'col_1': Gone"):
-        delete_collection("http://localhost:8096", "test_key", "col_1")
+        delete_collection(TEST_URL, TEST_KEY, "col_1")
 
 
 @patch('mimetypes.guess_type')
@@ -636,7 +639,7 @@ def test_set_collection_image_success(mock_post, mock_open, mock_guess, caplog):
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
-    set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/cover.png")
+    set_collection_image(TEST_URL, TEST_KEY, "col_1", "/path/cover.png")
 
     mock_post.assert_called_once_with(
         "http://localhost:8096/Items/col_1/Images/Primary",
@@ -651,7 +654,7 @@ def test_set_collection_image_success(mock_post, mock_open, mock_guess, caplog):
 def test_set_collection_image_os_error(mock_open, caplog):
     mock_open.side_effect = OSError("Permission denied")
 
-    set_collection_image("http://localhost:8096", "test_key", "col_1", "/bad/path.jpg")
+    set_collection_image(TEST_URL, TEST_KEY, "col_1", "/bad/path.jpg")
     assert "Cannot set collection image: Failed to read '/bad/path.jpg': Permission denied" in caplog.text
 
 
@@ -665,7 +668,7 @@ def test_set_collection_image_unknown_mime(mock_post, mock_open, mock_guess, cap
     mock_response.raise_for_status.return_value = None
     mock_post.return_value = mock_response
 
-    set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/file.bin")
+    set_collection_image(TEST_URL, TEST_KEY, "col_1", "/path/file.bin")
 
     call_headers = mock_post.call_args[1]["headers"]
     assert call_headers["Content-Type"] == "application/octet-stream"
@@ -684,7 +687,7 @@ def test_set_collection_image_http_error(mock_post, mock_open, mock_guess, caplo
     mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
     mock_post.return_value = mock_response
 
-    set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/img.jpg")
+    set_collection_image(TEST_URL, TEST_KEY, "col_1", "/path/img.jpg")
     assert "Failed to upload image for item 'col_1' (Status 400): Bad Image" in caplog.text
 
 
@@ -696,7 +699,7 @@ def test_set_collection_image_request_exception_no_response(mock_post, mock_open
     mock_open.return_value.__enter__.return_value.read.return_value = b"jpeg_data"
     mock_post.side_effect = requests.exceptions.RequestException("Upload Error")
 
-    set_collection_image("http://localhost:8096", "test_key", "col_1", "/path/img.jpg")
+    set_collection_image(TEST_URL, TEST_KEY, "col_1", "/path/img.jpg")
     assert "Failed to upload image for item 'col_1': Upload Error" in caplog.text
 
 

--- a/tests/test_virtual_jellyfin_exhaustive.py
+++ b/tests/test_virtual_jellyfin_exhaustive.py
@@ -16,6 +16,8 @@ from jellyfin import (
 
 pytestmark = pytest.mark.exhaustive
 
+TEST_API_KEY = "test_key"
+
 
 @pytest.fixture
 def jellyfin_url(virtual_jellyfin):
@@ -40,7 +42,7 @@ def test_timeout(jellyfin_url):
 def test_connection_error():
     # Attempt connecting to an invalid port/host
     with pytest.raises(RuntimeError) as excinfo:
-        fetch_jellyfin_items("http://localhost:12345", "test_key", timeout=1)
+        fetch_jellyfin_items("http://localhost:12345", TEST_API_KEY, timeout=1)
     assert isinstance(excinfo.value.__cause__, requests.exceptions.ConnectionError)
 
 # 2. fetch_jellyfin_items Exhaustive
@@ -63,7 +65,7 @@ def test_fetch_malformed_json(jellyfin_url):
 
 def test_fetch_extra_query_params(jellyfin_url):
     # The server ignores it, but we test requests is passing it
-    items = fetch_jellyfin_items(jellyfin_url, "test_key", extra_params={"IncludeItemTypes": "Movie"})
+    items = fetch_jellyfin_items(jellyfin_url, TEST_API_KEY, extra_params={"IncludeItemTypes": "Movie"})
     assert len(items) >= 2
 
 # 3. get_libraries Exhaustive
@@ -91,19 +93,19 @@ def test_get_libraries_empty(jellyfin_url):
 def test_add_virtual_folder_409_conflict(jellyfin_url):
     # Movies already exists, add_virtual_folder silent recovery (returns 409 but caught in 200 checks for path/refresh)
     # The current code in add_virtual_folder expects 409 to not be raised, and proceed
-    add_virtual_folder(jellyfin_url, "test_key", "Movies", ["/tmp/safe"])
+    add_virtual_folder(jellyfin_url, TEST_API_KEY, "Movies", ["/tmp/safe"])
     # If no exception, it passes
 
 
 def test_add_virtual_folder_500_create(jellyfin_url):
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder(jellyfin_url, "test_key", "FAIL_CREATE", ["/tmp/safe"])
+        add_virtual_folder(jellyfin_url, TEST_API_KEY, "FAIL_CREATE", ["/tmp/safe"])
     assert "Failed to create virtual folder 'FAIL_CREATE'" in str(excinfo.value)
 
 
 def test_add_virtual_folder_400_paths(jellyfin_url):
     with pytest.raises(RuntimeError) as excinfo:
-        add_virtual_folder(jellyfin_url, "test_key", "NewLibPath", ["/tmp/FAIL_PATH"])
+        add_virtual_folder(jellyfin_url, TEST_API_KEY, "NewLibPath", ["/tmp/FAIL_PATH"])
     assert "Failed to add path" in str(excinfo.value)
     assert "Status 400" in str(excinfo.value)
 
@@ -117,32 +119,32 @@ def test_add_virtual_folder_502_refresh(jellyfin_url):
 
 def test_add_virtual_folder_invalid_collection(jellyfin_url):
     # Mixed should omit collectionType parameter.
-    add_virtual_folder(jellyfin_url, "test_key", "MixedLib2", ["/tmp/safe"], collection_type="mixed")
+    add_virtual_folder(jellyfin_url, TEST_API_KEY, "MixedLib2", ["/tmp/safe"], collection_type="mixed")
     # if it doesn't fail, we consider it a success.
 
 
 def test_add_virtual_folder_empty_paths(jellyfin_url):
     # Should not fail.
-    add_virtual_folder(jellyfin_url, "test_key", "EmptyLib", [])
+    add_virtual_folder(jellyfin_url, TEST_API_KEY, "EmptyLib", [])
 
 # 5. delete_virtual_folder Exhaustive
 
 
 def test_delete_virtual_folder_404(jellyfin_url, caplog):
     with pytest.raises(RuntimeError):
-        delete_virtual_folder(jellyfin_url, "test_key", "FAIL_DELETE_404")
+        delete_virtual_folder(jellyfin_url, TEST_API_KEY, "FAIL_DELETE_404")
     assert "Delete Virtual Folder Failed (404)" in caplog.text
 
 
 def test_delete_virtual_folder_500(jellyfin_url):
     with pytest.raises(RuntimeError):
-        delete_virtual_folder(jellyfin_url, "test_key", "FAIL_DELETE_500")
+        delete_virtual_folder(jellyfin_url, TEST_API_KEY, "FAIL_DELETE_500")
 
 # 6. get_library_id Exhaustive
 
 
 def test_get_library_id_missing(jellyfin_url):
-    lib_id = get_library_id(jellyfin_url, "test_key", "DoesNotExist")
+    lib_id = get_library_id(jellyfin_url, TEST_API_KEY, "DoesNotExist")
     assert lib_id is None
 
 
@@ -163,12 +165,12 @@ def test_set_virtual_folder_image_missing_id(jellyfin_url, tmp_path, caplog):
     caplog.set_level(logging.INFO)
     img_path = tmp_path / "test.jpg"
     img_path.write_bytes(b"data")
-    set_virtual_folder_image(jellyfin_url, "test_key", "DoesNotExist", str(img_path))
+    set_virtual_folder_image(jellyfin_url, TEST_API_KEY, "DoesNotExist", str(img_path))
     assert "not found or ID unknown" in caplog.text
 
 
 def test_set_virtual_folder_image_oserror(jellyfin_url, caplog):
-    set_virtual_folder_image(jellyfin_url, "test_key", "Movies", "/does/not/exist.jpg")
+    set_virtual_folder_image(jellyfin_url, TEST_API_KEY, "Movies", "/does/not/exist.jpg")
     assert "Failed to read image file" in caplog.text
 
 
@@ -177,7 +179,7 @@ def test_set_virtual_folder_image_unknown_mime(jellyfin_url, tmp_path, caplog):
     img_path = tmp_path / "testfile"  # No extension
     img_path.write_bytes(b"data")
     # Standard call should work and fallback to application/octet-stream
-    set_virtual_folder_image(jellyfin_url, "test_key", "Movies", str(img_path))
+    set_virtual_folder_image(jellyfin_url, TEST_API_KEY, "Movies", str(img_path))
     assert "Successfully updated cover image" in caplog.text
 
 
@@ -192,7 +194,7 @@ def test_set_virtual_folder_image_400(jellyfin_url, tmp_path, caplog):
     jellyfin.get_library_id = lambda *args, **kwargs: "FAIL_IMAGE_ID"
 
     try:
-        set_virtual_folder_image(jellyfin_url, "test_key", "Movies", str(img_path))
+        set_virtual_folder_image(jellyfin_url, TEST_API_KEY, "Movies", str(img_path))
     finally:
         jellyfin.get_library_id = original_get_id
 
@@ -208,10 +210,10 @@ def test_get_users_500(jellyfin_url):
 
 
 def test_get_user_recent_items_bad_user(jellyfin_url):
-    items = get_user_recent_items(jellyfin_url, "test_key", "BAD_USER")
+    items = get_user_recent_items(jellyfin_url, TEST_API_KEY, "BAD_USER")
     assert items == []
 
 
 def test_get_user_recent_items_missing_data(jellyfin_url):
-    items = get_user_recent_items(jellyfin_url, "test_key", "MISSING_DATA_USER")
+    items = get_user_recent_items(jellyfin_url, TEST_API_KEY, "MISSING_DATA_USER")
     assert items == []


### PR DESCRIPTION
## Summary
Extract common hardcoded test values to module-level constants in the test suite.

## Changes
- `tests/test_jellyfin_api.py`: Added `TEST_URL` and `TEST_KEY` constants, replaced 50+ hardcoded occurrences.
- `tests/test_api_client.py`: Added `TEST_URL` and `TEST_API_KEY` constants.
- `tests/test_config.py`: Added `TEST_URL` constant.
- `tests/test_virtual_jellyfin_exhaustive.py`: Added `TEST_API_KEY` constant.

## Motivation
Reduces duplication, makes future updates easier, and lowers the risk of typos.

Closes #271