### PR TITLE
perf: O(1) dedup in trakt.py, handle ConnectTimeoutError in network.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         always_run: true
     -   id: mypy
         name: mypy type checking
-        entry: bash -c "mypy --ignore-missing-imports --exclude tests --exclude venv --exclude __pycache__ --exclude node_modules --no-incremental ."
+        entry: bash -c "mypy --ignore-missing-imports --exclude tests --exclude venv --exclude __pycache__ --exclude node_modules --exclude '.git' --no-incremental ."
         language: system
         pass_filenames: false
         always_run: true

--- a/network.py
+++ b/network.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.exceptions import MaxRetryError, ReadTimeoutError
+from urllib3.exceptions import ConnectTimeoutError, MaxRetryError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
 logger = logging.getLogger(__name__)
@@ -145,10 +145,11 @@ _SESSION = _build_retry_session()
 
 
 def _reraise_timeout(exc: requests.ConnectionError) -> None:
-    """Re-raise a retry timeout as :class:`requests.Timeout`.
+    """Re-raise a retry timeout as :class:`requests.Timeout`, regardless of reason.
 
-    If *exc* wraps a read-timeout from the retry adapter, re-raise it so callers
-    see the expected exception type.
+    Detects both ``ReadTimeoutError`` and ``ConnectTimeoutError`` wrapped by
+    the retry adapter's ``MaxRetryError``, and re-raises them as the standard
+    ``requests.Timeout`` exception so callers see the expected exception type.
     """
     inner = exc.args[0] if exc.args else None
     if not isinstance(inner, MaxRetryError):
@@ -157,6 +158,9 @@ def _reraise_timeout(exc: requests.ConnectionError) -> None:
     reason = getattr(inner, "reason", None)
     if isinstance(reason, ReadTimeoutError):
         msg = "Read timed out."
+        raise requests.Timeout(msg) from reason
+    if isinstance(reason, ConnectTimeoutError):
+        msg = "Connection timed out."
         raise requests.Timeout(msg) from reason
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -20,14 +20,15 @@ def test_reraise_timeout_read() -> None:
 
 
 def test_reraise_timeout_connect() -> None:
-    """_reraise_timeout returns normally for ConnectTimeout, not ReadTimeout."""
+    """_reraise_timeout raises requests.Timeout for ConnectTimeoutError."""
     from network import _reraise_timeout
 
     connect_err = ConnectTimeoutError("pool", "url", "msg")
     max_retry = MaxRetryError("pool", "url", reason=connect_err)
     conn_err = requests.ConnectionError(max_retry)
 
-    _reraise_timeout(conn_err)  # should not raise
+    with pytest.raises(requests.Timeout, match=r"Connection timed out\."):
+        _reraise_timeout(conn_err)
 
 
 def test_reraise_timeout_plain_connection_error() -> None:
@@ -169,7 +170,7 @@ def testdelete_timeout_re_raise(monkeypatch) -> None:
 
 
 def testpost_maxretry_non_readtimeout(monkeypatch) -> None:
-    """Post re-raises ConnectionError when MaxRetryError reason is not ReadTimeout."""
+    """Post raises requests.Timeout when MaxRetryError reason is ConnectTimeout."""
     from network import _SESSION, post
 
     connect_err = ConnectTimeoutError("pool", "url", "msg")
@@ -180,12 +181,12 @@ def testpost_maxretry_non_readtimeout(monkeypatch) -> None:
         raise conn_err
 
     monkeypatch.setattr(_SESSION, "post", _fail)
-    with pytest.raises(requests.ConnectionError):
+    with pytest.raises(requests.Timeout, match=r"Connection timed out\."):
         post("http://example.com/api")
 
 
 def testdelete_maxretry_non_readtimeout(monkeypatch) -> None:
-    """Delete re-raises ConnectionError when MaxRetryError reason is not ReadTimeout."""
+    """Delete raises requests.Timeout when MaxRetryError reason is ConnectTimeout."""
     from network import _SESSION, delete
 
     connect_err = ConnectTimeoutError("pool", "url", "msg")
@@ -196,7 +197,7 @@ def testdelete_maxretry_non_readtimeout(monkeypatch) -> None:
         raise conn_err
 
     monkeypatch.setattr(_SESSION, "delete", _fail)
-    with pytest.raises(requests.ConnectionError):
+    with pytest.raises(requests.Timeout, match=r"Connection timed out\."):
         delete("http://example.com/api")
 
 

--- a/trakt.py
+++ b/trakt.py
@@ -82,6 +82,7 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
     }
 
     ids: list[str] = []
+    seen: set[str] = set()
     page: int = 1
 
     while True:
@@ -104,7 +105,8 @@ def fetch_trakt_list(list_url: str, client_id: str) -> list[str]:
             item_type: str | None = entry.get("type")  # "movie" or "show"
             media: dict[str, Any] = entry.get(item_type, {}) if item_type else {}
             imdb_id: str | None = media.get("ids", {}).get("imdb")
-            if imdb_id and imdb_id not in ids:
+            if imdb_id and imdb_id not in seen:
+                seen.add(imdb_id)
                 ids.append(imdb_id)
 
         try:


### PR DESCRIPTION
- **trakt.py**: Replace O(n²) linear scan with O(1) set for dedup across paginated results
- **network.py**: Handle `ConnectTimeoutError` in `_reraise_timeout` (re-raises as `requests.Timeout`)
- **.pre-commit-config.yaml**: Exclude `.git` from mypy traversal for faster checks
- **tests**: Update for new ConnectTimeout timeout semantics, fix RUF043 raw-string warnings
