### PR TITLE
style: fix EM102 f-string literal violations in exception constructors

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -137,7 +137,8 @@ def _request_or_raise(
         elif method == "DELETE":
             response = requests.delete(url, **kwargs)
         else:
-            raise ValueError(f"Unsupported HTTP method: {method}")
+            msg = f"Unsupported HTTP method: {method}"
+            raise ValueError(msg)
         response.raise_for_status()
     except requests.exceptions.RequestException as exc:
         _raise_request_error(exc, error_prefix)
@@ -626,7 +627,8 @@ def create_collection(
     )
     collection_id: str | None = data.get("Id")
     if not collection_id:
-        raise RuntimeError(f"Collection created but no Id returned for {name!r}")
+        msg = f"Collection created but no Id returned for {name!r}"
+        raise RuntimeError(msg)
     return collection_id
 
 

--- a/letterboxd.py
+++ b/letterboxd.py
@@ -159,7 +159,8 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
     """
     list_url = list_url.rstrip("/")
     if "letterboxd.com" not in list_url:
-        raise ValueError(f"Invalid Letterboxd URL: {list_url!r}")
+        msg = f"Invalid Letterboxd URL: {list_url!r}"
+        raise ValueError(msg)
 
     ids: list[str] = []
     seen_ids: set[str] = set()
@@ -174,7 +175,8 @@ def fetch_letterboxd_list(list_url: str) -> list[str]:
                 break
             resp.raise_for_status()
         except requests.exceptions.RequestException as exc:
-            raise RuntimeError(f"Failed to fetch Letterboxd list page {page}: {exc}") from exc
+            msg = f"Failed to fetch Letterboxd list page {page}: {exc}"
+            raise RuntimeError(msg) from exc
 
         html = resp.text
 

--- a/tmdb.py
+++ b/tmdb.py
@@ -99,7 +99,8 @@ def get_tmdb_recommendations(items_with_type: list[tuple[str, str]], api_key: st
 
     """
     if not api_key:
-        raise ValueError("A TMDb API Key is required to fetch TMDb recommendations.")
+        msg = "A TMDb API Key is required to fetch TMDb recommendations."
+        raise ValueError(msg)
 
     recommendation_counts: dict[str, float] = {}
 


### PR DESCRIPTION
## Summary
- Assign f-string messages to variables before passing to exception constructors
- Fixes EM102 violations in `jellyfin.py` and `letterboxd.py`

## Test plan
- [x] All 452 tests pass locally
- [x] `ruff check .` is clean