### PR TITLE
feat: support PUT/PATCH in _request_or_raise, add test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Healthcheck in `docker-compose.yml` uses `python3` for consistency.
 - Updated README Docker environment example to include `NETWORK_RETRY_*` vars.
 - Fixed output path in `run_tests_to_file.py` to use absolute repo-root path.
+- Added PUT and PATCH method support to `_request_or_raise` in jellyfin.py
+  (future-proofing — network.py already provides retry-aware helpers for these).
+- Achieved 100% code coverage across all 12 source modules (1881/1881 lines).
 - Moved `_SOURCE_DISPATCH` routing from a module-level dict of lambdas to a
   `match/case`-based `_dispatch_list_source` function, removing the unused
   dispatch table.

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -166,6 +166,10 @@ def _request_or_raise(
     try:
         if method == "POST":
             response = network.post(url, timeout=timeout, **kwargs)
+        elif method == "PUT":
+            response = network.put(url, timeout=timeout, **kwargs)
+        elif method == "PATCH":
+            response = network.patch(url, timeout=timeout, **kwargs)
         elif method == "DELETE":
             response = network.delete(url, timeout=timeout, **kwargs)
         else:

--- a/tests/test_jellyfin_api.py
+++ b/tests/test_jellyfin_api.py
@@ -844,8 +844,34 @@ def test_post_or_raise_with_data(mock_post) -> None:
 def test_request_or_raise_unsupported_method() -> None:
     from jellyfin import _request_or_raise
 
-    with pytest.raises(ValueError, match="Unsupported HTTP method: PUT"):
-        _request_or_raise("PUT", "http://test")
+    with pytest.raises(ValueError, match="Unsupported HTTP method: OPTIONS"):
+        _request_or_raise("OPTIONS", "http://test")
+
+
+@patch("jellyfin.network.put")
+@patch("jellyfin.network.get")
+def test_request_or_raise_put(mock_get, mock_put) -> None:
+    """PUT method delegates to network.put."""
+    mock_put.return_value = MagicMock()
+    mock_put.return_value.raise_for_status.return_value = None
+    from jellyfin import _request_or_raise
+
+    resp = _request_or_raise("PUT", "http://test")
+    assert resp is mock_put.return_value
+    mock_put.assert_called_once()
+
+
+@patch("jellyfin.network.patch")
+@patch("jellyfin.network.get")
+def test_request_or_raise_patch(mock_get, mock_patch) -> None:
+    """PATCH method delegates to network.patch."""
+    mock_patch.return_value = MagicMock()
+    mock_patch.return_value.raise_for_status.return_value = None
+    from jellyfin import _request_or_raise
+
+    resp = _request_or_raise("PATCH", "http://test")
+    assert resp is mock_patch.return_value
+    mock_patch.assert_called_once()
 
 
 @patch("jellyfin.network.get")

--- a/tests/test_sync_uncovered.py
+++ b/tests/test_sync_uncovered.py
@@ -118,3 +118,22 @@ def test_parse_mmdd_non_numeric() -> None:
 
     assert _parse_mmdd("ab-cd") == (0, 0)
     assert _parse_mmdd("01-XX") == (0, 0)
+
+
+def test_dispatch_list_source_unknown_type() -> None:
+    """_dispatch_list_source returns ( [], error_msg, 400 ) for unknown source_type."""
+    from sync import _dispatch_list_source
+
+    items, error, code = _dispatch_list_source(
+        "nonexistent_source",
+        "test-group",
+        "val",
+        "name",
+        "http://jf:8096",
+        "key",
+        "",
+    )
+    assert items == []
+    assert error is not None
+    assert "Unknown source type" in error
+    assert code == 400


### PR DESCRIPTION
## Summary

This PR adds PUT/PATCH support to `_request_or_raise` in `jellyfin.py` (future-proofing since `network.py` already supports these methods) and adds missing test coverage.

### Changes

- **jellyfin.py**: Added PUT and PATCH method support to `_request_or_raise`, matching the existing POST/DELETE handling. The `network.py` module already provides retry-aware `put()` and `patch()` helpers.
- **tests/test_jellyfin_api.py**: Updated unsupported-method test from PUT → OPTIONS. Added dedicated tests for PUT and PATCH in `_request_or_raise`.
- **tests/test_sync_uncovered.py**: Added test for the `case _:` default branch in `_dispatch_list_source` (unknown source type returns error with status 400).

### Testing

- All 538 tests pass (up from 535)
- 100% code coverage across all 12 source modules (1881/1881 lines)
- Mypy passes with no issues
- Ruff linting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PUT and PATCH HTTP methods for API requests

* **Tests**
  * Enhanced test suite with new unit tests for HTTP method handling and delegation
  * Added coverage validation for edge case scenarios

* **Chores**
  * Achieved 100% code coverage across all modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->