### PR TITLE
test: fix fragile test_run_sync_invalid_group

### DIFF
--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -165,7 +165,8 @@ def test_run_sync_invalid_group():
         "groups": ["not_a_dict"]
     }
     # Should skip the string and continue
-    with patch('sync.os.path.exists', return_value=True):
+    with patch('sync.os.path.exists', return_value=True), \
+            patch('sync.os.makedirs'):
         results = run_sync(config)
     assert results == []
 


### PR DESCRIPTION
## Summary
Patch `sync.os.makedirs` in `test_run_sync_invalid_group` so the test does not depend on an internal `os.path.exists` guard.

## Motivation
The test previously only patched `sync.os.path.exists`. This accidentally prevented `os.makedirs` from being called only because the implementation had a `not os.path.exists(target_base)` guard. Removing or changing that guard (e.g. using `exist_ok=True` directly) would cause the test to fail with a `PermissionError` when it tries to create `/target`.

## Non-breaking
Test-only change.

Closes #278