### PR TITLE
chore: remove unused noqa directives (RUF100)

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from flask import Flask
 
-import network  # noqa: F401 — monkey-patches requests.get/post/delete with retry
+import network  # monkey-patches requests.get/post/delete with retry
 from config import CONFIG_FILE, DEFAULT_CONFIG, save_config
 from routes import bp
 from scheduler import start_scheduler

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -544,7 +544,7 @@ def _upload_image(
         timeout: HTTP request timeout.
 
     """
-    with open(image_path, "rb") as f:  # noqa: PTH123
+    with open(image_path, "rb") as f:
         image_bytes = f.read()
     mime_type, _ = mimetypes.guess_type(image_path)
     headers = _auth_headers(api_key)


### PR DESCRIPTION
## Summary

Remove two unused `noqa` directives flagged by RUF100:

- `app.py`: F401 is not in `extend-select`
- `jellyfin.py`: PTH123 is not in `extend-select`

Closes #379

## Test plan

- [x] `ruff check . --select RUF` passes
- [x] All 452 tests pass locally