### PR TITLE
fix: handle null values before .strip() in config and request parsing

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -542,7 +542,7 @@ def preview_grouping() -> ResponseReturnValue:
     if not val:
         return _error("Value cannot be empty", 400)
 
-    watch_state = data.get("watch_state", "").strip().lower()
+    watch_state = (data.get("watch_state") or "").strip().lower()
 
     try:
         # Resolve items using the public sync API

--- a/sync.py
+++ b/sync.py
@@ -1165,7 +1165,7 @@ def _process_group(
         A result dict with keys ``"group"``, ``"links"``, optionally ``"error"``,
         and ``"items"`` (the first 100 matches) if *dry_run* is True.
     """
-    group_name: str = group.get("name", "").strip()
+    group_name: str = (group.get("name") or "").strip()
     if not group_name:
         return {"group": "(unnamed)", "links": 0, "error": "Empty group name"}
 
@@ -1372,7 +1372,7 @@ def run_sync(
             logger.info("Skipping invalid group entry: %s", group)
             continue
 
-        name = group.get("name", "").strip()
+        name = (group.get("name") or "").strip()
         if group_names is not None:
             if not name or name not in group_names:
                 continue


### PR DESCRIPTION
## Summary
Fixes three places where `.strip()` was called on the result of `dict.get(key, "")` without guarding against `None`.

`dict.get(key, "")` only returns the default when the key is **missing**. If the key exists with value `None`, it returns `None`. Calling `.strip()` on `None` raises `AttributeError`.

## Changes
- `routes.py:545` – `data.get("watch_state", "").strip().lower()` → `(data.get("watch_state") or "").strip().lower()`
- `sync.py:1168` – `group.get("name", "").strip()` → `(group.get("name") or "").strip()`
- `sync.py:1375` – `group.get("name", "").strip()` → `(group.get("name") or "").strip()`

## Test plan
- [x] Full test suite passes (450 passed, 17 skipped)

Closes #299