### PR TITLE
style: fix single quotes to double quotes (Q000)

### DIFF
--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -5,15 +5,15 @@ from pathlib import Path
 
 
 def main() -> None:
-    existing = os.environ.get('PYTHONPATH')
-    os.environ['PYTHONPATH'] = f"{existing}:." if existing else "."
-    with Path('test_results.txt').open('w', encoding='utf-8') as f:
+    existing = os.environ.get("PYTHONPATH")
+    os.environ["PYTHONPATH"] = f"{existing}:." if existing else "."
+    with Path("test_results.txt").open("w", encoding="utf-8") as f:
         try:
             # Running all tests with coverage
             f.write("Starting test run...\n")
             f.flush()
             subprocess.run(
-                [sys.executable, '-m', 'pytest', '--cov=.', 'tests/'],
+                [sys.executable, "-m", "pytest", "--cov=.", "tests/"],
                 stdout=f,
                 stderr=subprocess.STDOUT,
                 timeout=120,

--- a/sync.py
+++ b/sync.py
@@ -1078,7 +1078,7 @@ def _create_group_symlinks(
 
         source_path: str | None = item.get("Path")
         if not source_path or not isinstance(source_path, str):
-            logger.info("Item %s has no valid Path — skipping", item.get('Id'))
+            logger.info("Item %s has no valid Path — skipping", item.get("Id"))
             continue
 
         host_path = _translate_path(source_path, jellyfin_root, host_root)


### PR DESCRIPTION
## Summary
- Replace single quotes with double quotes in `run_tests_to_file.py` and `sync.py` to match project style

## Test plan
- [x] All 452 tests pass locally
- [x] `ruff check .` is clean