### PR TITLE
refactor: extract helpers to reduce update_scheduler_jobs complexity

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import Any
 
 from apscheduler.schedulers.background import (
     BackgroundScheduler,  # type: ignore[import-untyped]
@@ -31,44 +32,39 @@ def start_scheduler() -> None:
     update_scheduler_jobs()
 
 
-def update_scheduler_jobs() -> None:
-    """Synchronise the scheduled jobs with the current configuration."""
-    _scheduler.remove_all_jobs()
+def _schedule_global_sync(scheduler: BackgroundScheduler, sched_cfg: dict[str, Any]) -> None:
+    """Add the global sync job if enabled."""
+    if not sched_cfg.get("global_enabled"):
+        return
+    cron_expr = sched_cfg.get("global_schedule")
+    if not cron_expr:
+        return
+    try:
+        excluded_names = sched_cfg.get("global_exclude_ids", [])
+        scheduler.add_job(
+            _run_global_sync_job,
+            CronTrigger.from_crontab(cron_expr),
+            id="global_sync",
+            name="Global Sync (with exclusions)",
+            args=[excluded_names],
+        )
+        logger.info("Scheduled global sync: %s (excluding: %s)", cron_expr, excluded_names)
+    except (ValueError, KeyError, OSError):
+        logger.exception("Failed to schedule global sync")
 
-    config = load_config()
-    sched_cfg = config.get("scheduler", {})
-    groups = config.get("groups", [])
 
-    # 1. Global Scheduler
-    if sched_cfg.get("global_enabled"):
-        cron_expr = sched_cfg.get("global_schedule")
-        if cron_expr:
-            try:
-                excluded_names = sched_cfg.get("global_exclude_ids", [])  # We use names as IDs for now
-                _scheduler.add_job(
-                    _run_global_sync_job,
-                    CronTrigger.from_crontab(cron_expr),
-                    id="global_sync",
-                    name="Global Sync (with exclusions)",
-                    args=[excluded_names],
-                )
-                logger.info("Scheduled global sync: %s (excluding: %s)", cron_expr, excluded_names)
-            except (ValueError, KeyError, OSError):
-                logger.exception("Failed to schedule global sync")
-
-    # 2. Per-group Schedulers
+def _schedule_group_syncs(scheduler: BackgroundScheduler, groups: list[Any]) -> None:
+    """Add per-group sync jobs for groups that have scheduling enabled."""
     for group in groups:
         if not isinstance(group, dict):
             continue
-
         group_name = group.get("name")
         if not group_name:
             continue
-
         if group.get("schedule_enabled") and group.get("schedule"):
             cron_expr = group["schedule"]
             try:
-                _scheduler.add_job(
+                scheduler.add_job(
                     _run_group_sync_job,
                     CronTrigger.from_crontab(cron_expr),
                     id=f"group_sync_{group_name}",
@@ -79,20 +75,37 @@ def update_scheduler_jobs() -> None:
             except (ValueError, KeyError, OSError):
                 logger.exception("Failed to schedule sync for group '%s'", group_name)
 
-    # 3. Cleanup Scheduler
-    if sched_cfg.get("cleanup_enabled", True):  # Default to true
-        cleanup_cron = sched_cfg.get("cleanup_schedule", "0 * * * *")
-        if cleanup_cron:
-            try:
-                _scheduler.add_job(
-                    _run_cleanup_job,
-                    CronTrigger.from_crontab(cleanup_cron),
-                    id="cleanup_sync",
-                    name="Cleanup Broken Symlinks",
-                )
-                logger.info("Scheduled cleanup job: %s", cleanup_cron)
-            except (ValueError, KeyError, OSError):
-                logger.exception("Failed to schedule cleanup job")
+
+def _schedule_cleanup(scheduler: BackgroundScheduler, sched_cfg: dict[str, Any]) -> None:
+    """Add the broken-symlink cleanup job if enabled."""
+    if not sched_cfg.get("cleanup_enabled", True):
+        return
+    cleanup_cron = sched_cfg.get("cleanup_schedule", "0 * * * *")
+    if not cleanup_cron:
+        return
+    try:
+        scheduler.add_job(
+            _run_cleanup_job,
+            CronTrigger.from_crontab(cleanup_cron),
+            id="cleanup_sync",
+            name="Cleanup Broken Symlinks",
+        )
+        logger.info("Scheduled cleanup job: %s", cleanup_cron)
+    except (ValueError, KeyError, OSError):
+        logger.exception("Failed to schedule cleanup job")
+
+
+def update_scheduler_jobs() -> None:
+    """Synchronise the scheduled jobs with the current configuration."""
+    _scheduler.remove_all_jobs()
+
+    config = load_config()
+    sched_cfg = config.get("scheduler", {})
+    groups = config.get("groups", [])
+
+    _schedule_global_sync(_scheduler, sched_cfg)
+    _schedule_group_syncs(_scheduler, groups)
+    _schedule_cleanup(_scheduler, sched_cfg)
 
 
 def _run_global_sync_job(exclude_names: list[str]) -> None:


### PR DESCRIPTION
Closes #363

Extracts the three scheduling blocks from `update_scheduler_jobs` into
dedicated helpers, dropping its cyclomatic complexity from 12 to below
the C901 threshold of 10.

New helpers:
- `_schedule_global_sync`
- `_schedule_group_syncs`
- `_schedule_cleanup`