### PR TITLE
docs: fix stale README REST API docs & refactor FLASK_DEBUG parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,43 +182,49 @@ are prefixed with `/api/`.
 | Endpoint | Method | Description |
 |---|---|---|
 | `/api/config` | `GET` | Load the current configuration |
-| `/api/config` | `POST` | Save the configuration (requires JSON body with config fields) |
-| `/api/config/export` | `POST` | Export configuration as a download |
-| `/api/config/import` | `POST` | Import configuration from a JSON file upload |
-| `/api/settings` | `GET` | Get current server/path settings |
+| `/api/config` | `POST` | Save the configuration (requires JSON body with config fields)
+
+### Server / Connection
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/test-server` | `POST` | Test connectivity to a Jellyfin server |
+| `/api/upload_cover` | `POST` | Upload a cover image for a group (base64-encoded data URL) |
 
 ### Jellyfin
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/api/jellyfin/metadata` | `POST` | Fetch available metadata (genres, actors, studios, tags, years) |
+| `/api/jellyfin/metadata` | `GET` | Fetch available metadata (genres, actors, studios, tags) |
+| `/api/jellyfin/users` | `GET` | Fetch the list of Jellyfin users (for recommendations) |
 | `/api/jellyfin/auto-detect-paths` | `POST` | Auto-detect path mappings between Jellyfin and host |
