### PR TITLE
chore: raise CI coverage threshold from 80% to 99%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,4 @@ jobs:
     - name: Run standard tests with coverage
       run: |
         export PYTHONPATH=$PYTHONPATH:.
-        pytest --cov=. --cov-report=term-missing --cov-fail-under=80 --ignore=tests/test_virtual_jellyfin_api.py --ignore=tests/test_virtual_jellyfin_exhaustive.py --ignore=tests/test_deep_sync.py tests/
+        pytest --cov=. --cov-report=term-missing --cov-fail-under=99 --ignore=tests/test_virtual_jellyfin_api.py --ignore=tests/test_virtual_jellyfin_exhaustive.py --ignore=tests/test_deep_sync.py tests/


### PR DESCRIPTION
## Summary

Bumps the pytest coverage fail-under threshold from 80% to 99% in the test workflow.

## Why

The codebase now has 100% line coverage. Raising the threshold prevents future PRs from accidentally introducing uncovered code paths.

## Change

`.github/workflows/test.yml` line 50:
- Before: `--cov-fail-under=80`
- After: `--cov-fail-under=99`

Using 99% instead of 100% provides a tiny buffer for edge-case infrastructure changes while still catching meaningful regressions.

## Test plan
- [x] Standard test suite passes locally

Closes #392