### PR TITLE
style: use list comprehension in anilist.py for efficiency

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -71,10 +71,9 @@ def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
     if not collection:
         return []
 
-    ids = []
-    for user_list in collection.get("lists", []):
-        for entry in user_list.get("entries", []):
-            if entry.get("mediaId"):
-                ids.append(entry["mediaId"])
-
-    return ids
+    return [
+        entry["mediaId"]
+        for user_list in collection.get("lists", [])
+        for entry in user_list.get("entries", [])
+        if entry.get("mediaId")
+    ]


### PR DESCRIPTION
Closes #307

Replaces the nested for-loop with  in  with a flat list comprehension. This resolves ruff PERF401 and is slightly more efficient and idiomatic.