### PR TITLE
docs: add CI/Python version badges, update test count to 550+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Docker](https://img.shields.io/badge/Docker-ready-blue.svg?logo=docker&logoColor=white)](https://github.com/entcheneric/jellyfin-auto-groupings)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Tests](https://github.com/EntchenEric/jellyfin-auto-groupings/actions/workflows/test.yml/badge.svg)](https://github.com/EntchenEric/jellyfin-auto-groupings/actions/workflows/test.yml)
+[![Python](https://img.shields.io/badge/Python-3.11%2B-blue?logo=python)](https://python.org)
 
 ---
 
@@ -268,7 +270,7 @@ See [`.env.example`](.env.example) for quick setup.
 ### 🧪 Testing
 
 ```bash
-# Run the full test suite (520+ tests, 98%+ coverage)
+# Run the full test suite (550+ tests, 98%+ coverage)
 python -m pytest
 
 # Run tests with coverage report


### PR DESCRIPTION
## Summary

- **Added CI status badge** for the Tests workflow (GitHub Actions)
- **Added Python version badge** (3.11+) 
- **Updated test count** from `520+` to `550+` (current: 552 tests)

Makes project status more visible at a glance for potential users/contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project badges with GitHub Actions Tests and Python 3.11+ compatibility indicators
  * Updated test suite count reference to reflect current coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->