### PR TITLE
chore: extract remaining hardcoded test fixtures

### DIFF
--- a/tests/test_sync_integration.py
+++ b/tests/test_sync_integration.py
@@ -2,6 +2,9 @@ from unittest.mock import patch
 
 from sync import run_sync
 
+TEST_URL = "http://localhost:8096"
+TEST_API_KEY = "test_key"
+
 
 @patch('sync.os.makedirs')
 @patch('sync.os.path.exists')
@@ -11,8 +14,8 @@ from sync import run_sync
 def test_run_sync_basic(mock_fetch, mock_symlink, mock_rmtree, mock_exists, mock_makedirs):
     """Test run_sync with a simple genre-based group."""
     config = {
-        "jellyfin_url": "http://localhost:8096",
-        "api_key": "test_key",
+        "jellyfin_url": TEST_URL,
+        "api_key": TEST_API_KEY,
         "target_path": "/host/target",
         "media_path_in_jellyfin": "/jf",
         "media_path_on_host": "/host",
@@ -53,8 +56,8 @@ def test_run_sync_imdb(mock_imdb_fetch, mock_jf_fetch, mock_exists):
     """Test run_sync with an IMDb-list group."""
     mock_exists.return_value = True
     config = {
-        "jellyfin_url": "http://localhost:8096",
-        "api_key": "test_key",
+        "jellyfin_url": TEST_URL,
+        "api_key": TEST_API_KEY,
         "target_path": "/host/target",
         "groups": [
             {

--- a/tests/test_virtual_jellyfin_api.py
+++ b/tests/test_virtual_jellyfin_api.py
@@ -10,6 +10,8 @@ from jellyfin import (
     set_virtual_folder_image,
 )
 
+TEST_API_KEY = "test_key"
+
 
 @pytest.fixture
 def jellyfin_url(virtual_jellyfin):
@@ -17,7 +19,7 @@ def jellyfin_url(virtual_jellyfin):
 
 
 def test_get_libraries(jellyfin_url):
-    libs = get_libraries(jellyfin_url, "test_key")
+    libs = get_libraries(jellyfin_url, TEST_API_KEY)
     # virtual_jellyfin starts with Movies and TV Shows
     assert "Movies" in libs
     assert "TV Shows" in libs
@@ -25,29 +27,29 @@ def test_get_libraries(jellyfin_url):
 
 def test_add_virtual_folder_success(jellyfin_url):
     name = "NewLib"
-    add_virtual_folder(jellyfin_url, "test_key", name, ["/tmp/path1"])
-    libs = get_libraries(jellyfin_url, "test_key")
+    add_virtual_folder(jellyfin_url, TEST_API_KEY, name, ["/tmp/path1"])
+    libs = get_libraries(jellyfin_url, TEST_API_KEY)
     assert name in libs
 
 
 def test_add_virtual_folder_already_exists(jellyfin_url):
     name = "Movies"  # Already exists in virtual_jellyfin
     # add_virtual_folder should handle 409 and not raise
-    add_virtual_folder(jellyfin_url, "test_key", name, ["/tmp/path2"])
+    add_virtual_folder(jellyfin_url, TEST_API_KEY, name, ["/tmp/path2"])
 
 
 def test_delete_virtual_folder(jellyfin_url):
     name = "ToStore"
-    add_virtual_folder(jellyfin_url, "test_key", name, ["/tmp/path"])
-    delete_virtual_folder(jellyfin_url, "test_key", name)
-    libs = get_libraries(jellyfin_url, "test_key")
+    add_virtual_folder(jellyfin_url, TEST_API_KEY, name, ["/tmp/path"])
+    delete_virtual_folder(jellyfin_url, TEST_API_KEY, name)
+    libs = get_libraries(jellyfin_url, TEST_API_KEY)
     assert name not in libs
 
 
 def test_get_library_id(jellyfin_url):
-    item_id = get_library_id(jellyfin_url, "test_key", "Movies")
+    item_id = get_library_id(jellyfin_url, TEST_API_KEY, "Movies")
     assert item_id == "movies_id"
-    item_id_none = get_library_id(jellyfin_url, "test_key", "NonExistent")
+    item_id_none = get_library_id(jellyfin_url, TEST_API_KEY, "NonExistent")
     assert item_id_none is None
 
 
@@ -55,16 +57,16 @@ def test_set_virtual_folder_image(jellyfin_url, tmp_path):
     img_path = tmp_path / "test.jpg"
     img_path.write_bytes(b"fake_image_data")
     # This should not raise
-    set_virtual_folder_image(jellyfin_url, "test_key", "Movies", str(img_path))
+    set_virtual_folder_image(jellyfin_url, TEST_API_KEY, "Movies", str(img_path))
 
 
 def test_get_users(jellyfin_url):
-    users = get_users(jellyfin_url, "test_key")
+    users = get_users(jellyfin_url, TEST_API_KEY)
     assert len(users) >= 1
     assert users[0]["Name"] == "Admin"
 
 
 def test_get_user_recent_items(jellyfin_url):
-    items = get_user_recent_items(jellyfin_url, "test_key", "admin_id", limit=10)
+    items = get_user_recent_items(jellyfin_url, TEST_API_KEY, "admin_id", limit=10)
     assert len(items) >= 2
     assert items[0]["Name"] == "Inception"


### PR DESCRIPTION
## Summary
Extract remaining hardcoded test values that were missed in #271.

## Changes
- `tests/test_virtual_jellyfin_api.py`: Added `TEST_API_KEY` constant, replaced 12 hardcoded occurrences.
- `tests/test_sync_integration.py`: Added `TEST_URL` and `TEST_API_KEY` constants, replaced 4 hardcoded occurrences.

Closes #282