### PR TITLE
chore: include pyproject.toml in CI pip cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'requirements-dev.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: Install dependencies

--- a/.github/workflows/virtual-jellyfin-tests.yml
+++ b/.github/workflows/virtual-jellyfin-tests.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'requirements.txt', 'requirements-dev.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.python-version }}-
     - name: Install dependencies


### PR DESCRIPTION
## Summary
Adds `pyproject.toml` to the `hashFiles` expression in both CI workflow cache keys.

The previous cache key only hashed `requirements.txt` and `requirements-dev.txt`. Since both files are thin wrappers around `pyproject.toml` (`-e .` and `-e .[dev]`), updating dependency versions in `pyproject.toml` alone would not invalidate the pip cache, potentially causing stale dependency resolution in CI.

## Changes
- `.github/workflows/test.yml` – adds `pyproject.toml` to cache key
- `.github/workflows/virtual-jellyfin-tests.yml` – adds `pyproject.toml` to cache key

Closes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to optimize dependency caching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->