### PR TITLE
chore: update stale references in .coveragerc and .pre-commit-config.yaml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,6 @@ omit =
     venv/*
     .venv/*
     run_tests_to_file.py
-    parse_test.py
     app.py
     start_virtual_jellyfin.py
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         always_run: true
     -   id: pytest-coverage
         name: check code coverage
-        entry: bash -c "export PYTHONPATH=$PYTHONPATH:. && pytest --cov=. --cov-fail-under=80 tests/"
+        entry: bash -c "export PYTHONPATH=$PYTHONPATH:. && pytest --cov=. --cov-fail-under=99 tests/"
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Summary

Cleans up two stale references after recent changes:

1. `.coveragerc` still listed `parse_test.py` (deleted in #391) in the omit section — removed.
2. `.pre-commit-config.yaml` still used `--cov-fail-under=80` while CI was bumped to 99% in #393 — aligned.

## Changes

| File | Before | After |
|------|--------|-------|
| `.coveragerc` | `parse_test.py` in omit list | Removed |
| `.pre-commit-config.yaml` | `--cov-fail-under=80` | `--cov-fail-under=99` |

## Test plan
- [x] Local test suite passes

Closes #394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased code coverage threshold requirement from 80% to 99% for pre-commit validation
  * Updated test coverage configuration to include previously omitted test files in measurement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EntchenEric/jellyfin-auto-groupings/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->