### PR TITLE
chore: ignore PT019 false positives from @patch decorator arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ warn_redundant_casts = true
 
 [tool.ruff.lint]
 extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400", "EM", "TRY401"]
+extend-ignore = ["PT019"]
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Closes #367

PT019 flags underscore-prefixed parameters in test functions, but these
are arguments injected by `unittest.mock.patch` decorators — not pytest
fixtures. Adding PT019 to `extend-ignore` avoids noise for this common
pattern in the test suite.