### PR TITLE
Add Makefile for common dev commands; address CodeRabbit review comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+.PHONY: install dev install-dev test test-all test-cov lint typecheck clean format run virtual-jellyfin docs
+
+# ── Installation ────────────────────────────────────────────────────────────
+
+install:
+	pip install -e .
+
+install-dev:
+	pip install -e ".[dev]"
+
+# ── Testing ─────────────────────────────────────────────────────────────────
+
+test:
+	python -m pytest -x -q --ignore=tests/test_deep_sync.py
+
+test-all:
+	python -m pytest
+
+test-cov:
+	python -m pytest --cov=. --cov-report=term-missing
+
+# ── Linting & Type Checking ─────────────────────────────────────────────────
+
+lint:
+	ruff check .
+
+typecheck:
+	mypy .
+
+# ── Code Quality ────────────────────────────────────────────────────────────
+
+format:
+	ruff format .
+
+clean:
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name '*.egg-info' -exec rm -rf {} + 2>/dev/null || true
+	rm -rf htmlcov .coverage
+
+# ── Development ──────────────────────────────────────────────────────────────
+
+run:
+	python app.py
+
+virtual-jellyfin:
+	python start_virtual_jellyfin.py
+
+# ── Docker ──────────────────────────────────────────────────────────────────
+
+docker-build:
+	docker build -t jellyfin-groupings .
+
+docker-run:
+	docker run -p 5000:5000 jellyfin-groupings


### PR DESCRIPTION
## Summary

This PR adds a convenient Makefile and addresses CodeRabbit review comments from PR #495.

### Changes

1. **Makefile** — Adds common developer commands (`test`, `lint`, `typecheck`, `run`, `format`, `clean`, `docker-build`, `docker-run`, `virtual-jellyfin`) to streamline development workflow for contributors.

2. **anilist.py** — Adds defensive `isinstance(user_list, dict)` check before accessing `user_list.get("entries")` when iterating over MediaListCollection lists. Prevents crashes on malformed API responses.

3. **scheduler.py** — Clarifies the `start_scheduler()` docstring to accurately describe behavior: when the scheduler is already running (re-entrant calls, tests, reloader child processes), starting is a no-op but jobs are always reloaded/refreshed.

### Testing

- All lint and typecheck CI checks pass.
- Makefile `test`, `lint`, and `typecheck` targets map to the existing project tooling.