### PR TITLE
docs: add SECURITY.md, CODE_OF_CONDUCT.md, and README improvements

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,110 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behaviour include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the community leaders responsible for enforcement by opening a
+GitHub issue or contacting the maintainer directly. All complaints will be
+reviewed and investigated promptly and fairly.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behaviour deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behaviour. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behaviour.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behaviour, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Docker](https://img.shields.io/badge/Docker-ready-blue.svg?logo=docker&logoColor=white)](https://github.com/entcheneric/jellyfin-auto-groupings)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 ---
 
@@ -384,3 +385,11 @@ a `message` field:
 
 Errors also include an `error` field in the response body with a human-readable description.
 When preview or sync fails, the error is shown in a modal dialog within the UI.
+
+---
+
+## 📚 Additional Resources
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Development guide and contribution process
+- [SECURITY.md](SECURITY.md) — Security policy and vulnerability reporting
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — Community guidelines

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| latest  | ✅ Yes             |
+| < 1.x   | ❌ No              |
+
+We recommend always running the latest published Docker image or building from the latest `main` commit.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Jellyfin Groupings, please report it by opening a [GitHub Security Advisory](https://github.com/entcheneric/jellyfin-auto-groupings/security/advisories/new).
+
+Do **not** open a public issue for security vulnerabilities.
+
+We aim to acknowledge reports within 48 hours and will work on a fix as quickly as possible.
+
+## Best Practices for Deployments
+
+1. **Use environment variables for secrets** — API keys, passwords, and tokens set via `JELLYFIN_API_KEY`, `APP_PASSWORD`, etc. are preferred over storing them in `config.json`.
+2. **Enable authentication** — Set `APP_PASSWORD` to enable HTTP Basic Auth for the web UI.
+3. **Restrict network access** — Do not expose the web UI (port 5000) to the public internet without a VPN or reverse proxy with authentication.
+4. **Run as non-root** — The Docker container runs as `appuser` (UID 1000) by default. Avoid running as root.
+5. **Keep dependencies updated** — Regularly rebuild the Docker image to pick up the latest security patches.


### PR DESCRIPTION
### Summary

Adds missing project governance documents and improves the README:

- **SECURITY.md** — Vulnerability reporting policy with best practices for secure deployments
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 community guidelines
- **README.md** — Added PRs Welcome badge and Additional Resources section linking to CONTRIBUTING, SECURITY, and CODE_OF_CONDUCT docs

### Checklist
- [x] All tests pass
- [x] No new ruff/mypy warnings
- [x] README updated
- [x] Conventional commit format