### PR TITLE
ci: Add ruff format check to CI and update docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Run ruff linter
       run: ruff check .
+    - name: Check ruff formatting
+      run: ruff format --check .
 
   typecheck:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,9 @@ Thank you for considering contributing! Here are a few guidelines to help things
 
 - Python: Follow [PEP 8](https://peps.python.org/pep-0008/). The project uses `ruff` for linting and formatting.
 - JavaScript: Follow standard ES module conventions. The project uses `eslint` for linting.
-- Run linting before committing:
+- Run linting and format-checking before committing:
   ```bash
-  ruff check .
-  ruff format --check .
+  make lint
   ```
 
 ### Type Hints

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev test test-all test-cov lint typecheck clean format run virtual-jellyfin docker-build docker-run
+.PHONY: install install-dev test test-all test-cov lint format-check typecheck clean format run virtual-jellyfin docker-build docker-run
 
 # ── Installation ────────────────────────────────────────────────────────────
 
@@ -23,6 +23,10 @@ test-cov:
 
 lint:
 	ruff check .
+	ruff format --check .
+
+format-check:
+	ruff format --check .
 
 typecheck:
 	mypy .

--- a/README.md
+++ b/README.md
@@ -315,7 +315,8 @@ A `Makefile` is provided for common development tasks:
 | `test` | Run the test suite (skips slow integration tests) |
 | `test-all` | Run the full test suite including integration tests |
 | `test-cov` | Run tests with a coverage report |
-| `lint` | Run Ruff linter (`ruff check .`) |
+| `lint` | Run Ruff linter and format check (`ruff check .` + `ruff format --check .`) |
+| `format-check` | Check code formatting without auto-fixing (`ruff format --check .`) |
 | `typecheck` | Run mypy type checker (`mypy .`) |
 | `format` | Auto-format code with Ruff (`ruff format .`) |
 | `clean` | Remove `__pycache__`, `.pytest_cache`, and build artifacts |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,8 +34,13 @@ You should receive a response within 48 hours. If the vulnerability is confirmed
 ### App Password
 
 - Set the `APP_PASSWORD` environment variable to enable HTTP Basic Auth for the web UI.
-- When enabled, all state-changing API endpoints require authentication.
-- The main UI page and static assets are accessible without authentication.
+- When enabled, authentication is required for **all** requests, enforced via a
+  Flask ``before_request`` handler on every route.
+- The only exemptions are the main UI page (``GET /``) and any ``/static/``
+  assets, which remain accessible without credentials so the page can load
+  CSS/JS files for the login dialog.
+- All API endpoints (including ``/api/health``) require authentication when
+  ``APP_PASSWORD`` is set.
 
 ### CSRF Protection
 

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -147,11 +147,13 @@ def test_fetch_anilist_list_entry_not_dict(mock_post) -> None:
                 "lists": [
                     "not a dict",
                     {"entries": None},
-                    {"entries": [
-                        "not a dict",
-                        {"mediaId": 12345},
-                        {},
-                    ]},
+                    {
+                        "entries": [
+                            "not a dict",
+                            {"mediaId": 12345},
+                            {},
+                        ]
+                    },
                 ],
             },
         },


### PR DESCRIPTION
## Summary

Adds a `ruff format --check` step to the CI lint workflow to prevent formatting drift. Previously only `ruff check` was run.

### Changes

1. **CI (`.github/workflows/test.yml`)** — Added `ruff format --check .` step after ruff linting.
2. **Makefile** — Updated `lint` to include format check; added `format-check` convenience target.
3. **SECURITY.md** — Fixed auth description to accurately reflect that `APP_PASSWORD` protects **all** routes via `before_request` (not just state-changing API endpoints), with only `/` and `/static/` exempted.
4. **CONTRIBUTING.md** — Updated to reference `make lint` which now includes both lint and format checks.
5. **README.md** — Updated Makefile targets table.
6. **tests/test_fetchers.py** — Ruff format fix (was 1 file out of compliance).

### Verification
- `ruff check .` — all checks pass
- `ruff format --check .` — all files formatted
- `pytest -x -q` — all tests pass (100% coverage)