### PR TITLE
fix: patch network.get/post instead of requests.get/post in external API tests

### DIFF
--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -15,7 +15,12 @@ from tmdb import fetch_tmdb_list
 from trakt import fetch_trakt_list
 
 
-@patch("requests.get")
+# ---------------------------------------------------------------------------
+# letterboxd.py — code uses network.get (not requests.get directly)
+# ---------------------------------------------------------------------------
+
+
+@patch("network.get")
 def test_fetch_letterboxd_list(mock_get):
     # Mock main list page
     mock_list_resp = MagicMock()
@@ -33,7 +38,7 @@ def test_fetch_letterboxd_list(mock_get):
     assert ids == ["tt0068646"]
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_letterboxd_list_tmdb(mock_get):
     # Test TMDb ID extraction and pagination stop
     mock_list_resp = MagicMock()
@@ -69,7 +74,7 @@ def test_fetch_letterboxd_invalid_url():
         fetch_letterboxd_list("https://not-lb-domain.com")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_letterboxd_http_error(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 500
@@ -79,7 +84,12 @@ def test_fetch_letterboxd_http_error(mock_get):
         fetch_letterboxd_list("https://letterboxd.com/user/list/list")
 
 
-@patch("requests.get")
+# ---------------------------------------------------------------------------
+# mal.py — code uses network.get
+# ---------------------------------------------------------------------------
+
+
+@patch("network.get")
 def test_fetch_mal_list(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -96,7 +106,7 @@ def test_fetch_mal_list(mock_get):
     assert kwargs["params"]["status"] == "watching"
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_pagination(mock_get):
     resp1 = MagicMock()
     resp1.status_code = 200
@@ -115,7 +125,12 @@ def test_fetch_mal_pagination(mock_get):
     assert ids == [1, 2]
 
 
-@patch("requests.get")
+# ---------------------------------------------------------------------------
+# trakt.py — code uses network.get
+# ---------------------------------------------------------------------------
+
+
+@patch("network.get")
 def test_fetch_trakt_list(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -129,7 +144,12 @@ def test_fetch_trakt_list(mock_get):
     assert ids == ["tt123"]
 
 
-@patch("requests.post")
+# ---------------------------------------------------------------------------
+# anilist.py — code uses network.post
+# ---------------------------------------------------------------------------
+
+
+@patch("network.post")
 def test_fetch_anilist_all(mock_post):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -138,6 +158,11 @@ def test_fetch_anilist_all(mock_post):
     fetch_anilist_list("user", "all")
     _args, kwargs = mock_post.call_args
     assert "status" not in kwargs["json"]["variables"]
+
+
+# ---------------------------------------------------------------------------
+# tmdb.py — code uses network.get
+# ---------------------------------------------------------------------------
 
 
 def test_fetch_tmdb_invalid_args():
@@ -149,7 +174,7 @@ def test_fetch_tmdb_invalid_args():
         fetch_tmdb_list("", "key")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_tmdb_url_parsing(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -160,7 +185,7 @@ def test_fetch_tmdb_url_parsing(mock_get):
     assert "list/999" in args[0]
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_error(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 401
@@ -172,7 +197,7 @@ def test_fetch_mal_error(mock_get):
         fetch_mal_list("u", "c")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_trakt_pagination(mock_get):
     resp1 = MagicMock()
     resp1.status_code = 200
@@ -187,7 +212,7 @@ def test_fetch_trakt_pagination(mock_get):
     assert ids == ["tt1", "tt2"]
 
 
-@patch("requests.post")
+@patch("network.post")
 def test_fetch_anilist_empty_data(mock_post):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -230,14 +255,15 @@ def test_extract_ids_priority_tmdb_over_imdb():
     assert result == {"film1": "111"}
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_id_for_slug_request_exception(mock_get):
+    # _fetch_id_for_slug uses network.get now
     mock_get.side_effect = requests.exceptions.ConnectionError("Network down")
     result = _fetch_id_for_slug("some-film")
     assert result is None
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_letterboxd_404_on_page_two(mock_get):
     resp1 = MagicMock()
     resp1.status_code = 200
@@ -256,7 +282,7 @@ def test_letterboxd_404_on_page_two(mock_get):
     assert ids == ["tt1234567"]
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_letterboxd_fallback_slug_regex(mock_get):
     resp = MagicMock()
     resp.status_code = 200
@@ -267,7 +293,7 @@ def test_letterboxd_fallback_slug_regex(mock_get):
     assert ids == []
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_letterboxd_no_slugs(mock_get):
     resp = MagicMock()
     resp.status_code = 200
@@ -279,7 +305,7 @@ def test_letterboxd_no_slugs(mock_get):
 
 
 @patch("letterboxd._fetch_id_for_slug")
-@patch("requests.get")
+@patch("network.get")
 def test_letterboxd_threadpool_exception(mock_get, mock_fetch_slug):
     resp = MagicMock()
     resp.status_code = 200
@@ -307,7 +333,7 @@ def test_fetch_mal_no_client_id():
         fetch_mal_list("user", "")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_status_current(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -319,7 +345,7 @@ def test_fetch_mal_status_current(mock_get):
     assert kwargs["params"]["status"] == "watching"
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_status_planning(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -331,7 +357,7 @@ def test_fetch_mal_status_planning(mock_get):
     assert kwargs["params"]["status"] == "plan_to_watch"
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_status_paused(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -343,7 +369,7 @@ def test_fetch_mal_status_paused(mock_get):
     assert kwargs["params"]["status"] == "on_hold"
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_status_all(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -355,7 +381,7 @@ def test_fetch_mal_status_all(mock_get):
     assert "status" not in kwargs["params"]
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_mal_status_unknown(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -377,7 +403,7 @@ def test_fetch_trakt_no_client_id():
         fetch_trakt_list("user/list", "")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_trakt_full_url(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -396,7 +422,7 @@ def test_fetch_trakt_invalid_url():
         fetch_trakt_list("not-a-valid-url", "client_id")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_trakt_http_error(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 500
@@ -408,7 +434,7 @@ def test_fetch_trakt_http_error(mock_get):
         fetch_trakt_list("user/list", "client_id")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_trakt_empty_items(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -420,7 +446,7 @@ def test_fetch_trakt_empty_items(mock_get):
     assert ids == []
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_trakt_bad_pagination_header(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -23,7 +23,7 @@ def test_fetch_jellyfin_items(mock_get):
     assert kwargs["params"]["Type"] == "Movie"
 
 
-@patch("imdb.requests.get")
+@patch("imdb.network.get")
 def test_fetch_imdb_list(mock_get):
     mock_response = MagicMock()
     mock_response.text = '<html><div class="lister-item-header"><a href="/title/tt1234567/"></a></div></html>'
@@ -32,7 +32,7 @@ def test_fetch_imdb_list(mock_get):
     assert ids == ["tt1234567"]
 
 
-@patch("tmdb.requests.get")
+@patch("tmdb.network.get")
 def test_fetch_tmdb_list(mock_get):
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -47,7 +47,7 @@ def test_fetch_tmdb_list(mock_get):
     assert ids == ["101", "202"]
 
 
-@patch("anilist.requests.post")
+@patch("anilist.network.post")
 def test_fetch_anilist_list(mock_post):
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -76,7 +76,7 @@ def test_fetch_imdb_invalid_id():
         fetch_imdb_list("not-a-valid-id")
 
 
-@patch("imdb.requests.get")
+@patch("imdb.network.get")
 def test_fetch_imdb_http_error(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 500
@@ -88,7 +88,7 @@ def test_fetch_imdb_http_error(mock_get):
         fetch_imdb_list("ls12345")
 
 
-@patch("imdb.requests.get")
+@patch("imdb.network.get")
 def test_fetch_imdb_pagination(mock_get):
     resp1 = MagicMock()
     resp1.status_code = 200
@@ -113,7 +113,7 @@ def test_fetch_imdb_pagination(mock_get):
 # ---------------------------------------------------------------------------
 
 
-@patch("anilist.requests.post")
+@patch("anilist.network.post")
 def test_fetch_anilist_empty_collection(mock_post):
     mock_resp = MagicMock()
     mock_resp.status_code = 200

--- a/tests/test_tmdb.py
+++ b/tests/test_tmdb.py
@@ -13,7 +13,7 @@ def test_fetch_tmdb_list_missing_args():
         fetch_tmdb_list("", "api_key")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_tmdb_list_success(mock_get):
     mock_resp_1 = MagicMock()
     mock_resp_1.status_code = 200
@@ -34,7 +34,7 @@ def test_fetch_tmdb_list_success(mock_get):
     assert mock_get.call_count == 2
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_tmdb_list_url_parsing(mock_get):
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -52,7 +52,7 @@ def test_fetch_tmdb_list_url_parsing(mock_get):
     assert "/list/456" in args[0]
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_fetch_tmdb_list_failure(mock_get):
     mock_get.side_effect = requests.exceptions.RequestException("Network Error")
     with pytest.raises(RuntimeError, match="Failed to fetch TMDb list page 1"):
@@ -64,7 +64,7 @@ def test_get_tmdb_recommendations_missing_key():
         get_tmdb_recommendations([("101", "movie")], "")
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_get_tmdb_recommendations_success(mock_get):
     mock_resp_movie = MagicMock()
     mock_resp_movie.status_code = 200
@@ -91,7 +91,7 @@ def test_get_tmdb_recommendations_success(mock_get):
     assert recs == ["202", "201", "203"]
 
 
-@patch("requests.get")
+@patch("network.get")
 def test_get_tmdb_recommendations_failure_skipped(mock_get):
     mock_resp_movie = MagicMock()
     mock_resp_movie.status_code = 200


### PR DESCRIPTION
## Summary

All external API modules (letterboxd, imdb, mal, trakt, tmdb, anilist, jellyfin) use `network.get` / `network.post` (the retry-aware wrappers in `network.py`) rather than `requests.get` / `requests.post` directly. However, the unit tests in `test_external.py`, `test_fetchers.py`, and `test_tmdb.py` were patching at the wrong module path (`requests.get` instead of `network.get`), causing all standard test CI runs to fail.

## Changes

- **tests/test_external.py**: Patch `network.get` for letterboxd, mal, trakt, tmdb tests; `network.post` for anilist tests (was `requests.get`/`requests.post`)
- **tests/test_fetchers.py**: Patch `imdb.network.get`, `anilist.network.post`, `tmdb.network.get` (was `imdb.requests.get`, `anilist.requests.post`, `tmdb.requests.get`)
- **tests/test_tmdb.py**: Patch `network.get` instead of `requests.get` for all 5 tests

## Verification

- 421 tests pass
- Coverage: 99.54% (above 99% threshold)
- Ruff + mypy: clean