### PR TITLE
fix: mypy error in _parse_trakt_list_url return type

### DIFF
--- a/trakt.py
+++ b/trakt.py
@@ -32,7 +32,8 @@ def _parse_trakt_list_url(list_url: str) -> tuple[str, str]:
     if full_url_match:
         return full_url_match.group(1), full_url_match.group(2)
     if "/" in list_url and not list_url.startswith("http"):
-        return list_url.split("/", 1)
+        parts = list_url.split("/", 1)
+        return parts[0], parts[1]
     msg = (
         f"Invalid Trakt list URL: {list_url!r}. "
         "Expected format: https://trakt.tv/users/username/lists/list-slug"


### PR DESCRIPTION
## Summary

`str.split("/", 1)` returns `list[str]`, but `_parse_trakt_list_url` promises `tuple[str, str]`. This caused a mypy error. Unpack the split result explicitly to satisfy the type checker.

Closes #377

## Test plan

- [x] `mypy .` passes
- [x] `ruff check .` passes
- [x] All 452 tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code clarity with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->