### PR TITLE
Improve cover path resolution in dry_run mode and fix test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `_prepare_group_directory` now resolves the cover path even during dry runs,
+  so callers can access `source_cover` for preview purposes regardless of mode.
+- Improved `network.py` error logging to include the actual invalid value when
+  `NETWORK_RETRY_BACKOFF_FACTOR` fails to parse.
+
+### Fixed
+- Fixed order-dependent `test_clear_library_cache` test in `test_sync_more_edges.py`
+  by clearing the module-level cache before populating it.
+
 ### Added
 - Documented Makefile targets in README.md (test, lint, typecheck, run, format, etc.)
   for contributor discoverability.

--- a/network.py
+++ b/network.py
@@ -67,7 +67,8 @@ def _parse_retry_config() -> tuple[int, float, list[int]]:
         backoff = float(os.environ.get("NETWORK_RETRY_BACKOFF_FACTOR", "1.0"))
     except ValueError:
         logger.warning(
-            "Invalid NETWORK_RETRY_BACKOFF_FACTOR value, falling back to default 1.0",
+            "Invalid NETWORK_RETRY_BACKOFF_FACTOR value %r, falling back to default 1.0",
+            os.environ.get("NETWORK_RETRY_BACKOFF_FACTOR"),
         )
         backoff = 1.0
     if backoff < 0:

--- a/sync.py
+++ b/sync.py
@@ -181,15 +181,18 @@ def _get_cover_path(
 ) -> str | None:
     """Compute the expected cover image path for a group, resolving storage priority.
 
-    Priority:
-    1. Library-local .covers/ directory (new storage location).
-    2. Internal config/covers/ directory (legacy storage location).
+    Resolution order:
+    1. Library-local ``.covers/`` directory under *target_base* (new storage location).
+    2. Internal ``config/covers/`` directory (legacy storage location).
 
     Args:
         group_name: The human-readable name of the group.
-        target_base: The root library directory where .covers/ resides.
+        target_base: The root library directory where ``.covers/`` resides.
         check_exists: If True, return None if the file doesn't exist on disk.
-            If False, return the prioritized path regardless of existence (useful for saving).
+            If False, return the prioritized path regardless of disk presence
+            (useful for saving new covers — prefers the library-local path
+            when *target_base* is a directory, falling back to the legacy
+            config location otherwise).
 
     Returns:
         The absolute path to the cover image, or None if not found/possible.
@@ -209,7 +212,7 @@ def _get_cover_path(
     )
 
     if not check_exists:
-        # If we are just resolving where to SAVE, we prefer the library-local path if target_base exists
+        # Resolving where to SAVE: prefer library-local if target_base exists
         if target_base and Path(target_base).is_dir():
             return lib_cover_path
         return legacy_cover_path
@@ -1348,21 +1351,25 @@ def _prepare_group_directory(
 ) -> str | None:
     """Clean up and recreate the group directory, copying a cover image if available.
 
+    If *dry_run* is ``True`` the directory is not modified, but the cover path
+    is still resolved (if any) so callers can use it for preview purposes.
+
     Returns:
-        The path to the source cover image (or ``None`` if none found / dry run).
+        The path to the source cover image (or ``None`` if none found).
 
     Raises:
-        OSError: If the directory cannot be cleaned or created.
+        OSError: If the directory cannot be cleaned or created (only in
+            non-dry-run mode).
 
     """
-    source_cover: str | None = None
+    source_cover: str | None = _get_cover_path(group_name, target_base)
+
     if not dry_run:
         if Path(group_dir).exists():
             logger.info("Cleaning existing directory: %s", group_dir)
             shutil.rmtree(group_dir)
         Path(group_dir).mkdir(parents=True, exist_ok=True)
 
-        source_cover = _get_cover_path(group_name, target_base)
         if source_cover:
             poster_dest = str(Path(group_dir) / "poster.jpg")
             try:

--- a/tests/test_sync_more_edges.py
+++ b/tests/test_sync_more_edges.py
@@ -172,6 +172,7 @@ def test_clear_library_cache() -> None:
     """clear_library_cache clears the internal library cache dict."""
     from sync import _LIBRARY_CACHE, clear_library_cache
 
+    _LIBRARY_CACHE.clear()
     _LIBRARY_CACHE[("http://jf:8096", "key")] = [{"Id": "1"}]
     assert len(_LIBRARY_CACHE) == 1
     clear_library_cache()


### PR DESCRIPTION
## Summary

Three focused improvements to the codebase:

### 1. `_prepare_group_directory` resolves cover path during dry runs

Previously, `source_cover` was only computed inside the `if not dry_run:` block, meaning callers got `None` even when a valid cover existed. Now the cover path is always resolved, so preview and other dry-run consumers can access it.

### 2. Better error logging in `network.py`

When `NETWORK_RETRY_BACKOFF_FACTOR` fails to parse, the log message now includes the actual invalid value:
```python
"Invalid NETWORK_RETRY_BACKOFF_FACTOR value %r, falling back to default 1.0"
```

### 3. Fixed order-dependent test

`test_clear_library_cache` could fail when run after other tests that populated the module-level `_LIBRARY_CACHE`. Added `_LIBRARY_CACHE.clear()` before populating to ensure test isolation.

## Checklist

- [x] Tests pass (`pytest`)
- [x] MyPy passes
- [x] Changelog updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages to display the actual invalid value when network retry backoff configuration cannot be parsed, improving diagnostic clarity
  * Resolved a test flakiness issue by ensuring cache state is properly cleared before test execution

* **Changed**
  * Cover path resolution now occurs during dry-run operations, enabling access to cover information for preview purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->