### PR TITLE
chore: migrate remaining inline styles to CSS classes and add FAQ to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,3 +404,53 @@ When preview or sync fails, the error is shown in a modal dialog within the UI.
 
 ---
 
+## ❓ FAQ
+
+### Can I use this alongside my existing Jellyfin libraries?
+
+Yes — the app creates *new* virtual directories and symlinks; it never modifies or removes your original media files. Jellyfin scans the new directories as independent libraries.
+
+### Does this duplicate my media files?
+
+No. Symlinks are tiny files that point to the original media. The Jellyfin Groupings app never copies, moves, or alters your media files.
+
+### Why aren't my groups appearing after syncing?
+
+1. Ensure the **target path** symlink folder is added as a library in Jellyfin.
+2. Perform a **Library Scan** in Jellyfin (or wait for the auto-scan).
+3. Groups with 0 items will not create symlinks — use the **Preview** button to check matches first.
+
+### Can I use the same media item in multiple groups?
+
+Yes. Since each group creates its own symlink (not a copy), the same movie can appear in as many virtual libraries as you like — for example "Action Movies", "90s Movies", and "Christopher Nolan" — all pointing to the same file on disk.
+
+### Can I hide the original libraries in Jellyfin?
+
+Yes. In Jellyfin Dashboard > Libraries, you can uncheck "Display library in home screen" or restrict access per user to keep the original libraries hidden while showing only the virtual groupings.
+
+### What happens if I rename/move a media file?
+
+The symlink will break (show as missing). Run the **Cleanup** operation in the app to remove broken symlinks, then re-sync affected groups. Consider making media files read-only via Docker volume mounts to prevent accidental moves.
+
+### Can I use this without Docker?
+
+Absolutely. See the **Building from Source** section above. You need Python 3.11+, Flask, and the dependencies listed in `pyproject.toml`.
+
+### Does the app need to run on the same machine as Jellyfin?
+
+It needs filesystem access to both your media files and the target symlink directory. If using Docker, both volumes must be mounted into the container. If running natively, the app needs read access to your media directory and write access to the target directory.
+
+### How do I back up my configuration?
+
+Your group definitions and settings are stored in `config/config.json`. Back up this file to preserve all your groups, schedules, and API keys.
+
+### Can multiple users access the web UI?
+
+Yes. You can optionally set an `APP_PASSWORD` environment variable to enable HTTP Basic Auth. Without it, the UI is accessible to anyone on your network.
+
+### Why is my cover image not updating?
+
+Jellyfin aggressively caches images. After uploading a new cover, trigger a **Library Scan** in Jellyfin or restart the container. Covers are stored in `{target_path}/.covers/`.
+
+---
+

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -968,6 +968,70 @@ pre {
     color: var(--text-secondary);
 }
 
+/* ── Added section: inline-style migrations ────────────────── */
+
+/* Sync results panel */
+.sync-results-panel {
+    display: none;
+    margin-top: 1.25rem;
+    border-top: 1px solid var(--glass-border);
+    padding-top: 1rem;
+}
+
+.sync-results-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
+.sync-results-heading {
+    margin: 0;
+    font-size: 0.85rem;
+}
+
+.sync-results-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+/* Secondary button compact variant */
+.secondary-btn-sm {
+    width: auto;
+    margin: 0;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.72rem;
+}
+
+/* Add condition button inline */
+.add-condition-btn {
+    display: none;
+    margin-bottom: 0.5rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.82rem;
+    width: fit-content;
+    margin-top: 0;
+}
+
+/* Panel toggles (hidden by default) */
+.toggle-panel {
+    display: none;
+    margin-top: 0.6rem;
+}
+
+/* Seasonal label helper */
+.label-sm-spaced {
+    font-size: 0.68rem;
+    margin-bottom: 0.25rem;
+}
+
+/* Seasonal separator */
+.seasonal-separator {
+    padding-top: 1rem;
+    flex-shrink: 0;
+}
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
     width: 6px;

--- a/templates/partials/main/groupings.html
+++ b/templates/partials/main/groupings.html
@@ -47,8 +47,7 @@
             <label for="source_value">Filter Value</label>
 
             <div id="metadata_rules_container" class="hidden-flex-col mb-0_5"></div>
-            <button type="button" onclick="addMetadataRule()" class="secondary-btn" id="add-rule-btn"
-                style="display: none; margin-bottom: 0.5rem; padding: 0.35rem 0.75rem; font-size: 0.82rem; width: fit-content; margin-top:0;">+ Add Condition</button>
+            <button type="button" onclick="addMetadataRule()" class="secondary-btn add-condition-btn" id="add-rule-btn">+ Add Condition</button>
 
             <div id="source_value_container" class="flex-col gap-0_5">
                 <input type="text" id="source_value" list="source_value_datalist"
