### PR TITLE
fix: fall back to cwd when home dir is not writable

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -837,6 +837,8 @@ def auto_detect_paths() -> ResponseReturnValue:
                 break
 
     suggested_target = str(Path(home_dir) / "jellyfin-groupings-virtual")
+    if not os.access(home_dir, os.W_OK):
+        suggested_target = str(Path.cwd() / "jellyfin-groupings-virtual")
 
     return _success(
         "",


### PR DESCRIPTION
When running in Docker, Path.home() can return /root even though the app runs as appuser. This causes sync to fail with Permission denied. Fall back to the current working directory when the home directory is not writable.