### PR TITLE
chore: use time.monotonic() for elapsed-time checks

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -657,7 +657,7 @@ def _search_local_filesystem(
 
     Returns the absolute path of the first match found, or ``None``.
     """
-    walk_start = time.time()
+    walk_start = time.monotonic()
     files_scanned = 0
     for root in search_roots:
         if not os.path.isdir(root):
@@ -666,7 +666,7 @@ def _search_local_filesystem(
             if os.path.ismount(dirpath) and dirpath != root:
                 dirnames.clear()
                 continue
-            if time.time() - walk_start > timeout:
+            if time.monotonic() - walk_start > timeout:
                 logger.warning(
                     "auto-detect timed out after %ds, %d files scanned",
                     timeout,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -837,7 +837,7 @@ def test_auto_detect_mount_skip(mock_walk, mock_isdir, mock_ismount, mock_fetch,
 
 # Auto-detect: timeout (lines 701-703)
 @patch('routes.fetch_jellyfin_items')
-@patch('routes.time.time')
+@patch('routes.time.monotonic')
 @patch('routes.os.walk')
 @patch('routes.os.path.isdir')
 @patch('routes.os.path.ismount')


### PR DESCRIPTION
## Summary
Replace `time.time()` with `time.monotonic()` in `_search_local_filesystem` so the filesystem scan timeout is immune to system clock adjustments (NTP jumps, manual changes, etc.).

## Changes
- `routes.py`: `walk_start = time.time()` → `time.monotonic()`, and the elapsed-time check accordingly.
- `tests/test_routes.py`: Update the auto-detect timeout test to patch `time.monotonic` instead of `time.time`.

## Non-breaking
Behavioral equivalent under normal conditions, more robust under clock adjustments.

Closes #280