### PR TITLE
fix: copy source before pip install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install dependencies
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
 # Copy application files
 COPY . .
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Create a non-root user for security
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app


### PR DESCRIPTION
## Summary
Fixes the Docker build by copying the application source **before** running `pip install`.

`requirements.txt` contains `-e .`, which tells pip to perform an editable install of the current directory. The previous Dockerfile copied only `requirements.txt` and then ran `pip install` — at that point `pyproject.toml` and the package source were not yet present in the container, so the build would fail.

## Changes
- Move `COPY . .` before `RUN pip install -r requirements.txt`

## Non-breaking
Only affects the Docker build; no application code changes.

Closes #289