### PR TITLE
fix: align routes.py CSRF testing check with CHANGELOG

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -151,7 +151,7 @@ def _check_auth() -> ResponseReturnValue | None:
 def _check_csrf() -> ResponseReturnValue | None:
     """Require X-Requested-With header on state-changing requests."""
     if request.method in ("POST", "PUT", "DELETE", "PATCH"):
-        if current_app.testing:
+        if current_app.config.get("TESTING"):
             return None
         if request.headers.get("X-Requested-With") != "XMLHttpRequest":
             return _error("CSRF validation failed", 403)


### PR DESCRIPTION
## Summary

PR #481 added a CHANGELOG.md entry stating that `current_app.testing` was changed to `current_app.config.get("TESTING")` in routes.py. However, the actual code change was never made — it was listed in the changelog but not included in PR #480's changes (which only touched config.py, sync.py, and tests/virtual_jellyfin.py).

This PR fixes the inconsistency by making the code match the documented behavior.

## Change

- `routes.py`: Replace `current_app.testing` with `current_app.config.get("TESTING")` in the CSRF testing bypass (line 154)