### PR TITLE
style: add request timeouts and noqa markers for S113

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -96,7 +96,7 @@ def _get_json(
     if params is not None:
         kwargs["params"] = params
     try:
-        response = requests.get(url, **kwargs)
+        response = requests.get(url, **kwargs)  # noqa: S113
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         _raise_request_error(exc, f"Failed to GET {url}")
@@ -131,9 +131,9 @@ def _request_or_raise(
         kwargs["json"] = json
     try:
         if method == "POST":
-            response = requests.post(url, **kwargs)
+            response = requests.post(url, **kwargs)  # noqa: S113
         elif method == "DELETE":
-            response = requests.delete(url, **kwargs)
+            response = requests.delete(url, **kwargs)  # noqa: S113
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
         response.raise_for_status()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def virtual_jellyfin():
     start_time = time.monotonic()
     while time.monotonic() - start_time < timeout:
         try:
-            requests.get(f"{base_url}/Library/VirtualFolders")
+            requests.get(f"{base_url}/Library/VirtualFolders", timeout=1)
             break
         except requests.exceptions.ConnectionError:
             time.sleep(0.1)

--- a/tests/test_deep_sync.py
+++ b/tests/test_deep_sync.py
@@ -18,7 +18,7 @@ def mock_filesystem():
 
 def test_mock_server_up(virtual_jellyfin):
     """Verify the mock server is actually reachable."""
-    response = requests.get(f"{virtual_jellyfin}/System/Info")
+    response = requests.get(f"{virtual_jellyfin}/System/Info", timeout=5)
     assert response.status_code == 200
     assert response.json()["ServerName"] == "Virtual-Jellyfin-Mock"
 


### PR DESCRIPTION
Closes #321

Resolves ruff S113 (requests without timeout):

- jellyfin.py: add  to calls where timeout is already passed via kwargs (false positives)
- tests/conftest.py: add  to virtual-server polling loop
- tests/test_deep_sync.py: add  to mock-server health check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved HTTP request reliability by adding explicit timeouts to ensure tests don't block indefinitely
  * Enhanced code quality standards across the codebase

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->