### PR TITLE
test: cover final 4 uncovered lines across scheduler, sync, letterboxd

### DIFF
--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -7,6 +7,7 @@ from anilist import fetch_anilist_list
 from letterboxd import (
     _extract_ids_from_list_page,
     _fetch_id_for_slug,
+    _fetch_ids_for_slugs,
     fetch_letterboxd_list,
 )
 from mal import fetch_mal_list
@@ -280,6 +281,11 @@ def test_letterboxd_threadpool_exception(mock_get, mock_fetch_slug):
 
     ids = fetch_letterboxd_list("https://letterboxd.com/user/list/my-list")
     assert ids == []
+
+
+def test_fetch_ids_for_slugs_empty():
+    """Cover letterboxd.py:80 — early return when slugs list is empty."""
+    assert _fetch_ids_for_slugs([]) == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -40,6 +40,36 @@ def test_update_scheduler_jobs_global(mock_load, mock_sched):
 
 @patch('scheduler._scheduler')
 @patch('scheduler.load_config')
+def test_update_scheduler_jobs_global_empty_schedule(mock_load, mock_sched):
+    mock_load.return_value = {
+        "scheduler": {
+            "global_enabled": True,
+            "global_schedule": "",
+            "cleanup_enabled": False,
+        },
+        "groups": [],
+    }
+    update_scheduler_jobs()
+    mock_sched.add_job.assert_not_called()
+
+
+@patch('scheduler._scheduler')
+@patch('scheduler.load_config')
+def test_update_scheduler_jobs_cleanup_empty_schedule(mock_load, mock_sched):
+    mock_load.return_value = {
+        "scheduler": {
+            "global_enabled": False,
+            "cleanup_enabled": True,
+            "cleanup_schedule": "",
+        },
+        "groups": [],
+    }
+    update_scheduler_jobs()
+    mock_sched.add_job.assert_not_called()
+
+
+@patch('scheduler._scheduler')
+@patch('scheduler.load_config')
 def test_update_scheduler_jobs_groups(mock_load, mock_sched):
     mock_load.return_value = {
         "scheduler": {"global_enabled": False, "cleanup_enabled": False},

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1471,6 +1471,34 @@ def test_run_sync_seasonal_no_dir(mock_libs, mock_season, mock_process, tmp_path
     assert results[0]["status"] == "out_of_season"
 
 
+@patch('sync._process_group')
+@patch('sync._is_in_season')
+@patch('sync.get_libraries')
+def test_run_sync_seasonal_in_season(mock_libs, mock_season, mock_process, tmp_path):
+    """Cover line 1398: seasonal group that is in season returns None and is processed normally."""
+    mock_libs.return_value = []
+    mock_season.return_value = True
+    mock_process.return_value = {"group": "Test", "links": 1}
+    target = tmp_path / "target"
+    target.mkdir()
+    config = {
+        "jellyfin_url": "http://jf",
+        "api_key": "key",
+        "target_path": str(target),
+        "groups": [
+            {
+                "name": "Test",
+                "seasonal_enabled": True,
+                "seasonal_start": "01-01",
+                "seasonal_end": "12-31",
+            },
+        ],
+    }
+    results = run_sync(config, dry_run=False)
+    assert results[0]["links"] == 1
+    mock_process.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Remaining branch coverage for sync.py
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds tests for the last 4 uncovered lines in the codebase, achieving **100% line coverage**.

## What's covered

- `scheduler.py:41` — early return when `global_enabled=True` but `global_schedule` is empty
- `scheduler.py:85` — early return when `cleanup_enabled=True` but `cleanup_schedule` is empty
- `sync.py:1398` — seasonal group that is **in** season returns `None` and proceeds to normal `_process_group` handling
- `letterboxd.py:80` — `_fetch_ids_for_slugs` with empty `slugs` list returns empty dict immediately

## Coverage

| Metric | Before | After |
|--------|--------|-------|
| Statements | 1691 | 1691 |
| Missing | 4 | **0** |
| Coverage | 99.76% | **100%** |

## Test plan
- [x] All 456 tests pass
- [x] 100% line coverage confirmed via `pytest --cov`

Closes #388