### PR TITLE
chore: fix remaining EM101/EM102 violations and enable EM in ruff

### DIFF
--- a/imdb.py
+++ b/imdb.py
@@ -54,9 +54,10 @@ def fetch_imdb_list(list_id: str) -> list[str]:
         list_id = url_match.group(0)
 
     if not list_id.startswith("ls"):
-        raise ValueError(
-            f"Invalid IMDb list ID: {list_id!r}. Expected format: ls000024390",
+        msg = (
+            f"Invalid IMDb list ID: {list_id!r}. Expected format: ls000024390"
         )
+        raise ValueError(msg)
 
     ids: list[str] = []
     page: int = 1
@@ -75,7 +76,8 @@ def fetch_imdb_list(list_id: str) -> list[str]:
             resp.raise_for_status()
         except requests.exceptions.RequestException as exc:
             logger.exception("HTTP error fetching IMDb list page %d: %s", page, exc)
-            raise RuntimeError(f"Failed to fetch IMDb list page {page}: {exc}") from exc
+            msg = f"Failed to fetch IMDb list page {page}: {exc}"
+            raise RuntimeError(msg) from exc
 
         html: str = resp.text
 

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -74,9 +74,8 @@ def _parse_json(response: requests.Response) -> Any:
         return response.json()
     except requests.exceptions.JSONDecodeError as exc:
         snippet = response.text[:200]
-        raise RuntimeError(
-            f"Invalid JSON response (status {response.status_code}): {snippet}",
-        ) from exc
+        msg = f"Invalid JSON response (status {response.status_code}): {snippet}"
+        raise RuntimeError(msg) from exc
 
 
 def _get_json(

--- a/mal.py
+++ b/mal.py
@@ -44,7 +44,8 @@ def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> 
 
     """
     if not client_id:
-        raise ValueError("MyAnimeList Client ID is required.")
+        msg = "MyAnimeList Client ID is required."
+        raise ValueError(msg)
 
     normalized_status = _normalize_mal_status(status)
 

--- a/network.py
+++ b/network.py
@@ -67,7 +67,8 @@ def _reraise_timeout(exc: requests.ConnectionError) -> None:
 
     reason = getattr(inner, "reason", None)
     if isinstance(reason, ReadTimeoutError):
-        raise requests.Timeout("Read timed out.") from reason
+        msg = "Read timed out."
+        raise requests.Timeout(msg) from reason
 
 
 def _patched_get(url, **kwargs) -> requests.Response:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400"]
+extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400", "EM"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sync.py
+++ b/sync.py
@@ -1370,7 +1370,8 @@ def run_sync(
     target_path_in_jellyfin: str = str(config.get("target_path_in_jellyfin") or "").strip()
 
     if not url or not api_key or not target_base:
-        raise ValueError("Server settings or target path not configured")
+        msg = "Server settings or target path not configured"
+        raise ValueError(msg)
 
     if not dry_run:
         Path(target_base).mkdir(parents=True, exist_ok=True)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1543,7 +1543,8 @@ def test_fetch_items_complex_group_malformed_rule(mock_lib):
     # Create a dict whose operator value raises AttributeError during str()
     class BadStr:
         def __str__(self):
-            raise AttributeError("boom")
+            err = "boom"
+            raise AttributeError(err)
 
     class BadRule(dict):
         def get(self, key, default=None):

--- a/tmdb.py
+++ b/tmdb.py
@@ -35,9 +35,11 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
 
     """
     if not api_key:
-        raise ValueError("A TMDb API Key is required to fetch TMDb lists.")
+        msg = "A TMDb API Key is required to fetch TMDb lists."
+        raise ValueError(msg)
     if not list_id:
-        raise ValueError("A TMDb List ID is required.")
+        msg = "A TMDb List ID is required."
+        raise ValueError(msg)
 
     list_id = list_id.strip()
 
@@ -61,9 +63,8 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
             resp = requests.get(url, params=params, timeout=15)
             resp.raise_for_status()
         except requests.exceptions.RequestException as exc:
-            raise RuntimeError(
-                f"Failed to fetch TMDb list page {page}: {exc}",
-            ) from exc
+            msg = f"Failed to fetch TMDb list page {page}: {exc}"
+            raise RuntimeError(msg) from exc
 
         data: dict[str, Any] = resp.json()
         items: list[dict[str, Any]] = data.get("items", [])

--- a/trakt.py
+++ b/trakt.py
@@ -45,9 +45,10 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
 
     """
     if not client_id:
-        raise ValueError(
-            "A Trakt API Client ID (trakt_client_id) is required to fetch Trakt lists.",
+        msg = (
+            "A Trakt API Client ID (trakt_client_id) is required to fetch Trakt lists."
         )
+        raise ValueError(msg)
 
     list_url = list_url.strip()
 
@@ -63,10 +64,11 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
     elif "/" in list_url and not list_url.startswith("http"):
         username, list_slug = list_url.split("/", 1)
     else:
-        raise ValueError(
+        msg = (
             f"Invalid Trakt list URL: {list_url!r}. "
-            "Expected format: https://trakt.tv/users/username/lists/list-slug",
+            "Expected format: https://trakt.tv/users/username/lists/list-slug"
         )
+        raise ValueError(msg)
 
     headers: dict[str, str] = {
         "trakt-api-key": client_id,
@@ -86,9 +88,8 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
             resp = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
             resp.raise_for_status()
         except requests.exceptions.RequestException as exc:
-            raise RuntimeError(
-                f"Failed to fetch Trakt list page {page}: {exc}",
-            ) from exc
+            msg = f"Failed to fetch Trakt list page {page}: {exc}"
+            raise RuntimeError(msg) from exc
 
         items: list[dict[str, Any]] = resp.json()
         if not items:


### PR DESCRIPTION
Closes #357

Assign exception messages to variables before raising to satisfy EM101 (raw-string-in-exception) and EM102 (f-string-in-exception) across the codebase.

Also adds EM to ruff extend-select to prevent future regressions.