### PR TITLE
chore: remove redundant os.path.exists guard before os.makedirs

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -1346,7 +1346,7 @@ def run_sync(
     if not url or not api_key or not target_base:
         raise ValueError("Server settings or target path not configured")
 
-    if not dry_run and not os.path.exists(target_base):
+    if not dry_run:
         os.makedirs(target_base, exist_ok=True)
 
     logger.info("Starting sync to: %s", target_base)


### PR DESCRIPTION
## Summary
Removes the redundant `os.path.exists` check before `os.makedirs(..., exist_ok=True)` in `sync.py`.

`os.makedirs` with `exist_ok=True` is idempotent — it safely does nothing when the directory already exists, making the preceding `os.path.exists` guard unnecessary.

## Test plan
- [x] Full test suite passes (448 passed, 17 skipped)
- [x] Specific previously-fragile test `test_run_sync_invalid_group` passes

Closes #275