### PR TITLE
chore: remove redundant requirements.txt install from CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Run ruff linter
       run: ruff check .
@@ -44,7 +43,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Run standard tests with coverage
       run: |

--- a/.github/workflows/virtual-jellyfin-tests.yml
+++ b/.github/workflows/virtual-jellyfin-tests.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install -r requirements-dev.txt
     - name: Run Virtual Jellyfin Tests
       run: |


### PR DESCRIPTION
## Summary
Removes the redundant `pip install -r requirements.txt` step from all CI workflow jobs that also install `requirements-dev.txt`.

`requirements-dev.txt` begins with `-e .[dev]`, which already installs the package and all its dependencies (including the production ones). The separate `pip install -r requirements.txt` added no value and slightly inflated CI runtimes.

## Changes
- `.github/workflows/test.yml` – removed from both `lint` and `test` jobs
- `.github/workflows/virtual-jellyfin-tests.yml` – removed from `test-virtual` job

Closes #291