### PR TITLE
chore: fix TRY401 redundant exc in logger.exception and RUF034 useless if-else

### DIFF
--- a/imdb.py
+++ b/imdb.py
@@ -75,7 +75,7 @@ def fetch_imdb_list(list_id: str) -> list[str]:
             )
             resp.raise_for_status()
         except requests.exceptions.RequestException as exc:
-            logger.exception("HTTP error fetching IMDb list page %d: %s", page, exc)
+            logger.exception("HTTP error fetching IMDb list page %d", page)
             msg = f"Failed to fetch IMDb list page {page}: {exc}"
             raise RuntimeError(msg) from exc
 

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -582,8 +582,8 @@ def set_virtual_folder_image(
         _upload_image(base_url, api_key, library_id, image_path, timeout=timeout)
     except RuntimeError as exc:
         logger.info(str(exc))
-    except OSError as exc:
-        logger.exception("Cannot set image: Failed to read image file %r: %s", image_path, exc)
+    except OSError:
+        logger.exception("Cannot set image: Failed to read image file %r", image_path)
     else:
         logger.info("Successfully updated cover image for library %r", name)
 
@@ -778,7 +778,7 @@ def set_collection_image(
         _upload_image(base_url, api_key, collection_id, image_path, timeout=timeout)
     except RuntimeError as exc:
         logger.info(str(exc))
-    except OSError as exc:
-        logger.exception("Cannot set collection image: Failed to read %r: %s", image_path, exc)
+    except OSError:
+        logger.exception("Cannot set collection image: Failed to read %r", image_path)
     else:
         logger.info("Successfully updated cover image for collection %r", collection_id)

--- a/mal.py
+++ b/mal.py
@@ -27,7 +27,7 @@ def _normalize_mal_status(status: str | None) -> str | None:
         "paused": "on_hold",
         "all": None,
     }
-    return mapping.get(s, s if s in _VALID_MAL_STATUSES else s)
+    return mapping.get(s, s)
 
 
 def fetch_mal_list(username: str, client_id: str, status: str | None = None) -> list[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400", "EM"]
+extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400", "EM", "TRY401"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/sync.py
+++ b/sync.py
@@ -249,7 +249,7 @@ def _fetch_full_library(
         with _LIBRARY_CACHE_LOCK:
             _LIBRARY_CACHE[cache_key] = all_items
     except (RuntimeError, OSError, ValueError) as exc:
-        logger.exception("Infrastructure error fetching Jellyfin library for group %r: %s", group_name, exc)
+        logger.exception("Infrastructure error fetching Jellyfin library for group %r", group_name)
         return [], f"Jellyfin connection error: {exc!s}", 500
     else:
         return all_items, None, 200
@@ -386,7 +386,7 @@ def _fetch_and_resolve(
         external_ids = fetch_fn()
         logger.info(log_msg_fn(len(external_ids)))
     except (requests.exceptions.RequestException, RuntimeError, ValueError) as exc:
-        logger.exception("Error fetching %s list for group %r: %s", source_label, group_name, exc)
+        logger.exception("Error fetching %s list for group %r", source_label, group_name)
         return [], f"{source_label} fetch error: {exc!s}", 400
 
     if not external_ids:
@@ -568,7 +568,7 @@ def _fetch_items_for_letterboxd_group(
         external_ids = fetch_letterboxd_list(source_value)
         logger.info("Letterboxd list %r: %s IDs found", source_value, len(external_ids))
     except (requests.exceptions.RequestException, RuntimeError, ValueError) as exc:
-        logger.exception("Error fetching Letterboxd items for group %r: %s", group_name, exc)
+        logger.exception("Error fetching Letterboxd items for group %r", group_name)
         return [], f"Letterboxd fetch error: {exc!s}", 400
 
     if not external_ids:
@@ -674,7 +674,7 @@ def _fetch_items_for_recommendations_group(
         tmdb_ids = get_tmdb_recommendations(tmdb_requests, tmdb_api_key)
         logger.info("TMDb recommendations: %s items found", len(tmdb_ids))
     except (requests.exceptions.RequestException, RuntimeError, ValueError) as exc:
-        logger.exception("Error fetching recommendations for group %r: %s", group_name, exc)
+        logger.exception("Error fetching recommendations for group %r", group_name)
         return [], f"Recommendations fetch error: {exc!s}", 400
 
     if not tmdb_ids:
@@ -875,7 +875,7 @@ def _fetch_items_for_metadata_group(
         items = fetch_jellyfin_items(url, api_key, params, timeout=_METADATA_FETCH_TIMEOUT)
         logger.info("Found %s potential items for group %r", len(items), group_name)
     except (RuntimeError, OSError, ValueError) as exc:
-        logger.exception("Infrastructure error fetching items for group %r: %s", group_name, exc)
+        logger.exception("Infrastructure error fetching items for group %r", group_name)
         return [], f"Jellyfin connection error: {exc!s}", 500
     else:
         return items, None, 200
@@ -1002,8 +1002,8 @@ def _process_collection_group(
         if source_cover and Path(source_cover).exists():
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
-            except OSError as exc:
-                logger.exception("Failed to set collection image for %r: %s", group_name, exc)
+            except OSError:
+                logger.exception("Failed to set collection image for %r", group_name)
 
     return result
 
@@ -1033,7 +1033,7 @@ def _auto_create_library(
             logger.info("Successfully created library %r with path %r", group_name, lib_path)
             existing_libraries.append(group_name)
         except (RuntimeError, OSError) as exc:
-            logger.exception("Failed to create Jellyfin library %r: %s", group_name, exc)
+            logger.exception("Failed to create Jellyfin library %r", group_name)
             result["library_error"] = str(exc)
     return result
 
@@ -1103,8 +1103,8 @@ def _create_group_symlinks(
                 Path(dest_path).symlink_to(host_path)
                 logger.info("Created symlink: %s -> %s", dest_path, host_path)
                 links_created += 1
-            except OSError as exc:
-                logger.exception("Error creating symlink %s: %s", dest_path, exc)
+            except OSError:
+                logger.exception("Error creating symlink %s", dest_path)
 
     if dry_run:
         logger.info("Would create %s symlinks for %r", links_created, group_name)
@@ -1134,7 +1134,7 @@ def _prepare_group_directory(
                 shutil.rmtree(group_dir)
             Path(group_dir).mkdir(parents=True, exist_ok=True)
         except OSError as exc:
-            logger.exception("Failed to prepare group directory %r: %s", group_dir, exc)
+            logger.exception("Failed to prepare group directory %r", group_dir)
             return {"group": group_name, "links": 0, "error": f"Directory error: {exc!s}"}
 
         source_cover = _get_cover_path(group_name, target_base)
@@ -1143,8 +1143,8 @@ def _prepare_group_directory(
             try:
                 shutil.copy2(source_cover, poster_dest)
                 logger.info("Copied cover image from %s to %s", source_cover, poster_dest)
-            except OSError as exc:
-                logger.exception("Failed to copy cover image: %s", exc)
+            except OSError:
+                logger.exception("Failed to copy cover image")
 
     return source_cover or ""
 
@@ -1466,7 +1466,7 @@ def run_cleanup_broken_symlinks(config: dict[str, Any]) -> int:
                     path.unlink()
                     logger.info("Deleted broken symlink: %s", path)
                     deleted_count += 1
-                except OSError as exc:
-                    logger.exception("Error deleting broken symlink %s: %s", path, exc)
+                except OSError:
+                    logger.exception("Error deleting broken symlink %s", path)
 
     return deleted_count

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -351,7 +351,7 @@ def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
     with patch('builtins.open', side_effect=OSError("Permission Denied")):
         set_virtual_folder_image(TEST_URL, TEST_KEY, "MyLib", "/path/to/img.jpg")
 
-    assert "Cannot set image: Failed to read image file '/path/to/img.jpg': Permission Denied" in caplog.text
+    assert "Cannot set image: Failed to read image file '/path/to/img.jpg'" in caplog.text
 
 
 @patch('mimetypes.guess_type')
@@ -666,7 +666,7 @@ def test_set_collection_image_os_error(mock_open, caplog):
     mock_open.side_effect = OSError("Permission denied")
 
     set_collection_image(TEST_URL, TEST_KEY, "col_1", "/bad/path.jpg")
-    assert "Cannot set collection image: Failed to read '/bad/path.jpg': Permission denied" in caplog.text
+    assert "Cannot set collection image: Failed to read '/bad/path.jpg'" in caplog.text
 
 
 @patch('mimetypes.guess_type')


### PR DESCRIPTION
Closes #359

Removes redundant exception objects from `logger.exception()` calls (TRY401).
`logging.exception()` already includes the full traceback, so passing `exc`
to the message string is unnecessary and clutters logs.

Also fixes the single RUF034 (useless-if-else) violation in `mal.py`.

Adds TRY401 to ruff extend-select to prevent regressions.