### PR TITLE
fix: handle null values in test-server config extraction

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -269,8 +269,8 @@ def test_server() -> ResponseReturnValue:
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return _error("Request body must be a JSON object", 400)
-    url: str = str(data.get("jellyfin_url", "")).rstrip("/")
-    api_key: str = str(data.get("api_key", ""))
+    url: str = str(data.get("jellyfin_url") or "").rstrip("/")
+    api_key: str = str(data.get("api_key") or "")
 
     if not url or not api_key:
         return _error("URL and API Key are required", 400)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -211,6 +211,11 @@ def test_test_server_missing_fields(client):
     assert response.status_code == 400
 
 
+def test_test_server_null_fields(client):
+    response = client.post('/api/test-server', json={"jellyfin_url": None, "api_key": None})
+    assert response.status_code == 400
+
+
 @patch('routes.requests.get')
 def test_test_server_exception(mock_get, client):
     mock_get.side_effect = requests.exceptions.ConnectionError("Failed")


### PR DESCRIPTION
## Summary
Fixes a subtle edge case where sending `"jellyfin_url": null` or `"api_key": null` in the JSON body would bypass validation and trigger a confusing downstream connection error.

`dict.get(key, "")` returns the default only when the key is **missing**. If the key exists with value `None`, it returns `None`. `str(None)` produces the truthy string `"None"`, which passed the `if not url` check.

Using `data.get("jellyfin_url") or ""` ensures that `None`, empty string, and any other falsy value are all normalized to `""` before validation.

## Changes
- `routes.py`: normalize null/falsy config values with `or ""`
- `tests/test_routes.py`: add regression test for null fields

## Test plan
- [x] Full test suite passes (449 passed, 17 skipped)
- [x] New regression test `test_test_server_null_fields` passes

Closes #295