### PR TITLE
chore: add __all__ to external API service modules

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import requests
 
+__all__ = ["fetch_anilist_list"]
+
 ANILIST_API_URL = "https://graphql.anilist.co"
 
 # Request timeout (seconds)

--- a/imdb.py
+++ b/imdb.py
@@ -11,6 +11,8 @@ import re
 
 import requests
 
+__all__ = ["fetch_imdb_list"]
+
 logger = logging.getLogger(__name__)
 
 # Request timeout (seconds)

--- a/letterboxd.py
+++ b/letterboxd.py
@@ -13,6 +13,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
 
+__all__ = ["fetch_letterboxd_list"]
+
 logger = logging.getLogger(__name__)
 
 # Request timeouts (seconds)

--- a/mal.py
+++ b/mal.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import requests
 
+__all__ = ["fetch_mal_list"]
+
 MAL_API_BASE_URL = "https://api.myanimelist.net/v2"
 
 # Request timeout (seconds)

--- a/tmdb.py
+++ b/tmdb.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 import requests
 
+__all__ = ["fetch_tmdb_list", "get_tmdb_recommendations"]
+
 logger = logging.getLogger(__name__)
 
 _TMDB_API_BASE: str = "https://api.themoviedb.org/3"

--- a/trakt.py
+++ b/trakt.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import requests
 
+__all__ = ["fetch_trakt_list"]
+
 logger = logging.getLogger(__name__)
 
 # Request timeout (seconds)


### PR DESCRIPTION
## Summary

The six small service modules that fetch data from external APIs had no `__all__` definitions, making their public APIs implicit.

## Changes

Add `__all__` to each module to explicitly document the public API:

- `anilist.py` — `["fetch_anilist_list"]`
- `imdb.py` — `["fetch_imdb_list"]`
- `letterboxd.py` — `["fetch_letterboxd_list"]`
- `mal.py` — `["fetch_mal_list"]`
- `tmdb.py` — `["fetch_tmdb_list", "get_tmdb_recommendations"]`
- `trakt.py` — `["fetch_trakt_list"]`

## Verification

- `ruff check .` passes.
- Full test suite passes (455 passed, 17 skipped).
- No behavioural change.

Closes #410