### PR TITLE
refactor: convert if/elif chain to match/case in _eval_rules

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -767,14 +767,15 @@ def _eval_item(item: dict[str, Any], rules: list[dict[str, Any]]) -> bool:
         op = rule["operator"]
         matched = _match_condition(item, rule["type"], rule["value"])
 
-        if op == "AND":
-            result = result and matched
-        elif op == "OR":
-            result = result or matched
-        elif op in ("AND NOT", "NOT"):
-            result = result and not matched
-        elif op == "OR NOT":
-            result = result or not matched
+        match op:
+            case "AND":
+                result = result and matched
+            case "OR":
+                result = result or matched
+            case "AND NOT" | "NOT":
+                result = result and not matched
+            case "OR NOT":
+                result = result or not matched
 
     return result
 


### PR DESCRIPTION
## Summary

Replaces the 4-branch `if/elif` operator dispatch in `_eval_rules` with `match/case` syntax.

## Before

```python
if op == "AND":
    result = result and matched
elif op == "OR":
    result = result or matched
elif op in ("AND NOT", "NOT"):
    result = result and not matched
elif op == "OR NOT":
    result = result or not matched
```

## After

```python
match op:
    case "AND":
        result = result and matched
    case "OR":
        result = result or matched
    case "AND NOT" | "NOT":
        result = result and not matched
    case "OR NOT":
        result = result or not matched
```

## Why

- `match/case` is the idiomatic Python 3.10+ pattern for literal dispatch
- Union patterns (`|`) cleanly express multiple keys mapping to the same branch
- Exhaustiveness checking (static) can warn if a new operator is added without a case

## Test plan
- [x] `ruff check .` passes
- [x] All 456 tests pass

Closes #402