### PR TITLE
style: Use theme variables for light mode, add print styles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,15 @@
 repos:
 -   repo: local
     hooks:
-    -   id: ruff
+    -   id: ruff-lint
         name: ruff linting
         entry: bash -c "ruff check ."
+        language: system
+        pass_filenames: false
+        always_run: true
+    -   id: ruff-format
+        name: ruff format check
+        entry: bash -c "ruff format --check ."
         language: system
         pass_filenames: false
         always_run: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Print-friendly stylesheet with hidden UI chrome, expanded link URLs, and
+  readable code blocks when printing docs/setup guides.
+
+### Changed
+- Scrollbar thumb colors now use `color-mix(in srgb, var(--text-secondary) …%,
+  transparent)` instead of hardcoded `rgba(255,255,255,…)` — adapts correctly
+  in light theme.
+- `#topbar` and `#sidebar::-webkit-scrollbar-thumb` backgrounds use
+  `color-mix()` with theme variables for light-mode compatibility.
+- Footer color uses `var(--text-secondary)` with `opacity` instead of hardcoded
+  `rgba(148, 163, 184, 0.45)`.
+- `.pre-commit-config.yaml` splits ruff into `ruff-lint` and `ruff-format`
+  hooks to match `make lint` target.
+- Removed deprecated `page-break-*` CSS properties (courtesy of CodeRabbit
+  review) — using modern `break-*` equivalents only.
+
 ### Changed
 - Improved `network.py` error logging to include the actual invalid value when
   `NETWORK_RETRY_TOTAL` or `NETWORK_RETRY_BACKOFF_FACTOR` fails to parse.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,18 @@ See [`.env.example`](.env.example) for quick setup.
    ```
 4. Run: `python3 app.py`.
 
+### Print-Friendly Pages
+
+The UI includes a print stylesheet that:
+- Hides navigation chrome (sidebar, topbar, modals, toasts), so you get clean
+  printed output of setup guides, API docs, or troubleshooting sections.
+- Shows link URLs after anchor text so printed references are still useful.
+- Prevents page breaks inside cards and headings.
+- Displays code blocks with visible borders for readability.
+
+Use your browser's **Print** function on any page to see the print-optimized
+layout.
+
 ### Makefile Targets
 
 A `Makefile` is provided for common development tasks:

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -1309,7 +1309,7 @@ pre {
 }
 
 ::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, var(--text-secondary) 15%, transparent);
     border-radius: 3px;
 }
 

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -47,7 +47,7 @@
     align-items: center;
     gap: 1rem;
     padding: 0 1.5rem;
-    background: rgba(13, 13, 18, 0.85);
+    background: color-mix(in srgb, var(--bg-color) 85%, transparent);
     backdrop-filter: blur(20px);
     border-bottom: 1px solid var(--glass-border);
 }
@@ -206,7 +206,7 @@
 }
 
 #sidebar::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.1);
+    background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
     border-radius: 3px;
 }
 
@@ -227,7 +227,7 @@
 }
 
 #main-content::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.08);
+    background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
     border-radius: 3px;
 }
 
@@ -236,7 +236,8 @@
     margin-top: auto;
     padding-top: 1rem;
     font-size: 0.72rem;
-    color: rgba(148, 163, 184, 0.45);
+    color: var(--text-secondary);
+    opacity: 0.45;
     text-align: center;
 }
 

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -263,7 +263,6 @@
     .group-card {
         border: 1px solid #ccc !important;
         break-inside: avoid;
-        page-break-inside: avoid;
     }
 
     a[href]::after {
@@ -277,7 +276,6 @@
     h3,
     h4 {
         break-after: avoid;
-        page-break-after: avoid;
     }
 
     pre,

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -224,3 +224,65 @@
         transition-duration: 0.01ms !important;
     }
 }
+
+/* ─────────────────────────────────────────────────────────
+   PRINT  (docs, setup guides, troubleshooting)
+───────────────────────────────────────────────────────── */
+@media print {
+    * {
+        background: transparent !important;
+        color: #000 !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    #sidebar,
+    #topbar,
+    .modal,
+    #status-msg,
+    .bg-blob,
+    #loading-overlay,
+    .skip-to-content {
+        display: none !important;
+    }
+
+    #app-layout {
+        position: static;
+        display: block;
+        margin-top: 0;
+        height: auto;
+    }
+
+    #main-content {
+        height: auto;
+        overflow: visible;
+        padding: 0;
+    }
+
+    .card,
+    .group-card {
+        border: 1px solid #ccc !important;
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+
+    a[href]::after {
+        content: " (" attr(href) ")";
+        font-size: 0.75em;
+        color: #555 !important;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4 {
+        break-after: avoid;
+        page-break-after: avoid;
+    }
+
+    pre,
+    code {
+        border: 1px solid #ccc !important;
+        font-size: 0.8rem;
+    }
+}


### PR DESCRIPTION
## Summary

CSS improvements for theme adaptability and print compatibility.

### Changes

1. **layout.css** — Replace hardcoded dark  on `#topbar` with `color-mix(in srgb, var(--bg-color) 85%, transparent)` so it adapts correctly in light theme. Same treatment for scrollbar thumb colors and footer color.

2. **components.css** — Global webkit scrollbar thumb uses `var(--text-secondary)` via `color-mix()` instead of hardcoded `rgba(255,255,255,0.1)`.

3. **responsive.css** — New `@media print` block:
   - Hides UI chrome (sidebar, topbar, modals, toasts, blobs, overlays)
   - Flattens layout for readable print output
   - Shows link URLs after anchor text (`a[href]::after`)
   - Prevents page breaks inside cards/headings
   - Styles code blocks with visible borders

4. **.pre-commit-config.yaml** — Split the single ruff hook into separate `ruff-lint` and `ruff-format` hooks, matching the `make lint` target (which now includes `ruff format --check`).

### Verification
- `ruff check .` — all checks pass
- `ruff format --check .` — 47 files already formatted
- `mypy .` — no issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scrollbar styling in multiple components to use dynamic theme color variables instead of static hardcoded values, enhancing visual consistency throughout the application
  * Added comprehensive print stylesheet with optimizations for document layout, element visibility, improved readability, and link preservation in printed output
  * Refined UI element colors to better align with the application's theme scheme

* **Chores**
  * Updated pre-commit hook configuration for code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->