### PR TITLE
fix: handle null values in _get_jellyfin_config

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -176,8 +176,8 @@ def _get_jellyfin_config(
     config = load_config()
     if not isinstance(config, dict):
         abort(500, description="Invalid configuration format")
-    url = str(config.get("jellyfin_url", "")).rstrip("/")
-    api_key = str(config.get("api_key", ""))
+    url = str(config.get("jellyfin_url") or "").rstrip("/")
+    api_key = str(config.get("api_key") or "")
     if not url or not api_key:
         abort(400, description=missing_msg)
     return url, api_key

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,6 +10,7 @@ from routes import (
     MAX_B64_SIZE,
     _compute_common_root,
     _fetch_jellyfin_endpoint,
+    _get_jellyfin_config,
     _handle_config_error,
 )
 
@@ -1066,3 +1067,11 @@ def test_compute_common_root_single_match():
 
 def test_compute_common_root_full_match():
     assert _compute_common_root("/a/b/c", "/a/b/c") == (os.sep, os.sep)
+
+
+@patch('routes.load_config')
+def test_get_jellyfin_config_null_values(mock_load_config):
+    mock_load_config.return_value = {"jellyfin_url": None, "api_key": None}
+    with pytest.raises(HTTPException) as excinfo:
+        _get_jellyfin_config()
+    assert excinfo.value.code == 400


### PR DESCRIPTION
## Summary
Fixes a bug in `_get_jellyfin_config()` where `null` values in `config.json` would bypass validation and cause confusing downstream connection errors.

`dict.get(key, "")` only returns the default when the key is **missing**. If the key exists with value `None`, it returns `None`. `str(None)` produces `"None"`, which is truthy and passes the `if not url` check. The app then tries to connect to `None/System/Info`, which fails with a connection error instead of the intended validation error.

Since `_get_jellyfin_config()` is used by 4 route handlers, this bug affected multiple endpoints.

## Changes
- `routes.py`: normalize null/falsy config values with `or ""`
- `tests/test_routes.py`: add regression test for null config values

## Test plan
- [x] Full test suite passes (450 passed, 17 skipped)
- [x] New regression test `test_get_jellyfin_config_null_values` passes

Closes #297