### PR TITLE
chore: replace for-loop with list comprehension and enable PERF ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "PTH", "B", "SIM", "C4", "RET"]
+extend-select = ["I", "PTH", "B", "SIM", "C4", "RET", "PERF"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/routes.py
+++ b/routes.py
@@ -591,13 +591,11 @@ def get_cleanup_items() -> ResponseReturnValue:
     configured_groups: set[str] = {str(g.get("name")) for g in config.get("groups", []) if g.get("name")}
 
     try:
-        entries: list[dict[str, Any]] = []
-        for entry in Path(target_base).iterdir():
-            if entry.is_dir() and not entry.name.startswith("."):
-                entries.append({
-                    "name": entry.name,
-                    "is_configured": entry.name in configured_groups,
-                })
+        entries = [
+            {"name": entry.name, "is_configured": entry.name in configured_groups}
+            for entry in Path(target_base).iterdir()
+            if entry.is_dir() and not entry.name.startswith(".")
+        ]
         return _success("", items=sorted(entries, key=lambda x: str(x["name"])))
     except OSError as exc:
         return _error(str(exc), 500)


### PR DESCRIPTION
## Summary
- Convert the for-loop that builds `entries` in `get_cleanup_items()` to a list comprehension (PERF401)
- Add `PERF` to `[tool.ruff.lint] extend-select` so future regressions are caught automatically

## Test plan
- [x] All 452 tests pass locally
- [x] `ruff check .` is clean with the new rule enabled
- [x] No behavioural changes (same filter logic, same output shape)

Closes #338