### PR TITLE
Fix G201 logging, D401 docstring, add missing docstring param, add .gitignore for .cover files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ test_results.txt
 current_test_out.txt
 test_api_out.txt
 
-# Test artifacts
+# Coverage data (coverage.py may create .cover files)
+*.py,cover
 test_error.log
 coverage_report.txt
 pytest_verbose.log

--- a/routes.py
+++ b/routes.py
@@ -999,7 +999,7 @@ def browse_directory() -> ResponseReturnValue:
 
 @bp.route("/api/health", methods=["GET"])
 def health_check() -> ResponseReturnValue:
-    """Simple health check endpoint for Docker / Kubernetes probes.
+    """Provide a simple health check endpoint for Docker / Kubernetes probes.
 
     Returns a lightweight JSON response with service status, uptime
     (Flask app start time), and a quick config sanity check.

--- a/scheduler.py
+++ b/scheduler.py
@@ -167,11 +167,9 @@ def _run_global_sync_job(exclude_names: list[str]) -> None:
         with sync_lock:
             try:
                 run_sync(config, group_names=sync_names)
-            except (ValueError, OSError, RuntimeError) as exc:
-                logger.error(
-                    "Background global sync failed: %s",
-                    exc,
-                    exc_info=True,
+            except (ValueError, OSError, RuntimeError):
+                logger.exception(
+                    "Background global sync failed",
                 )
     else:
         logger.info(
@@ -186,12 +184,10 @@ def _run_group_sync_job(group_name: str) -> None:
     with sync_lock:
         try:
             run_sync(config, group_names=[group_name])
-        except (ValueError, OSError, RuntimeError) as exc:
-            logger.error(
-                "Background sync failed for group '%s': %s",
+        except (ValueError, OSError, RuntimeError):
+            logger.exception(
+                "Background sync failed for group '%s'",
                 group_name,
-                exc,
-                exc_info=True,
             )
 
 

--- a/sync.py
+++ b/sync.py
@@ -1552,6 +1552,7 @@ def _process_group(
         auto_set_library_covers: Whether to set library cover images.
         existing_libraries: List of libraries already created this run.
         target_path_in_jellyfin: Path prefix for Jellyfin library paths.
+        anilist_api_url: AniList API URL (may be None).
 
     Returns:
         A result dict with keys ``"group"``, ``"links"``, optionally ``"error"``,


### PR DESCRIPTION
## Changes

1. **Fix G201 logging warnings** (scheduler.py): Replace `logger.error(..., exc_info=True)` with `logger.exception()` for background sync error handlers. This is the idiomatic Python pattern that includes the full traceback automatically.

2. **Fix D401 docstring** (routes.py): Changed `"Simple health check endpoint..."` to `"Provide a simple health check endpoint..."` to use imperative mood as required by PEP 257.

3. **Add missing docstring param** (sync.py): Added `anilist_api_url` parameter description to `_process_group()` docstring.

4. **Prevent .cover file commits** (.gitignore): Added `*.py,cover` pattern to .gitignore. Coverage.py can create these files and they should not be tracked.

## Validation

- All unit tests pass
- ruff check passes with no new warnings