### PR TITLE
style: fix docstring formatting (D200, D212, RUF002)

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -1,6 +1,4 @@
-"""
-anilist.py – AniList API client for fetching user lists.
-"""
+"""anilist.py - AniList API client for fetching user lists."""
 
 from __future__ import annotations
 
@@ -13,8 +11,7 @@ _REQUEST_TIMEOUT: int = 15
 
 
 def fetch_anilist_list(username: str, status: str | None = None) -> list[int]:
-    """
-    Fetch anime IDs from a user's AniList profile.
+    """Fetch anime IDs from a user's AniList profile.
 
     Args:
         username: The AniList username.

--- a/app.py
+++ b/app.py
@@ -1,17 +1,16 @@
-"""
-app.py – Application entry-point for Jellyfin Groupings.
+"""app.py - Application entry-point for Jellyfin Groupings.
 
 Creates the Flask application, registers the route Blueprint defined in
 :mod:`routes`, and starts the development server when run directly.
 
 The bulk of the application logic lives in the following modules:
 
-* :mod:`config`   – configuration persistence
-* :mod:`imdb`     – IMDb list scraping
-* :mod:`trakt`    – Trakt API list fetching
-* :mod:`jellyfin` – Jellyfin API helpers and sort-order mapping
-* :mod:`sync`     – synchronisation business logic
-* :mod:`routes`   – Flask Blueprint with all HTTP route handlers
+* :mod:`config`   - configuration persistence
+* :mod:`imdb`     - IMDb list scraping
+* :mod:`trakt`    - Trakt API list fetching
+* :mod:`jellyfin` - Jellyfin API helpers and sort-order mapping
+* :mod:`sync`     - synchronisation business logic
+* :mod:`routes`   - Flask Blueprint with all HTTP route handlers
 """
 
 from __future__ import annotations

--- a/config.py
+++ b/config.py
@@ -1,5 +1,4 @@
-"""
-config.py – Configuration persistence helpers.
+"""config.py - Configuration persistence helpers.
 
 Handles loading and saving the application's ``config.json`` file, including
 backwards-compatible key migration and first-run default creation.

--- a/imdb.py
+++ b/imdb.py
@@ -1,5 +1,4 @@
-"""
-imdb.py – IMDb list scraping utilities.
+"""imdb.py - IMDb list scraping utilities.
 
 Provides a single public function for fetching ordered IMDb IDs from a
 public IMDb list page via regex extraction over the rendered HTML.
@@ -48,7 +47,7 @@ def fetch_imdb_list(list_id: str) -> list[str]:
     """
     list_id = list_id.strip()
 
-    # Accept full URLs – extract just the ls-ID
+    # Accept full URLs - extract just the ls-ID
     url_match = re.search(r"ls\d+", list_id)
     if url_match:
         list_id = url_match.group(0)

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -1,5 +1,4 @@
-"""
-jellyfin.py – Jellyfin API client helpers.
+"""jellyfin.py - Jellyfin API client helpers.
 
 Contains the sort-order mapping used across the application and a thin
 convenience wrapper around ``requests.get`` for fetching items from the

--- a/letterboxd.py
+++ b/letterboxd.py
@@ -1,5 +1,4 @@
-"""
-letterboxd.py – Letterboxd list scraping utilities.
+"""letterboxd.py - Letterboxd list scraping utilities.
 
 Provides a single public function for fetching ordered IMDb or TMDb IDs from a
 Letterboxd list by parsing the HTML.

--- a/mal.py
+++ b/mal.py
@@ -1,6 +1,4 @@
-"""
-mal.py – MyAnimeList API client for fetching user lists.
-"""
+"""mal.py - MyAnimeList API client for fetching user lists."""
 
 from __future__ import annotations
 
@@ -15,8 +13,7 @@ _REQUEST_TIMEOUT: int = 15
 
 
 def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> list[int]:
-    """
-    Fetch anime IDs from a user's MyAnimeList profile.
+    """Fetch anime IDs from a user's MyAnimeList profile.
 
     Args:
         username: The MAL username.

--- a/network.py
+++ b/network.py
@@ -1,5 +1,4 @@
-"""
-network.py – Retry-aware HTTP for external API calls.
+"""network.py - Retry-aware HTTP for external API calls.
 
 Importing this module monkey-patches ``requests.get``, ``requests.post``, and
 ``requests.delete`` to use a shared :class:`requests.Session` configured with

--- a/parse_test.py
+++ b/parse_test.py
@@ -1,6 +1,4 @@
-"""
-parse_test.py - Unit tests for complex query parsing.
-"""
+"""parse_test.py - Unit tests for complex query parsing."""
 
 import logging
 