-| `/api/jellyfin/test-connection` | `POST` | Test the Jellyfin server connection |
 
 ### Sync & Preview
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/api/sync/preview` | `POST` | Preview which items would be matched for a single group |
-| `/api/sync/preview_all` | `POST` | Preview all configured groups without syncing |
-| `/api/sync` | `POST` | Execute a full synchronisation (creates symlinks/collections) |
-| `/api/sync/cleanup` | `POST` | Remove broken symlinks from the target directory |
+| `/api/grouping/preview` | `POST` | Preview which items match a single grouping rule |
+| `/api/sync/preview_all` | `POST` | Preview all configured groups without making changes |
+| `/api/sync` | `POST` | Execute a full synchronisation (creates symlinks / collections) |
 
-### Groups
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/api/groups` | `GET` | Get the list of configured groups |
-| `/api/groups` | `POST` | Add a new group |
-| `/api/groups/<id>` | `PUT` | Update an existing group |
-| `/api/groups/<id>` | `DELETE` | Delete a group and optionally its symlinks |
-
-### Export/Import
+### Cleanup
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/api/export-import/export` | `POST` | Export group configurations as JSON |
-| `/api/export-import/import` | `POST` | Import group configurations from JSON |
+| `/api/cleanup` | `GET` | List logical folders in the target directory |
+| `/api/cleanup` | `POST` | Delete selected folders and optionally their Jellyfin libraries |
+
+### Filesystem
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/browse` | `GET` | Browse the host filesystem (restricted to home + `/media` + `/mnt`) |
+
+### Diagnostics
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/test/results` | `GET` | Return the latest test output logs |
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from flask import Flask
 
-from config import CONFIG_FILE, DEFAULT_CONFIG, save_config
+from config import CONFIG_FILE, DEFAULT_CONFIG, _env_flag, save_config
 from routes import bp
 from scheduler import start_scheduler
 
@@ -61,5 +61,5 @@ if __name__ == "__main__":
         save_config(DEFAULT_CONFIG.copy())
 
     port = int(os.environ.get("FLASK_PORT", "5000"))
-    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    debug = _env_flag("FLASK_DEBUG")
     app.run(host="0.0.0.0", debug=debug, port=port)

--- a/config.py
+++ b/config.py
@@ -72,6 +72,16 @@ DEFAULT_CONFIG: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Parse an environment variable as a boolean flag.
+
+    Accepts ``"true"``, ``"1"``, ``"yes"`` (case-insensitive) as truthy.
+    All other values (including the default *False*) are falsy.
+    """
+    raw = os.environ.get(name, "")
+    return raw.strip().lower() in ("true", "1", "yes")
+
+
 def _fill_defaults(cfg: dict[str, Any], defaults: dict[str, Any]) -> None:
     """Fill missing keys in *cfg* from *defaults*, including nested dicts."""
     for key, default_value in defaults.items():

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -7,8 +7,8 @@ Provides a dashboard at http://localhost:8096.
 from __future__ import annotations
 
 import logging
-import os
 
+from config import _env_flag
 from tests.virtual_jellyfin import app
 
 logger = logging.getLogger(__name__)
@@ -17,5 +17,5 @@ if __name__ == "__main__":
     logger.info("Starting Virtual Jellyfin Mock Server...")
     logger.info("Dashboard: http://localhost:8096")
     logger.info("Press Ctrl+C to stop.")
-    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    debug = _env_flag("FLASK_DEBUG")
     app.run(host="0.0.0.0", port=8096, debug=debug)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,3 +153,49 @@ def test_config_no_migration_needed(temp_config) -> None:
     # Modern keys should be kept
     assert result["media_path_in_jellyfin"] == "/jellyfin/media"
     assert result["media_path_on_host"] == "/host/media"
+
+
+def test_env_flag_default() -> None:
+    """_env_flag returns False when the env var is not set."""
+    from config import _env_flag
+
+    assert _env_flag("THIS_VAR_SHOULD_NOT_EXIST_12345") is False
+
+
+def test_env_flag_true(monkeypatch) -> None:
+    """_env_flag returns True for "true"."""
+    from config import _env_flag
+
+    monkeypatch.setenv("TEST_ENV_FLAG", "true")
+    assert _env_flag("TEST_ENV_FLAG") is True
+
+
+def test_env_flag_case_insensitive(monkeypatch) -> None:
+    """_env_flag treats "True", "TRUE", "Yes" as truthy."""
+    from config import _env_flag
+
+    monkeypatch.setenv("TEST_ENV_FLAG_2", "TRUE")
+    assert _env_flag("TEST_ENV_FLAG_2") is True
+
+    monkeypatch.setenv("TEST_ENV_FLAG_3", "Yes")
+    assert _env_flag("TEST_ENV_FLAG_3") is True
+
+    monkeypatch.setenv("TEST_ENV_FLAG_4", "1")
+    assert _env_flag("TEST_ENV_FLAG_4") is True
+
+
+def test_env_flag_false_values(monkeypatch) -> None:
+    """_env_flag returns False for falsy values."""
+    from config import _env_flag
+
+    monkeypatch.setenv("TEST_ENV_FLAG_5", "false")
+    assert _env_flag("TEST_ENV_FLAG_5") is False
+
+    monkeypatch.setenv("TEST_ENV_FLAG_6", "0")
+    assert _env_flag("TEST_ENV_FLAG_6") is False
+
+    monkeypatch.setenv("TEST_ENV_FLAG_7", "no")
+    assert _env_flag("TEST_ENV_FLAG_7") is False
+
+    monkeypatch.setenv("TEST_ENV_FLAG_8", "")
+    assert _env_flag("TEST_ENV_FLAG_8") is False


### PR DESCRIPTION
## Summary

### 📚 README REST API Docs — Fixed
The REST API documentation in the README was significantly out of date. This PR corrects all endpoints to match `routes.py`:

- `/api/jellyfin/metadata`: fixed method from `POST` → `GET`
- `/api/jellyfin/test-connection` → replaced with actual `/api/test-server`
- `/api/sync/preview` → replaced with actual `/api/grouping/preview`
- `/api/sync/cleanup` → replaced with `/api/cleanup` (GET list + POST delete)
- Added missing endpoints: `/api/jellyfin/users`, `/api/upload_cover`, `/api/browse`, `/api/test/results`
- Removed dead endpoints: `config/export`, `config/import`, `settings`
- Reorganized into cleaner sections (Server/Connection, Cleanup, Filesystem, Diagnostics)

### 🔧 Refactor — DRY FLASK_DEBUG parsing
- Added `_env_flag(name, default=False)` helper to `config.py`, supporting `"true"`, `"1"`, `"yes"` (case-insensitive)
- Replaced duplicated `FLASK_DEBUG` env parsing in `app.py` and `start_virtual_jellyfin.py`
- Removed unused `os` import from `start_virtual_jellyfin.py`

### ✅ Tests
- Added 4 new tests covering `_env_flag` edge cases (unset, truthy, case-insensitive, falsy values)
- Coverage remains at **100%**
- All existing tests pass
- Ruff linting and mypy type-checking clean

Closes #N/A (no open issues matched)