### PR TITLE
chore: enable additional ruff lint rules (B, SIM, C4, RET)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "PTH"]
+extend-select = ["I", "PTH", "B", "SIM", "C4", "RET"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Closes #336

Enable bugbear, simplify, comprehensions, and return-statement rules to prevent regressions. No code changes required.