### PR TITLE
fix: update test mocks from builtins.open to jellyfin.Path.open

### DIFF
--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -193,7 +193,7 @@ def test_get_library_id(mock_get):
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 @patch("jellyfin.get_library_id")
 def test_set_virtual_folder_image(
@@ -388,7 +388,7 @@ def test_set_virtual_folder_image_no_library_id(mock_get_library_id, caplog):
 def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
     mock_get_library_id.return_value = "123"
 
-    with patch("builtins.open", side_effect=OSError("Permission Denied")):
+    with patch("jellyfin.Path.open", side_effect=OSError("Permission Denied")):
         set_virtual_folder_image(TEST_URL, TEST_KEY, "MyLib", "/path/to/img.jpg")
 
     assert (
@@ -397,7 +397,7 @@ def test_set_virtual_folder_image_os_error(mock_get_library_id, caplog):
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 @patch("jellyfin.get_library_id")
 def test_set_virtual_folder_image_request_exception(
@@ -427,7 +427,7 @@ def test_set_virtual_folder_image_request_exception(
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 @patch("jellyfin.get_library_id")
 def test_set_virtual_folder_image_request_exception_no_response(
@@ -725,7 +725,7 @@ def test_delete_collection_request_exception(mock_delete):
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 def test_set_collection_image_success(mock_post, mock_open, mock_guess, caplog):
     mock_guess.return_value = ("image/png", None)
@@ -745,7 +745,7 @@ def test_set_collection_image_success(mock_post, mock_open, mock_guess, caplog):
     assert "Successfully updated cover image for collection 'col_1'" in caplog.text
 
 
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 def test_set_collection_image_os_error(mock_open, caplog):
     mock_open.side_effect = OSError("Permission denied")
 
@@ -754,7 +754,7 @@ def test_set_collection_image_os_error(mock_open, caplog):
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 def test_set_collection_image_unknown_mime(mock_post, mock_open, mock_guess, caplog):
     mock_guess.return_value = (None, None)
@@ -771,7 +771,7 @@ def test_set_collection_image_unknown_mime(mock_post, mock_open, mock_guess, cap
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 def test_set_collection_image_http_error(mock_post, mock_open, mock_guess, caplog):
     mock_guess.return_value = ("image/jpeg", None)
@@ -791,7 +791,7 @@ def test_set_collection_image_http_error(mock_post, mock_open, mock_guess, caplo
 
 
 @patch("mimetypes.guess_type")
-@patch("builtins.open")
+@patch("jellyfin.Path.open")
 @patch("jellyfin.network.post")
 def test_set_collection_image_request_exception_no_response(
     mock_post, mock_open, mock_guess, caplog


### PR DESCRIPTION
## Summary

The `_upload_image()` function in `jellyfin.py` was recently changed (commit 548571b) to use `Path(image_path).open('rb')` instead of `open(image_path, 'rb')`. However, the corresponding tests still mocked `builtins.open`, which no longer intercepts the call since `Path.open()` is a different method. This caused 7 test failures on the CI runs.

This was blocking the merge of PR #456 (refactor/translate-path-to-pathlib), whose tests were clean but the main branch tests were already broken.

## Changes

- Changed all `@patch('builtins.open')` decorators to `@patch('jellyfin.Path.open')` in:
  - `test_set_virtual_folder_image`
  - `test_set_virtual_folder_image_os_error` (context manager)
  - `test_set_virtual_folder_image_request_exception`
  - `test_set_virtual_folder_image_request_exception_no_response`
  - `test_set_collection_image_success`
  - `test_set_collection_image_os_error`
  - `test_set_collection_image_unknown_mime`
  - `test_set_collection_image_http_error`
  - `test_set_collection_image_request_exception_no_response`

## Verification

- ✅ All 464 tests pass (0 failures, 17 skipped)
- ✅ Same pass/fail/skip counts as before the breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path resolution logic during media synchronization to more reliably validate Jellyfin media paths and their relationship to configured media roots, with improved error handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->