### PR TITLE
chore: enable RUF lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ exclude = [
 warn_redundant_casts = true
 
 [tool.ruff.lint]
-extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400", "EM", "TRY401"]
+extend-select = ["I", "F401", "PTH", "B", "SIM", "C4", "RET", "PERF", "TCH", "TRY300", "TRY400", "EM", "TRY401", "RUF"]
 extend-ignore = ["PT019"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Enable RUF (ruff-specific) rules in `pyproject.toml` to catch additional code quality issues.

Closes #381

## Test plan

- [x] `ruff check .` passes with RUF enabled
- [x] All 452 tests pass locally