### PR TITLE
chore: add missing __future__ annotations to utility scripts

### DIFF
--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -4,6 +4,8 @@ Sets PYTHONPATH and invokes pytest with coverage, writing all output to
 ``test_results.txt`` for offline review.
 """
 
+from __future__ import annotations
+
 import os
 import subprocess
 import sys

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -4,6 +4,8 @@
 Provides a dashboard at http://localhost:8096.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 


### PR DESCRIPTION
## Summary

`start_virtual_jellyfin.py` and `run_tests_to_file.py` were the only modules without `from __future__ import annotations`.

## Changes

- Add `from __future__ import annotations` to both files.

## Verification

- `ruff check .` passes.
- Full test suite passes (455 passed, 17 skipped).
- No behavioural change.

Closes #414