### PR TITLE
style: fix docstring formatting (D205, D401, D417)

### DIFF
--- a/network.py
+++ b/network.py
@@ -56,8 +56,11 @@ _original_delete = requests.delete
 
 
 def _reraise_timeout(exc: requests.ConnectionError) -> None:
-    """If *exc* wraps a read-timeout from the retry adapter, re-raise as
-    :class:`requests.Timeout` so callers see the expected exception type."""
+    """Re-raise a retry timeout as :class:`requests.Timeout`.
+
+    If *exc* wraps a read-timeout from the retry adapter, re-raise it so callers
+    see the expected exception type.
+    """
     inner = exc.args[0] if exc.args else None
     if not isinstance(inner, MaxRetryError):
         return

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Helper script to run the virtual Jellyfin mock server for development and testing.
-Provides a dashboard at http://localhost:8096
+
+Provides a dashboard at http://localhost:8096.
 """
 
 import logging

--- a/sync.py
+++ b/sync.py
@@ -938,6 +938,7 @@ def preview_group(
         val: The filter value or complex query string.
         url: Jellyfin base URL.
         api_key: Jellyfin API key.
+        watch_state: Optional watch-state filter (watched, unwatched).
 
     Returns:
         A ``(items, error, status_code)`` tuple.
@@ -1174,6 +1175,10 @@ def _process_group(
         tmdb_api_key: TMDb API Key (may be empty).
         mal_client_id: MyAnimeList Client ID (may be empty).
         dry_run: If True, do not create directories or symlinks; return matches.
+        auto_create_libraries: Whether to auto-create Jellyfin libraries.
+        auto_set_library_covers: Whether to set library cover images.
+        existing_libraries: List of libraries already created this run.
+        target_path_in_jellyfin: Path prefix for Jellyfin library paths.
 
     Returns:
         A result dict with keys ``"group"``, ``"links"``, optionally ``"error"``,
@@ -1294,6 +1299,7 @@ def _process_group(
 
 def _is_in_season(start_str: Any, end_str: Any) -> bool:
     """Check if the current date is within the seasonal window [start, end).
+
     Dates are in 'MM-DD' format.
     """
     if not isinstance(start_str, str) or not isinstance(end_str, str):

--- a/tests/test_e2e/conftest.py
+++ b/tests/test_e2e/conftest.py
@@ -101,14 +101,14 @@ def e2e_session(e2e_app_url, e2e_jellyfin_url, e2e_api_key):
 
 
 def api_post(session, path, data=None):
-    """Helper to POST to the app API."""
+    """POST to the app API."""
     url = f"{session['app_url']}{path}"
     resp = requests.post(url, json=data or {}, timeout=10)
     return resp.json()
 
 
 def api_get(session, path):
-    """Helper to GET from the app API."""
+    """GET from the app API."""
     url = f"{session['app_url']}{path}"
     resp = requests.get(url, timeout=10)
     return resp.json()

--- a/tests/test_metadata_rules.py
+++ b/tests/test_metadata_rules.py
@@ -1,4 +1,5 @@
 """Tests for metadata rule parsing used in grouping filters.
+
 The JS frontend parses filter strings like "Horror AND Action AND NOT Comedy".
 These tests verify the Python-side logic for parsing and filtering rules.
 """


### PR DESCRIPTION
Closes #329

Fixes 8 docstring issues flagged by ruff:

- **D205** – add blank lines between summary and description (network.py, start_virtual_jellyfin.py, sync.py, test_metadata_rules.py)
- **D401** – reword helpers to use imperative mood (test_e2e/conftest.py)
- **D417** – add missing argument descriptions (sync.py preview_group, _process_group)