### PR TITLE
docs: add module docstrings to tests/conftest.py and tests/virtual_jellyfin.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Shared pytest fixtures and configuration for the test suite."""
+
 import logging
 import threading
 import time

--- a/tests/virtual_jellyfin.py
+++ b/tests/virtual_jellyfin.py
@@ -1,3 +1,10 @@
+"""A lightweight Flask mock of the Jellyfin API for end-to-end testing.
+
+Provides stubbed endpoints for libraries, items, and user views so that
+the test suite can exercise the full sync pipeline without a live Jellyfin
+server.
+"""
+
 from __future__ import annotations
 
 import uuid


### PR DESCRIPTION
Adds missing module docstrings to two test files for consistency with the rest of the test suite.