### PR TITLE
chore: move return statements into else blocks after try/except (TRY300)

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -139,9 +139,10 @@ def _request_or_raise(
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
         response.raise_for_status()
-        return response
     except requests.exceptions.RequestException as exc:
         _raise_request_error(exc, error_prefix)
+    else:
+        return response
 
 
 def _post_or_raise(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY400"]
+extend-select = ["I", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sync.py
+++ b/sync.py
@@ -248,10 +248,11 @@ def _fetch_full_library(
         logger.info("Jellyfin library: %s items fetched for matching", len(all_items))
         with _LIBRARY_CACHE_LOCK:
             _LIBRARY_CACHE[cache_key] = all_items
-        return all_items, None, 200
     except (RuntimeError, OSError, ValueError) as exc:
         logger.exception("Infrastructure error fetching Jellyfin library for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
+    else:
+        return all_items, None, 200
 
 
 def _match_jellyfin_items_by_provider(
@@ -873,10 +874,11 @@ def _fetch_items_for_metadata_group(
     try:
         items = fetch_jellyfin_items(url, api_key, params, timeout=_METADATA_FETCH_TIMEOUT)
         logger.info("Found %s potential items for group %r", len(items), group_name)
-        return items, None, 200
     except (RuntimeError, OSError, ValueError) as exc:
         logger.exception("Infrastructure error fetching items for group %r: %s", group_name, exc)
         return [], f"Jellyfin connection error: {exc!s}", 500
+    else:
+        return items, None, 200
 
 
 def parse_complex_query(query: str, default_type: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Move `return` statements that follow `try` blocks into `else` blocks in `jellyfin.py` and `sync.py`
- TRY300 prefers `else` for code that only runs when no exception was raised, making control flow clearer
- Add `TRY300` to `[tool.ruff.lint] extend-select`

## Files changed
- `jellyfin.py`: 1 fix
- `sync.py`: 2 fixes

## Test plan
- [x] All 452 tests pass locally
- [x] `ruff check .` is clean with the new rule enabled
- [x] No behavioural changes

Closes #344