### PR TITLE
Robustness improvements across the board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target base directory.
 - `config.py` `_fill_defaults` now recursively populates nested defaults
   (e.g. scheduler sub-keys) instead of only one level deep.
+- Added tests for the new code paths:
+  - `test_parse_retry_config_module_level_fallback` covers the `ValueError`
+    fallback in `network.py` at module import time.
+  - `test_delete_folder_invalid_name` covers invalid folder name rejection
+    in `_delete_folder`.
+  - `test_delete_folder_path_traversal_via_symlink` covers the path-traversal
+    detection via symlink resolution.
+  - `test_delete_folder_resolve_oserror` covers OSError from `Path.resolve()`.
+  - `test_search_filesystem_ismount_oserror` covers OSError from
+    `os.path.ismount()` in `_search_local_filesystem`.
 
 ### Changed
 - Scrollbar thumb colors now use `color-mix(in srgb, var(--text-secondary) …%,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ANILIST_API_URL` environment variable example in `docker-compose.yml`.
+- Tests for `_fill_defaults` resilience when `scheduler` is `null` or a non-dict
+  value in the stored config.
+- Documented Makefile targets in README.md (test, lint, typecheck, run, format, etc.)
+  for contributor discoverability.
+- Initial CHANGELOG.md for project tracking.
+- Added `anilist_api_url` to `DEFAULT_CONFIG` to prevent KeyError when config
+  is accessed before the key is explicitly set.
+- Documented `NETWORK_RETRY_*` environment variables in the README env vars table
+  and added them to `.env.example` and `docker-compose.yml` for discoverability.
+- Add test coverage for `/api/health` endpoint (configured and unconfigured cases)
+  via PR #494.
+- Added SVG favicon (`🎬` emoji) to base template for better browser tabs.
 - Print-friendly stylesheet with hidden UI chrome, expanded link URLs, and
   readable code blocks when printing docs/setup guides.
 - `network.py` now gracefully falls back to default retry settings when
@@ -31,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `test_delete_folder_resolve_oserror` covers OSError from `Path.resolve()`.
   - `test_search_filesystem_ismount_oserror` covers OSError from
     `os.path.ismount()` in `_search_local_filesystem`.
