### PR TITLE
docs: document NETWORK_RETRY_* env vars and python3 usage in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is not overwritten if another thread populated it during the fetch.
 
 ### Changed
+- Documented `NETWORK_RETRY_*` environment variables in the README env vars table
+  (total, backoff factor, and status-forcelist) for better discoverability.
+- Updated README example commands to use `python3` for consistency with system defaults.
+- Extended `network.py` module docstring to mention the `put` and `patch` helpers
+  so the public API is fully documented.
 - Minor documentation improvements in README.md and docstrings.
 - Moved `_SOURCE_DISPATCH` routing from a module-level dict of lambdas to a
   `match/case`-based `_dispatch_list_source` function, removing the unused

--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ The application reads the following environment variables (which take precedence
 | `FLASK_PORT` | Server port (default: `5000`) |
 | `FLASK_DEBUG` | Enable Flask debug mode (`true`/`false`) |
 | `ANILIST_API_URL` | AniList GraphQL endpoint (default: `https://graphql.anilist.co`) |
+| `NETWORK_RETRY_TOTAL` | Max HTTP retries (default: `3`; set `0` to disable) |
+| `NETWORK_RETRY_BACKOFF_FACTOR` | Sleep multiplier between retries (default: `1.0`) |
+| `NETWORK_RETRY_STATUS_FORCELIST` | Status codes that trigger reretry (default: `429,500,502,503,504`) |
 
 > **Note**: Environment variable overrides are *never* persisted back to `config.json`. They only affect the current process.
 
@@ -265,38 +268,38 @@ See [`.env.example`](.env.example) for quick setup.
    ```bash
    pip install -e .[dev]
    ```
-4. Run: `python app.py`.
+4. Run: `python3 app.py`.
 
 ### 🧪 Testing
 
 ```bash
 # Run the full test suite (550+ tests, 100% coverage)
-python -m pytest
+python3 -m pytest
 
 # Run tests with coverage report
-python -m pytest --cov=.
+python3 -m pytest --cov=.
 
 # Run a specific test file
-python -m pytest tests/test_routes.py -v
+python3 -m pytest tests/test_routes.py -v
 
 # Run without slow integration/exhaustive tests
-python -m pytest -m "not exhaustive" tests/
+python3 -m pytest -m "not exhaustive" tests/
 
 # Generate an HTML coverage report
-python -m pytest --cov=. --cov-report=html
+python3 -m pytest --cov=. --cov-report=html
 open htmlcov/index.html
 ```
 
 Run tests and save output to a file:
 ```bash
-python run_tests_to_file.py
+python3 run_tests_to_file.py
 ```
 
 #### Virtual Jellyfin for Development
 If you don't have a real Jellyfin server handy, or want to test without affecting your real setup, you can run a **mock Jellyfin server**:
 
 ```bash
-python start_virtual_jellyfin.py
+python3 start_virtual_jellyfin.py
 ```
 
 This will start a mock API at `http://localhost:8096`. You can then:

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The application reads the following environment variables (which take precedence
 | `ANILIST_API_URL` | AniList GraphQL endpoint (default: `https://graphql.anilist.co`) |
 | `NETWORK_RETRY_TOTAL` | Max HTTP retries (default: `3`; set `0` to disable) |
 | `NETWORK_RETRY_BACKOFF_FACTOR` | Sleep multiplier between retries (default: `1.0`) |
-| `NETWORK_RETRY_STATUS_FORCELIST` | Status codes that trigger reretry (default: `429,500,502,503,504`) |
+| `NETWORK_RETRY_STATUS_FORCELIST` | Status codes that trigger retry (default: `429,500,502,503,504`) |
 
 > **Note**: Environment variable overrides are *never* persisted back to `config.json`. They only affect the current process.
 

--- a/network.py
+++ b/network.py
@@ -1,10 +1,10 @@
 """network.py - Retry-aware HTTP for external API calls.
 
-Provides explicit :func:`get`, :func:`post`, and :func:`delete` helpers
+Provides explicit :func:`get`, :func:`post`, :func:`put`, :func:`patch`, and :func:`delete` helpers
 that delegate to a shared :class:`requests.Session` configured with
 exponential-backoff retry on transient failures (5xx, connection errors).
 
-Import these helpers instead of ``requests.get`` / ``requests.post`` / ``requests.delete``
+Import these helpers instead of ``requests.get`` / ``requests.post`` / etc.
 to benefit from retry logic with **zero monkey-patching**.
 """
 


### PR DESCRIPTION
## Summary

Documentation improvements for the README and network module docstring:

- **README**: Added `NETWORK_RETRY_TOTAL`, `NETWORK_RETRY_BACKOFF_FACTOR`, and `NETWORK_RETRY_STATUS_FORCELIST` to the environment variables table for discoverability
- **README**: Updated all example shell commands from `python` to `python3` for consistency with system defaults
- **network.py**: Extended module docstring to list `put` and `patch` helpers so the full public API is documented
- **CHANGELOG.md**: Documented the changes

## Testing

- Full test suite passes (550+ tests)
- No code logic changes — documentation only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented additional HTTP retry environment variables (`NETWORK_RETRY_TOTAL`, `NETWORK_RETRY_BACKOFF_FACTOR`, `NETWORK_RETRY_STATUS_FORCELIST`) with defaults and behavior notes.
  * Updated installation and testing command examples to use Python 3.
  * Clarified publicly available HTTP helper functions in API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->