### PR TITLE
fix: remove README.md from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,7 +51,6 @@ node_modules/
 *.egg-info/
 dist/
 build/
-README.md
 unraid/
 e2e/
 .env


### PR DESCRIPTION
The Dockerfile copies README.md during build, but .dockerignore excluded it, causing the Docker build to fail.