### PR TITLE
chore: add missing docstrings to run_tests_to_file.py

### DIFF
--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -1,3 +1,9 @@
+"""run_tests_to_file.py - Developer utility to run the test suite and capture output.
+
+Sets PYTHONPATH and invokes pytest with coverage, writing all output to
+``test_results.txt`` for offline review.
+"""
+
 import os
 import subprocess
 import sys
@@ -5,6 +11,7 @@ from pathlib import Path
 
 
 def main() -> None:
+    """Run pytest with coverage and stream output to ``test_results.txt``."""
     existing = os.environ.get("PYTHONPATH")
     os.environ["PYTHONPATH"] = f"{existing}:." if existing else "."
     with Path("test_results.txt").open("w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Adds module and function docstrings to `run_tests_to_file.py`, the only root-level Python file missing them.

## Changes

- Module docstring explaining purpose
- `main()` docstring

## Test plan
- [x] `ruff check .` passes
- [x] All 456 tests pass

Closes #396