### PR TITLE
docs: add module docstring to test_e2e __init__.py

### DIFF
--- a/tests/test_e2e/__init__.py
+++ b/tests/test_e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests for Jellyfin Groupings."""


### PR DESCRIPTION
Adds a missing module docstring to the e2e test package `__init__.py` for consistency with other packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added documentation to the end-to-end test module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->