@@ -86,7 +85,7 @@
                 <input type="checkbox" id="sort_order_enabled" onchange="toggleSortOrder(this)">
                 <span>Custom Sort Order <span class="badge-optional">(optional)</span></span>
             </label>
-            <div id="sort_order_panel" style="display: none; margin-top: 0.6rem;">
+            <div id="sort_order_panel" class="toggle-panel">
                 <select id="sort_order">
                     <option value="">None (filesystem order)</option>
                     <option value="imdb_list_order">IMDb List Order</option>
@@ -120,7 +119,7 @@
                 <input type="checkbox" id="schedule_enabled" onchange="toggleGroupScheduler(this)">
                 <span>Individual Sync Schedule <span class="badge-optional">(optional)</span></span>
             </label>
-            <div id="group_scheduler_panel" style="display: none; margin-top: 0.6rem;">
+            <div id="group_scheduler_panel" class="toggle-panel">
                 <input type="text" id="group_schedule" placeholder="0 12 * * * (Every day at noon)">
                 <small>Leave empty to use only the global schedule.</small>
             </div>
@@ -132,10 +131,10 @@
                 <input type="checkbox" id="seasonal_enabled" onchange="toggleSeasonal(this)">
                 <span>Seasonal Grouping <span class="badge-optional">(optional)</span></span>
             </label>
-            <div id="seasonal_panel" style="display: none; margin-top: 0.6rem;">
+            <div id="seasonal_panel" class="toggle-panel">
                 <div class="flex-row gap-1 align-items-center">
                     <div class="flex-1">
-                        <label class="label-sm" style="margin-bottom: 0.25rem;">Show From</label>
+                        <label class="label-sm-spaced">Show From</label>
                         <div class="flex-row gap-0_3">
                             <select id="seasonal_start_month" class="select-sm-2">
                                 <option value="01">Jan</option><option value="02">Feb</option><option value="03">Mar</option>
@@ -146,9 +145,9 @@
                             <select id="seasonal_start_day" class="select-sm"></select>
                         </div>
                     </div>
-                    <div class="text-secondary" style="padding-top: 1rem; flex-shrink:0;">to</div>
+                    <div class="text-secondary seasonal-separator">to</div>
                     <div class="flex-1">
-                        <label class="label-sm" style="margin-bottom: 0.25rem;">Delete On</label>
+                        <label class="label-sm-spaced">Delete On</label>
                         <div class="flex-row gap-0_3">
                             <select id="seasonal_end_month" class="select-sm-2">
                                 <option value="01">Jan</option><option value="02">Feb</option><option value="03">Mar</option>

--- a/templates/partials/main/sync-maintenance.html
+++ b/templates/partials/main/sync-maintenance.html
@@ -7,11 +7,11 @@
     <p class="section-desc">Use the toolbar above to sync, preview, or clean up. Results appear here after each sync.</p>
 
     <!-- Last Sync Results -->
-    <div id="sync-results-panel" style="display: none; margin-top: 1.25rem; border-top: 1px solid var(--glass-border); padding-top: 1rem;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;">
-            <h3 style="margin: 0; font-size: 0.85rem;">Last Sync Results</h3>
-            <button id="clear-sync-results" class="secondary-btn" style="width: auto; margin: 0; padding: 0.3rem 0.6rem; font-size: 0.72rem;">Clear</button>
+    <div id="sync-results-panel" class="sync-results-panel">
+        <div class="sync-results-header">
+            <h3 class="sync-results-heading">Last Sync Results</h3>
+            <button id="clear-sync-results" class="secondary-btn secondary-btn-sm">Clear</button>
         </div>
-        <div id="sync-results-content" style="display: flex; flex-direction: column; gap: 0.5rem;"></div>
+        <div id="sync-results-content" class="sync-results-content"></div>
     </div>
 </section>


### PR DESCRIPTION
## Summary

Migrates the last remaining inline style attributes from template HTML to reusable CSS classes, and adds a comprehensive FAQ section to the README.

### Changes

**CSS (components.css):**
- Added 10+ new utility/template classes: `sync-results-panel`, `sync-results-header`, `sync-results-heading`, `sync-results-content`, `secondary-btn-sm`, `add-condition-btn`, `toggle-panel`, `label-sm-spaced`, `seasonal-separator`

**HTML Templates:**
- `sync-maintenance.html`: replaced all 5 inline style blocks with CSS classes
- `groupings.html`: replaced 7 inline style blocks with CSS classes

**README:**
- Added FAQ section (11 common questions covering usage, filesystem concerns, multi-group, backup, covers, networking)

### Verification
- All inline styles removed from both template files (confirmed via grep)
- No visual changes expected (CSS values match original inline styles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive FAQ section covering library compatibility, media handling, group synchronization, configuration backup, Docker-free setup, multi-user access via HTTP Basic Auth, and cover image update behavior.

* **Style**
  * Improved UI styling consistency through CSS class organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->