### PR TITLE
chore: remove unused noqa: S113 directives

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -98,7 +98,7 @@ def _get_json(
     if params is not None:
         kwargs["params"] = params
     try:
-        response = requests.get(url, **kwargs)  # noqa: S113
+        response = requests.get(url, **kwargs)
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         _raise_request_error(exc, f"Failed to GET {url}")
@@ -133,9 +133,9 @@ def _request_or_raise(
         kwargs["json"] = json
     try:
         if method == "POST":
-            response = requests.post(url, **kwargs)  # noqa: S113
+            response = requests.post(url, **kwargs)
         elif method == "DELETE":
-            response = requests.delete(url, **kwargs)  # noqa: S113
+            response = requests.delete(url, **kwargs)
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
         response.raise_for_status()


### PR DESCRIPTION
## Summary
- Remove 3 unused `# noqa: S113` directives from `jellyfin.py`
- The S113 rule (requests-without-timeout) is not enabled in the project's ruff configuration, making these no-ops
- Reduces visual clutter and RUF100 noise

## Test plan
- [x] All 452 tests pass locally
- [x] `ruff check .` is clean