### PR TITLE
chore: add F401 to ruff extend-select to silence RUF100 false positive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400"]
+extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
## Summary
- Explicitly add `F401` to `[tool.ruff.lint] extend-select`
- F401 is already part of ruff's default select, but listing it explicitly makes RUF100 recognize the `noqa: F401` directive in `app.py` as valid
- This removes the only remaining RUF100 violation in the codebase

## Test plan
- [x] All 452 tests pass locally
- [x] `ruff check .` is completely clean (including RUF100)