### PR TITLE
fix: add setuptools_scm fallback_version for Docker builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 ]
 
 [tool.setuptools_scm]
+fallback_version = "1.0.0"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
setuptools_scm fails in Docker because .git is excluded by .dockerignore. Add fallback_version so builds without git metadata still work.