### PR TITLE
chore: consolidate duplicate Jellyfin page limit constants

### DIFF
--- a/jellyfin.py
+++ b/jellyfin.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-_COLLECTION_PAGE_LIMIT = 200
+_PAGE_LIMIT: int = 200
 
 # Default Jellyfin item types used across the application.
 DEFAULT_ITEM_TYPES = "Movie,Series"
@@ -242,7 +242,7 @@ def fetch_all_jellyfin_items(
     api_key: str,
     extra_params: dict[str, str] | None = None,
     *,
-    limit: int = 200,
+    limit: int = _PAGE_LIMIT,
     timeout: int = _DEFAULT_TIMEOUT,
     _fetch_page: Callable[..., list[dict[str, Any]]] | None = None,
 ) -> list[dict[str, Any]]:
@@ -287,7 +287,7 @@ def _paginate_jellyfin(
     endpoint: str,
     params: dict[str, Any] | None = None,
     *,
-    limit: int = 200,
+    limit: int = _PAGE_LIMIT,
     timeout: int = _DEFAULT_TIMEOUT,
 ) -> Iterator[list[dict[str, Any]]]:
     """Yield pages of items from a Jellyfin endpoint.
@@ -658,7 +658,7 @@ def find_collection_by_name(
         "SearchTerm": name,
     }
     for page in _paginate_jellyfin(
-        base_url, api_key, "Items", params, limit=_COLLECTION_PAGE_LIMIT, timeout=timeout,
+        base_url, api_key, "Items", params, limit=_PAGE_LIMIT, timeout=timeout,
     ):
         for item in page:
             if item.get("Name") == name:

--- a/routes.py
+++ b/routes.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 from config import load_config, save_config
 from jellyfin import (
+    _PAGE_LIMIT,
     RECURSIVE_TRUE,
     _paginate_jellyfin,
     delete_virtual_folder,
@@ -80,9 +81,6 @@ def _success(message: str, status_code: int = 200, **extra: Any) -> ResponseRetu
 
 # Max size for base64 encoded cover image (approx 4MB)
 MAX_B64_SIZE = 4 * 1024 * 1024
-
-# Jellyfin API pagination limit
-_JELLYFIN_PAGE_LIMIT = 200
 
 # Auto-detect filesystem search limits
 _AUTO_DETECT_TIMEOUT = 30
@@ -335,7 +333,7 @@ def _fetch_jellyfin_endpoint(
     items: list[dict[str, Any]] = []
     try:
         for page in _paginate_jellyfin(
-            base_url, api_key, endpoint, extra_params, limit=_JELLYFIN_PAGE_LIMIT, timeout=timeout,
+            base_url, api_key, endpoint, extra_params, limit=_PAGE_LIMIT, timeout=timeout,
         ):
             items.extend(page)
     except RuntimeError:


### PR DESCRIPTION
## Summary

Both `jellyfin.py` and `routes.py` defined a private constant for the same Jellyfin API pagination limit (200 items per page):

- `jellyfin.py`: `_COLLECTION_PAGE_LIMIT = 200`
- `routes.py`: `_JELLYFIN_PAGE_LIMIT = 200`

These were passed to the same `_paginate_jellyfin` helper, which itself defaulted to `limit=200`. Having two module-level copies of the same value is redundant and risks them drifting out of sync.

## Changes

- Rename `_COLLECTION_PAGE_LIMIT` in `jellyfin.py` to `_PAGE_LIMIT: int = 200`.
- Use `_PAGE_LIMIT` as the default for both `fetch_all_jellyfin_items` and `_paginate_jellyfin` instead of a bare integer literal.
- Remove `_JELLYFIN_PAGE_LIMIT` from `routes.py`.
- Import `_PAGE_LIMIT` from `jellyfin.py` into `routes.py` for the one call site there.

## Verification

- `ruff check .` passes.
- Full test suite passes (455 passed, 17 skipped).
- No behavioural change.

Closes #406