### PR TITLE
chore: use time.monotonic() in conftest.py virtual server wait

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,8 @@ def virtual_jellyfin():
     # Wait for server to be ready
     base_url = "http://localhost:8096"
     timeout = 5
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
         try:
             requests.get(f"{base_url}/Library/VirtualFolders")
             break


### PR DESCRIPTION
## Summary
Replace `time.time()` with `time.monotonic()` in the virtual Jellyfin server startup wait loop in `tests/conftest.py`.

## Motivation
Follow-up to #281. The startup timeout should also be immune to system clock adjustments.

## Non-breaking
Test-only change.

Closes #284