### PR TITLE
test: add coverage for /api/health endpoint

### DIFF
--- a/tests/test_routes_uncovered.py
+++ b/tests/test_routes_uncovered.py
@@ -306,3 +306,47 @@ def test_auto_detect_partial_match() -> None:
     # Trailing matches: D.mkv, action = 2 components
     assert result_j == "/movies"
     assert result_h == "/host/media"
+
+
+# ---------------------------------------------------------------------------
+# Health endpoint coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("temp_config")
+def test_health_check_configured(client) -> None:
+    """
+    GET /api/health returns ok status, configured=True when
+    jellyfin_url, api_key, and target_path are all set.
+    """
+    from config import save_config
+
+    save_config({
+        "jellyfin_url": "http://jellyfin:8096",
+        "api_key": "test-key-123",
+        "target_path": "/media/groupings",
+        "groups": [{"name": "Movies"}, {"name": "Shows"}],
+    })
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["healthcheck"]["ok"] is True
+    assert data["healthcheck"]["configured"] is True
+    assert data["healthcheck"]["groups"] == 2
+
+
+@pytest.mark.usefixtures("temp_config")
+def test_health_check_unconfigured(client) -> None:
+    """
+    GET /api/health returns configured=False when config is empty.
+    """
+    from config import save_config
+
+    save_config({})
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "ok"
+    assert data["healthcheck"]["configured"] is False
+    assert data["healthcheck"]["groups"] == 0


### PR DESCRIPTION
## Summary

Adds test coverage for the new `/api/health` endpoint introduced in PR #493.

### Changes

- **`test_health_check_configured`** — verifies the endpoint returns `status: ok`, `configured: true`, and correct group count when all config fields are set.
- **`test_health_check_unconfigured`** — verifies `configured: false` and `groups: 0` when config is empty.

### Verification
- ✅ 534 tests pass with **100%** line coverage across all source files
- ✅ Ruff check clean
- ✅ mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for the health check endpoint with additional test scenarios to verify correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->