### PR TITLE
style: use datetime.UTC alias (UP017)

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -18,7 +18,7 @@ import re
 import shutil
 import threading
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -1307,7 +1307,7 @@ def _is_in_season(start_str: Any, end_str: Any) -> bool:
     if not isinstance(start_str, str) or not isinstance(end_str, str):
         return True
 
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
     current_md = now.strftime("%m-%d")
 
     s: str = start_str


### PR DESCRIPTION
Closes #335

Replace timezone.utc with the UTC alias introduced in Python 3.11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timezone consistency in seasonal date evaluation to ensure the current date is correctly assessed against the configured seasonal window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->