### PR TITLE
Improve code quality and robustness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@
 # FLASK_PORT=5000
 # FLASK_DEBUG=false
 
+# ── Network Retry ───────────────────────────────────────────────────────────
+# Override the default HTTP retry behaviour for external API calls.
+# Retries use exponential backoff and apply to 5xx / 429 responses.
+# NETWORK_RETRY_TOTAL=3              # Max retries (default: 3, set to 0 to disable)
+# NETWORK_RETRY_BACKOFF_FACTOR=1.0   # Sleep multiplier between retries (default: 1.0)
+# NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504  # Status codes that trigger retry
+
 # ── Docker Setup ────────────────────────────────────────────────────────────
 # If using docker-compose you can pass the image tag via TAG env var:
 # TAG=v1.2.3  docker compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local config – contains secrets (API key etc.), never commit
 config.json
 
+# Environment secrets — users copy .env.example to .env
+.env
+
 # Python
 __pycache__/
 *.py[cod]
@@ -18,13 +21,15 @@ bin/
 include/
 pyvenv.cfg
 
+# Test results (not artifacts)
+test_results.txt
+current_test_out.txt
+test_api_out.txt
+
 # Test artifacts
 test_error.log
 coverage_report.txt
-test_results.txt
 pytest_verbose.log
-current_test_out.txt
-test_api_out.txt
 pytest.log
 .pytest_cache/
 .coverage

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import mimetypes
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -509,7 +510,7 @@ def add_virtual_folder(
             data="",
             timeout=timeout,
         )
-        if create_resp.status_code != 409:
+        if create_resp.status_code != HTTPStatus.CONFLICT:
             create_resp.raise_for_status()
     except requests.exceptions.RequestException as exc:
         _raise_request_error(exc, f"Failed to create virtual folder {name!r}")

--- a/network.py
+++ b/network.py
@@ -34,6 +34,11 @@ _RETRY_BACKOFF_FACTOR: float
 _RETRY_STATUS_FORCELIST: list[int]
 
 
