### PR TITLE
style: fix ruff B/SIM violations (SIM102, SIM103, B007, SIM210)

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -133,11 +133,13 @@ def _check_csrf() -> ResponseReturnValue | None:
 
 def _is_valid_folder_name(name: str) -> bool:
     """Return True if *name* is a safe, non-empty folder name without path separators."""
-    if not isinstance(name, str) or not name:
-        return False
-    if name in (".", "..") or "/" in name or "\\" in name:
-        return False
-    return True
+    return (
+        isinstance(name, str)
+        and bool(name)
+        and name not in (".", "..")
+        and "/" not in name
+        and "\\" not in name
+    )
 
 
 # Roots that the folder browser is allowed to expose.

--- a/sync.py
+++ b/sync.py
@@ -1004,18 +1004,17 @@ def _auto_create_library(
 
     Mutates *existing_libraries* to prevent double creation in the same run.
     """
-    if not dry_run and auto_create_libraries and links_created > 0:
-        if existing_libraries is not None and group_name not in existing_libraries:
-            logger.info("Creating Jellyfin library for grouping: %r", group_name)
-            lib_path = os.path.join(target_path_in_jellyfin, group_name) if target_path_in_jellyfin else group_dir
+    if not dry_run and auto_create_libraries and links_created > 0 and existing_libraries is not None and group_name not in existing_libraries:
+        logger.info("Creating Jellyfin library for grouping: %r", group_name)
+        lib_path = os.path.join(target_path_in_jellyfin, group_name) if target_path_in_jellyfin else group_dir
 
-            try:
-                add_virtual_folder(url, api_key, group_name, [lib_path], collection_type="mixed")
-                logger.info("Successfully created library %r with path %r", group_name, lib_path)
-                existing_libraries.append(group_name)
-            except (RuntimeError, OSError) as exc:
-                logger.error("Failed to create Jellyfin library %r: %s", group_name, exc)
-                result["library_error"] = str(exc)
+        try:
+            add_virtual_folder(url, api_key, group_name, [lib_path], collection_type="mixed")
+            logger.info("Successfully created library %r with path %r", group_name, lib_path)
+            existing_libraries.append(group_name)
+        except (RuntimeError, OSError) as exc:
+            logger.error("Failed to create Jellyfin library %r: %s", group_name, exc)
+            result["library_error"] = str(exc)
     return result
 
 
@@ -1373,9 +1372,8 @@ def run_sync(
             continue
 
         name = (group.get("name") or "").strip()
-        if group_names is not None:
-            if not name or name not in group_names:
-                continue
+        if group_names is not None and (not name or name not in group_names):
+            continue
 
         # --- Seasonal Check ---
         if group.get("seasonal_enabled"):
@@ -1430,7 +1428,7 @@ def run_cleanup_broken_symlinks(config: dict[str, Any]) -> int:
 
     deleted_count = 0
 
-    for root, dirs, files in os.walk(target_base):
+    for root, _dirs, files in os.walk(target_base):
         for name in files:
             path = os.path.join(root, name)
             if os.path.islink(path) and not os.path.exists(path):

--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -448,7 +448,7 @@ def test_run_sync_with_auto_set_library_covers(
         {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}}
     ]
     # Mock cover existence
-    _mock_exists.side_effect = lambda path: True if path == "/target/CoverGroup_cover.jpg" or path == "/p1" else False
+    _mock_exists.side_effect = lambda path: path in ("/target/CoverGroup_cover.jpg", "/p1")
     _mock_isdir.return_value = True
     mock_get_cover.return_value = "/target/CoverGroup_cover.jpg"
     with patch('sync.fetch_tmdb_list', return_value=["101"]):


### PR DESCRIPTION
Closes #303

Mechanical clean-ups flagged by ruff under the B (bugbear) and SIM (simplify) rule sets:

- **SIM103** – : return the negated condition directly in 
- **SIM102** – : collapse two nested  blocks into single conditions (library creation & group filtering)
- **B007**  – : rename unused ~/Documents/jellyfin-groupings →  in  loop
- **SIM210** – : replace  lambda with a plain  check

All existing tests pass.