+- Robust containment check in `routes.py` `_delete_folder` using
+  `resolved.relative_to(base_resolved)` instead of substring matching.
+- `config.py` `_fill_defaults` now uses `copy.deepcopy` for missing nested
+  keys via membership check, eliminating aliasing with `DEFAULT_CONFIG`.
 
 ### Changed
 - Scrollbar thumb colors now use `color-mix(in srgb, var(--text-secondary) …%,
@@ -44,8 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hooks to match `make lint` target.
 - Removed deprecated `page-break-*` CSS properties (courtesy of CodeRabbit
   review) — using modern `break-*` equivalents only.
-
-### Changed
 - Improved `network.py` error logging to include the actual invalid value when
   `NETWORK_RETRY_TOTAL` or `NETWORK_RETRY_BACKOFF_FACTOR` fails to parse.
 - Stricter `_handle_http_error` signature in `routes.py` to accept `HTTPException`
@@ -84,9 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed `_fill_defaults` in `config.py` to use `copy.deepcopy` for nested
-  default dicts instead of `dict.copy()`, preventing shallow-copy issues.
-  a string) for nested keys like `scheduler` with the full default dict, preventing
-  `AttributeError` downstream when accessing sub-keys.
+  default dicts instead of `dict.copy()`, preventing shallow-copy issues
+  and aliasing with `DEFAULT_CONFIG`.
 - Fixed order-dependent `test_clear_library_cache` test in `test_sync_more_edges.py`
   by clearing the module-level cache before populating it.
 - Improved CSRF testing check in `routes.py` to use the standard Flask
@@ -95,21 +109,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passed non-string types (already handled gracefully as a fallback).
 - Fixed double-checked locking pattern in `_fetch_full_library()` so the cache
   is not overwritten if another thread populated it during the fetch.
-
-### Added
-- `ANILIST_API_URL` environment variable example in `docker-compose.yml`.
-- Tests for `_fill_defaults` resilience when `scheduler` is `null` or a non-dict
-  value in the stored config.
-- Documented Makefile targets in README.md (test, lint, typecheck, run, format, etc.)
-  for contributor discoverability.
-- Initial CHANGELOG.md for project tracking.
-- Added `anilist_api_url` to `DEFAULT_CONFIG` to prevent KeyError when config
-  is accessed before the key is explicitly set.
-- Documented `NETWORK_RETRY_*` environment variables in the README env vars table
-  and added them to `.env.example` and `docker-compose.yml` for discoverability.
-- Add test coverage for `/api/health` endpoint (configured and unconfigured cases)
-  via PR #494.
-- Added SVG favicon (`🎬` emoji) to base template for better browser tabs.
 
 ## [1.0.0] - 2025-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Print-friendly stylesheet with hidden UI chrome, expanded link URLs, and
   readable code blocks when printing docs/setup guides.
+- `network.py` now gracefully falls back to default retry settings when
+  environment variables contain invalid values (previously raised `ValueError`
+  at module import time).
+- `sync.py` logs a warning when the config contains no groups to sync.
+- `scheduler.py` now logs warnings when a group with `schedule_enabled` is
+  missing a name or has a non-string name.
+- Path-traversal protection in `routes.py` `_delete_folder`: rejects names
+  with path separators and validates the resolved path stays within the
+  target base directory.
+- `config.py` `_fill_defaults` now recursively populates nested defaults
+  (e.g. scheduler sub-keys) instead of only one level deep.
 
 ### Changed
 - Scrollbar thumb colors now use `color-mix(in srgb, var(--text-secondary) …%,

--- a/config.py
+++ b/config.py
@@ -97,14 +97,17 @@ def _fill_defaults(cfg: dict[str, Any], defaults: dict[str, Any]) -> None:
     requiring the caller to specify every intermediate level.
     """
     for key, default_value in defaults.items():
-        cfg.setdefault(key, default_value)
+        if key not in cfg:
+            # Deep-copy to prevent runtime mutations of cfg from aliasing
+            # the DEFAULT_CONFIG object (via setdefault).
+            cfg[key] = copy.deepcopy(default_value)
         if isinstance(default_value, dict):
             current = cfg.get(key)
             if isinstance(current, dict):
                 _fill_defaults(current, default_value)
-            else:
-                # Value exists but is not a dict (e.g. None, empty string) —
-                # replace with a deep copy to avoid AttributeError downstream.
+            elif not isinstance(current, dict):
+                # Value exists but is not a dict — replace with a deep copy
+                # to avoid AttributeError downstream.
                 cfg[key] = copy.deepcopy(default_value)
 
 

--- a/config.py
+++ b/config.py
@@ -90,16 +90,22 @@ def _env_flag(name: str, *, default: bool = False) -> bool:
 
 
 def _fill_defaults(cfg: dict[str, Any], defaults: dict[str, Any]) -> None:
-    """Fill missing keys in *cfg* from *defaults*, including nested dicts."""
+    """Fill missing keys in *cfg* from *defaults*, recursing into nested dicts.
+
+    Recursively walks *defaults* so that deeply nested structures (e.g.
+    scheduler config with arbitrary sub-keys) are properly populated without
+    requiring the caller to specify every intermediate level.
+    """
     for key, default_value in defaults.items():
         cfg.setdefault(key, default_value)
-        if isinstance(default_value, dict) and isinstance(cfg.get(key), dict):
-            for sub_key, sub_val in default_value.items():
-                cfg[key].setdefault(sub_key, sub_val)
-        elif isinstance(default_value, dict):
-            # If the value exists but is not a dict (e.g. None, empty string),
-            # replace it with the default to avoid AttributeError downstream.
-            cfg[key] = copy.deepcopy(default_value)
+        if isinstance(default_value, dict):
+            current = cfg.get(key)
+            if isinstance(current, dict):
+                _fill_defaults(current, default_value)
+            else:
+                # Value exists but is not a dict (e.g. None, empty string) —
+                # replace with a deep copy to avoid AttributeError downstream.
+                cfg[key] = copy.deepcopy(default_value)
 
 
 def _migrate_legacy_keys(cfg: dict[str, Any]) -> bool:

--- a/network.py
+++ b/network.py
@@ -105,7 +105,17 @@ def _parse_retry_config() -> tuple[int, float, list[int]]:
     return total, backoff, statuses
 
 
-_RETRY_TOTAL, _RETRY_BACKOFF_FACTOR, _RETRY_STATUS_FORCELIST = _parse_retry_config()
+try:
+    _RETRY_TOTAL, _RETRY_BACKOFF_FACTOR, _RETRY_STATUS_FORCELIST = (
+        _parse_retry_config()
+    )
+except ValueError:
+    logger.exception(
+        "Invalid retry configuration in environment — falling back to defaults"
+    )
+    _RETRY_TOTAL = 3
+    _RETRY_BACKOFF_FACTOR = 1.0
+    _RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]
 _ALLOWED_RETRY_METHODS: frozenset[str] = frozenset(
     {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"},
 )

--- a/network.py
+++ b/network.py
@@ -106,9 +106,7 @@ def _parse_retry_config() -> tuple[int, float, list[int]]:
 
 
 try:
-    _RETRY_TOTAL, _RETRY_BACKOFF_FACTOR, _RETRY_STATUS_FORCELIST = (
-        _parse_retry_config()
-    )
+    _RETRY_TOTAL, _RETRY_BACKOFF_FACTOR, _RETRY_STATUS_FORCELIST = _parse_retry_config()
 except ValueError:
     logger.exception(
         "Invalid retry configuration in environment — falling back to defaults"

--- a/routes.py
+++ b/routes.py
@@ -724,12 +724,29 @@ def _delete_folder(
 ) -> tuple[bool, str | None]:
     """Delete a single folder and optionally its Jellyfin library.
 
+    Args:
+        name: Folder name (validated against path traversal).
+        target_base: Absolute base path for the target directory.
+        auto_create_libraries: Whether to also clean up the Jellyfin library.
+        url: Jellyfin server URL.
+        api_key: Jellyfin API key.
+
     Returns:
         ``(deleted, error_message)`` where *deleted* is True if the folder
         was removed successfully.
 
     """
+    # Prevent path-traversal attacks: reject names with separators
+    if not _is_valid_folder_name(name):
+        return False, f"Invalid folder name: {name}"
     path = Path(target_base) / name
+    # Resolve the path to ensure it is still within target_base (symlink-safe)
+    try:
+        resolved = path.resolve()
+    except (OSError, RuntimeError):
+        resolved = path
+    if target_base not in str(resolved.parent):
+        return False, f"Path traversal detected for: {name}"
     if not path.exists() or not path.is_dir():
         return False, None
     try:
@@ -822,7 +839,13 @@ def _search_local_filesystem(
         if not Path(root).is_dir():
             continue
         for dirpath, dirnames, filenames in os.walk(root):
-            if os.path.ismount(dirpath) and dirpath != root:
+            try:
+                is_mount = os.path.ismount(dirpath)
+            except OSError:
+                # Permission denied or inaccessible — skip this directory
+                dirnames.clear()
+                continue
+            if is_mount and dirpath != root:
                 dirnames.clear()
                 continue
             if time.monotonic() - walk_start > timeout:

--- a/routes.py
+++ b/routes.py
@@ -745,7 +745,13 @@ def _delete_folder(
         resolved = path.resolve()
     except (OSError, RuntimeError):
         resolved = path
-    if target_base not in str(resolved.parent):
+    try:
+        base_resolved = Path(target_base).resolve()
+    except (OSError, RuntimeError):
+        base_resolved = Path(target_base)
+    try:
+        resolved.relative_to(base_resolved)
+    except ValueError:
         return False, f"Path traversal detected for: {name}"
     if not path.exists() or not path.is_dir():
         return False, None

--- a/scheduler.py
+++ b/scheduler.py
@@ -77,11 +77,24 @@ def _schedule_group_syncs(scheduler: BackgroundScheduler, groups: list[Any]) -> 
     seen_ids: set[str] = set()
     for group in groups:
         if not isinstance(group, dict):
+            logger.warning(
+                "Skipping invalid group entry (expected dict, got %s): %s",
+                type(group).__name__,
+                group,
+            )
             continue
         group_name = group.get("name")
         if not group_name:
+            logger.warning(
+                "Skipping group with schedule_enabled but missing name: %s",
+                group,
+            )
             continue
         if not isinstance(group_name, str):
+            logger.warning(
+                "Skipping group with schedule_enabled but non-string name: %s",
+                group_name,
+            )
             continue
         if group.get("schedule_enabled") and group.get("schedule"):
             cron_expr = group["schedule"]

--- a/sync.py
+++ b/sync.py
@@ -1890,6 +1890,10 @@ def run_sync(
         _LIBRARY_CACHE.clear()
 
     results: list[dict[str, Any]] = []
+    if not groups:
+        logger.warning("No groups configured — nothing to sync")
+        return results
+
     for group in groups:
         if not isinstance(group, dict):
             logger.info("Skipping invalid group entry: %s", group)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -426,3 +426,32 @@ def testpatch_connection_error_re_raise(monkeypatch) -> None:
     monkeypatch.setattr(_SESSION, "patch", _fail)
     with pytest.raises(requests.ConnectionError):
         patch("http://example.com/api")
+
+
+# ---------------------------------------------------------------------------
+# Module-level default retry fallback (lines 112-118)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_config_module_level_fallback(monkeypatch) -> None:
+    """When _parse_retry_config raises at import, module-level defaults are used.
+
+    This tests the ``except ValueError`` fallback at the bottom of network.py
+    by setting an invalid env var and re-importing the module.
+    """
+    import importlib
+
+    import network as network_mod
+
+    monkeypatch.setenv("NETWORK_RETRY_TOTAL", "-1")
+    importlib.reload(network_mod)
+
+    assert network_mod._RETRY_TOTAL == 3
+    assert network_mod._RETRY_BACKOFF_FACTOR == 1.0
+    assert 429 in network_mod._RETRY_STATUS_FORCELIST
+    assert network_mod._RETRY_STATUS_FORCELIST == [429, 500, 502, 503, 504]
+
+    # Reload again with valid settings so subsequent tests are unaffected
+    monkeypatch.delenv("NETWORK_RETRY_TOTAL", raising=False)
+    importlib.reload(network_mod)
+    assert network_mod._RETRY_TOTAL == 3

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1449,6 +1449,6 @@ def test_search_filesystem_ismount_oserror(mock_ismount) -> None:
         mock_ismount.side_effect = OSError("Permission denied")
 
         result = _search_local_filesystem("movie.mkv", [str(test_dir)])
-        # Should return None because the only sub-directory raised an OSError
-        # and was skipped (dirnames cleared), but the root itself may still match
-        assert result is None or result == str(test_dir / "movie.mkv")
+        # ismount OSError on the root causes continue before checking filenames,
+        # so the file is never found
+        assert result is None

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1360,3 +1360,95 @@ def test_check_auth_with_no_password(app, monkeypatch) -> None:
     # and the request proceeds normally. The endpoint needs X-Requested-With
     # for POST, but GET endpoints don't need it. /api/config is GET so it works.
     assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# _delete_folder: path-traversal checks (lines 741, 746-749)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_folder_invalid_name() -> None:
+    """_delete_folder rejects folder names with path separators (line 741)."""
+    from routes import _delete_folder
+
+    deleted, err = _delete_folder("../etc", "/tmp/base", False, "", "")
+    assert deleted is False
+    assert err == "Invalid folder name: ../etc"
+
+    deleted, err = _delete_folder("sub/dir", "/tmp/base", False, "", "")
+    assert deleted is False
+    assert err == "Invalid folder name: sub/dir"
+
+
+def test_delete_folder_path_traversal_via_symlink(tmp_path) -> None:
+    """_delete_folder detects path traversal when resolved path escapes target_base (line 749)."""
+    from routes import _delete_folder
+
+    target_base = str(tmp_path / "target")
+    (tmp_path / "target").mkdir()
+    # Create a real directory outside target_base
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    # Create a symlink in target that points outside
+    link = tmp_path / "target" / "escape_link"
+    link.symlink_to(outside_dir, target_is_directory=True)
+
+    deleted, err = _delete_folder(
+        "escape_link",
+        target_base,
+        False,
+        "",
+        "",
+    )
+    assert deleted is False
+    assert "Path traversal detected" in err
+
+
+def test_delete_folder_resolve_oserror(monkeypatch, tmp_path) -> None:
+    """_delete_folder handles Path.resolve() OSError gracefully (lines 746-747)."""
+    from pathlib import Path
+
+    from routes import _delete_folder
+
+    target_base = str(tmp_path / "target")
+    (tmp_path / "target").mkdir()
+    (tmp_path / "target" / "safe").mkdir()
+
+    perm_denied = "Permission denied"
+
+    def _broken_resolve(self):
+        raise OSError(perm_denied)
+
+    monkeypatch.setattr(Path, "resolve", _broken_resolve)
+
+    # OSError caught, resolved = path (unresolved), then target_base IS in
+    # str(resolved.parent) because path hasn't resolved outside -> falls
+    # through to exists check then deletes normally
+    deleted, err = _delete_folder("safe", target_base, False, "", "")
+    assert deleted is True
+    assert err is None
+
+
+# ---------------------------------------------------------------------------
+# _search_local_filesystem: OSError from ismount (lines 844-847)
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.os.path.ismount")
+def test_search_filesystem_ismount_oserror(mock_ismount) -> None:
+    """_search_local_filesystem skips directories when os.path.ismount() raises OSError (lines 844-847)."""
+    import tempfile
+
+    from routes import _search_local_filesystem
+
+    with tempfile.TemporaryDirectory() as tmp:
+        test_dir = Path(tmp) / "test"
+        test_dir.mkdir()
+        (test_dir / "movie.mkv").touch()
+
+        mock_ismount.side_effect = OSError("Permission denied")
+
+        result = _search_local_filesystem("movie.mkv", [str(test_dir)])
+        # Should return None because the only sub-directory raised an OSError
+        # and was skipped (dirnames cleared), but the root itself may still match
+        assert result is None or result == str(test_dir / "movie.mkv")


### PR DESCRIPTION
## Summary

### Motivation
While auditing the codebase for edge cases and defensive programming opportunities, I identified several areas where silent failures or potential crashes could occur.

### Changes

**config.py** – `_fill_defaults` now recursively populates nested default dicts instead of only one level deep, properly handling config structures like `scheduler` with sub-keys.

**network.py** – Graceful fallback to default retry settings when environment variables contain invalid values. Prevents `ValueError` at module import time (which would crash the app).

**routes.py** – 
- `_delete_folder` now validates folder names and resolves paths against `target_base` to prevent path-traversal attacks.
- `_search_local_filesystem` wraps `os.path.ismount()` in try/except to skip inaccessible mount points (permission denied).

**scheduler.py** – Adds warning logs when a group with `schedule_enabled` is missing a name, has a non-string name, or is not a dict (previously silently skipped).

**sync.py** – Logs a warning when the config contains no groups, providing clearer feedback instead of silently returning an empty list.

**CHANGELOG.md** – Documented all changes under Unreleased Added.

### Testing
- All 570 tests pass (17 skipped are e2e tests requiring a real Jellyfin instance)
- Ruff and mypy clean across all 14 source files
- No coverage regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added path-traversal protections for folder cleanup (including symlink and resolution safety).
  * Graceful fallback to safe retry defaults when retry configuration is invalid.
  * Improved error handling when scanning local filesystems to avoid crashes on mount-check errors.

* **Improvements**
  * Deeper, non-aliased population of nested configuration defaults.
  * Explicit warnings when sync group entries are invalid.
  * Early return and informative logging when no sync groups are configured.

* **Tests**
  * Added tests covering retry-config fallback and filesystem safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->