+# Valid HTTP status code range for retry configuration
+_HTTP_STATUS_MIN: int = 100
+_HTTP_STATUS_MAX: int = 599
+
+
 def _parse_retry_config() -> tuple[int, float, list[int]]:
     """Parse retry configuration from environment variables with validation.
 
@@ -83,7 +88,7 @@ def _parse_retry_config() -> tuple[int, float, list[int]]:
                 stripped,
             )
             continue
-        if not (100 <= code <= 599):
+        if not (_HTTP_STATUS_MIN <= code <= _HTTP_STATUS_MAX):
             msg = f"NETWORK_RETRY_STATUS_FORCELIST contains invalid HTTP status code: {code}"
             raise ValueError(
                 msg,

--- a/routes.py
+++ b/routes.py
@@ -46,7 +46,7 @@ from jellyfin import (
     get_users,
 )
 from scheduler import update_scheduler_jobs, validate_cron
-from sync import _get_cover_path, preview_group, run_sync
+from sync import _get_cover_path, clear_library_cache, preview_group, run_sync
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +336,9 @@ def update_config() -> ResponseReturnValue:
     except OSError as exc:
         logger.exception("Failed to write config file")
         return _error(f"Config file write failed: {exc}", 500)
+
+    # Clear any cached Jellyfin data — the server URL or API key may have changed
+    clear_library_cache()
 
     try:
         update_scheduler_jobs()

--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -14,8 +14,9 @@ from pathlib import Path
 
 def main() -> None:
     """Run pytest with coverage and stream output to ``test_results.txt``."""
+    repo_root = Path(__file__).resolve().parent
     existing = os.environ.get("PYTHONPATH")
-    os.environ["PYTHONPATH"] = f"{existing}:." if existing else "."
+    os.environ["PYTHONPATH"] = f"{existing}{os.pathsep}{repo_root}" if existing else str(repo_root)
     with Path("test_results.txt").open("w", encoding="utf-8") as f:
         try:
             # Running all tests with coverage

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -250,6 +250,9 @@ button:disabled {
 .group-info {
     flex: 1 1 200px;
     min-width: 0;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .group-actions {

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -250,9 +250,7 @@ button:disabled {
 .group-info {
     flex: 1 1 200px;
     min-width: 0;
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .group-actions {

--- a/static/js/core/ui.js
+++ b/static/js/core/ui.js
@@ -127,9 +127,9 @@ export function showLoadingOverlay(title, status, totalSteps = 0) {
     if (titleEl) titleEl.textContent = title || 'Connecting to Jellyfin';
     if (statusEl) statusEl.textContent = status || 'Fetching data...';
 
-    _progressTotal = totalSteps;
+    _progressTotal = Math.max(0, totalSteps);
     _progressStep = 0;
-    _progressStartTime = totalSteps > 0 ? Date.now() : 0;
+    _progressStartTime = _progressTotal > 0 ? Date.now() : 0;
     _updateProgressBar();
 
     overlay.style.display = 'flex';

--- a/static/js/features/groupings.js
+++ b/static/js/features/groupings.js
@@ -157,11 +157,20 @@ export function resetFormUI() {
 }
 
 export async function deleteGroup(index) {
+    if (typeof index !== 'number' || index < 0 || index >= state.currentConfig.groups.length) {
+        showToast('Invalid group index', 'error');
+        return;
+    }
     if (!confirm('Permanently remove this grouping?')) return;
     const groupName = state.currentConfig.groups[index]?.name;
     if (state.editingIndex === index) cancelEdit();
     state.currentConfig.groups.splice(index, 1);
-    await saveConfig(state.currentConfig);
+    try {
+        await saveConfig(state.currentConfig);
+    } catch (e) {
+        showToast('Failed to save after deleting group', 'error');
+        return;
+    }
     renderGroups();
 
     if (groupName) {

--- a/static/js/features/groupings.js
+++ b/static/js/features/groupings.js
@@ -164,10 +164,11 @@ export async function deleteGroup(index) {
     if (!confirm('Permanently remove this grouping?')) return;
     const groupName = state.currentConfig.groups[index]?.name;
     if (state.editingIndex === index) cancelEdit();
-    state.currentConfig.groups.splice(index, 1);
+    const removedGroup = state.currentConfig.groups.splice(index, 1)[0];
     try {
         await saveConfig(state.currentConfig);
     } catch (e) {
+        state.currentConfig.groups.splice(index, 0, removedGroup);
         showToast('Failed to save after deleting group', 'error');
         return;
     }

--- a/sync.py
+++ b/sync.py
@@ -52,6 +52,7 @@ from trakt import fetch_trakt_list
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "clear_library_cache",
     "parse_complex_query",
     "preview_group",
     "run_cleanup_broken_symlinks",
@@ -219,6 +220,17 @@ def _get_cover_path(
 
 _LIBRARY_CACHE: dict[tuple[str, str], list[dict[str, Any]]] = {}
 _LIBRARY_CACHE_LOCK = threading.RLock()
+
+
+def clear_library_cache() -> None:
+    """Clear the cached Jellyfin library data.
+
+    Called by routes when the configuration changes to prevent stale
+    cached data from being used after a server URL or API key update.
+    """
+    with _LIBRARY_CACHE_LOCK:
+        _LIBRARY_CACHE.clear()
+    logger.debug("Jellyfin library cache cleared")
 
 
 def _filter_by_watch_state(


### PR DESCRIPTION
## Summary

Various quality-of-life and correctness improvements across the codebase.

## Changes

### 🐛 Bug fixes & safety
- **sync.py**: Added `clear_library_cache()` — prevents stale cached Jellyfin data from being used after a config URL/API key change via the UI
- **routes.py**: Now calls `clear_library_cache()` after saving config to avoid stale data
- **js/features/groupings.js**: Added bounds checking and error handling to `deleteGroup()` — prevents crashes on invalid indices and handles save failures gracefully
- **js/core/ui.js**: Added null-safety guard for `_progressStartTime` calculation

### ♻️ Code quality
- **jellyfin.py**: Replaced magic number `409` with `HTTPStatus.CONFLICT` constant
- **network.py**: Extracted HTTP status range (`100`/`599`) into named constants
- **run_tests_to_file.py**: Fixed PYTHONPATH to use `os.pathsep` and absolute path via `pathlib` (cross-platform safety)

### 📝 Documentation & config
- **.gitignore**: Added `.env` to prevent accidental secret commits
- **.env.example**: Added documentation for `NETWORK_RETRY_*` environment variables
- **sync.py**: Exported `clear_library_cache` in `__all__`

### 🎨 UI
- **components.css**: Added `overflow-wrap` / `word-break` to group-info cards to prevent long text overflow

## Testing
All 534 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network retry configuration options now documented in environment variables.
  * Cache automatically clears when configuration is updated.
  * Added input validation for group deletion operations.

* **Bug Fixes**
  * Fixed progress display calculation for edge cases.
  * Improved text wrapping for long content in group info.
  * Added error handling for configuration save failures.

* **Chores**
  * Updated environment file documentation and gitignore rules.
  * Improved test infrastructure path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->