--- a/routes.py
+++ b/routes.py
@@ -1,5 +1,4 @@
-"""
-routes.py – Flask Blueprint containing all HTTP route handlers.
+"""routes.py - Flask Blueprint containing all HTTP route handlers.
 
 Every route is registered on the ``bp`` Blueprint which is imported and
 registered with the Flask application in ``app.py``.  Route handlers are

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,5 +1,4 @@
-"""
-scheduler.py – Background scheduling for Jellyfin Groupings.
+"""scheduler.py - Background scheduling for Jellyfin Groupings.
 
 Manages a BackgroundScheduler that triggers library synchronisation according
 to either a global schedule (with exclusions) or per-group schedules.

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Helper script to run the virtual Jellyfin mock server for development and testing.
+"""Helper script to run the virtual Jellyfin mock server for development and testing.
 Provides a dashboard at http://localhost:8096
 """
 

--- a/sync.py
+++ b/sync.py
@@ -1,5 +1,4 @@
-"""
-sync.py – Core synchronisation logic for Jellyfin Groupings.
+"""sync.py - Core synchronisation logic for Jellyfin Groupings.
 
 This module contains :func:`run_sync`, which drives the per-group loop
 responsible for:
@@ -326,7 +325,7 @@ def _sort_items_in_memory(
     reverse = sort_dir_str.split(",")[0] == "Descending"
 
     def _key(item: dict[str, Any]) -> tuple[int, Any]:
-        """Sorting key – pushes items missing the field to the end.
+        """Sorting key - pushes items missing the field to the end.
 
         The *missing* component is set so that tuples for absent values are
         always larger than tuples for present values, regardless of whether
@@ -395,7 +394,7 @@ def _fetch_items_for_imdb_group(
     api_key: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for an IMDb-list–backed group."""
+    """Resolve Jellyfin items for an IMDb-list-backed group."""
     return _fetch_and_resolve(
         group_name,
         lambda: fetch_imdb_list(source_value),
@@ -419,7 +418,7 @@ def _fetch_items_for_trakt_group(
     trakt_client_id: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for a Trakt-list–backed group."""
+    """Resolve Jellyfin items for a Trakt-list-backed group."""
     if not trakt_client_id:
         msg = "Trakt Client ID not set — add trakt_client_id in Server Settings"
         logger.info("No Trakt Client ID configured for group %r", group_name)
@@ -448,7 +447,7 @@ def _fetch_items_for_tmdb_group(
     tmdb_api_key: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for a TMDb-list–backed group."""
+    """Resolve Jellyfin items for a TMDb-list-backed group."""
     if not tmdb_api_key:
         msg = "TMDb API Key not set — add tmdb_api_key in Server Settings"
         logger.info("No TMDb API Key configured for group %r", group_name)
@@ -476,7 +475,7 @@ def _fetch_items_for_anilist_group(
     api_key: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for an AniList-list–backed group."""
+    """Resolve Jellyfin items for an AniList-list-backed group."""
     username = source_value
     status = None
     if "/" in source_value:
@@ -505,7 +504,7 @@ def _fetch_items_for_mal_group(
     mal_client_id: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for a MyAnimeList-list–backed group."""
+    """Resolve Jellyfin items for a MyAnimeList-list-backed group."""
     if not mal_client_id:
         msg = "MyAnimeList Client ID not set — add mal_client_id in Server Settings"
         logger.info("No MAL Client ID configured for group %r", group_name)
@@ -538,7 +537,7 @@ def _fetch_items_for_letterboxd_group(
     api_key: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for a Letterboxd-list–backed group.
+    """Resolve Jellyfin items for a Letterboxd-list-backed group.
 
     Args:
         group_name: Human-readable group name (used for logging).
@@ -815,7 +814,7 @@ def _fetch_items_for_metadata_group(
     api_key: str,
     watch_state: str = "",
 ) -> tuple[list[dict[str, Any]], str | None, int]:
-    """Resolve Jellyfin items for a metadata-filter–backed group.
+    """Resolve Jellyfin items for a metadata-filter-backed group.
 
     Handles ``genre``, ``actor``, ``studio``, ``tag``, and unfiltered
     (general) groups.  Sorting is applied server-side via Jellyfin query

--- a/tmdb.py
+++ b/tmdb.py
@@ -1,5 +1,4 @@
-"""
-tmdb.py – TMDb API list fetching utilities.
+"""tmdb.py - TMDb API list fetching utilities.
 
 Provides a single public function for fetching TMDb IDs from a
 TMDb v3 list.

--- a/trakt.py
+++ b/trakt.py
@@ -1,5 +1,4 @@
-"""
-trakt.py – Trakt API list fetching utilities.
+"""trakt.py - Trakt API list fetching utilities.
 
 Provides a single public function for fetching ordered IMDb IDs from a
 Trakt list via the official Trakt v2 API.


### PR DESCRIPTION
Closes #315

Mechanical docstring clean-ups across 15 files:

- **D200** – collapse 3 module docstrings into proper one-liners
- **D212** – move summary to first line in 17 multi-line docstrings  
- **RUF002** – replace 28 en dashes with hyphens in docstrings

No functional changes.