### PR TITLE
style: add explicit check=False to subprocess.run

### DIFF
--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -15,7 +15,8 @@ def main() -> None:
                 [sys.executable, '-m', 'pytest', '--cov=.', 'tests/'],
                 stdout=f,
                 stderr=subprocess.STDOUT,
-                timeout=120
+                timeout=120,
+                check=False,
             )
         except (subprocess.TimeoutExpired, OSError) as e:
             f.write(f"\nERROR: {e!s}")


### PR DESCRIPTION
Closes #311

Adds  to the  call in . This resolves ruff PLW1510 and makes the intent explicit: we capture pytest output to a file and do not want to raise on non-zero exit codes.