### PR TITLE
chore: add ruff to pyproject.toml dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-flask>=1.3.0",
     "pytest-mock>=3.12.0",
+    "ruff>=0.15.0",
     "types-requests",
 ]
 


### PR DESCRIPTION
## Summary
Add `ruff>=0.15.0` to `[project.optional-dependencies] dev` in `pyproject.toml`.

## Motivation
#274 added ruff to `requirements-dev.txt` but not to `pyproject.toml`. This meant `pip install -e .[dev]` did not install ruff, causing the lint step to fail for anyone following the standard editable install workflow.

## Non-breaking
No production code affected.

Closes #276