### PR TITLE
fix: sync docker-compose healthcheck start_period (10s→15s) + tmdb dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `tmdb.py`: add O(1) dedup set in `fetch_tmdb_list` for defensive duplicate filtering.
+
+### Changed
+- `docker-compose.yml`: sync healthcheck `start_period` from 10s → 15s to match the Dockerfile.
+
+### Added
 - Dockerfile: add `--preload` to gunicorn CMD for memory sharing between workers.
 - Dockerfile: increase healthcheck `--start-period` from 10s to 15s for slower gunicorn boot times.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 15s
     security_opt:
       - no-new-privileges:true

--- a/tmdb.py
+++ b/tmdb.py
@@ -53,6 +53,7 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
         list_id = parsed.path.strip("/").split("/")[-1]
 
     ids: list[str] = []
+    seen: set[str] = set()
     page: int = 1
 
     while True:
@@ -79,7 +80,10 @@ def fetch_tmdb_list(list_id: str, api_key: str) -> list[str]:
         for item in items:
             tmdb_id = item.get("id")
             if tmdb_id:
-                ids.append(str(tmdb_id))
+                str_id = str(tmdb_id)
+                if str_id not in seen:
+                    seen.add(str_id)
+                    ids.append(str_id)
 
         total_pages: int = data.get("total_pages", 1)
         if page >= total_pages or page >= _MAX_TMDB_PAGES:  # Safety cap


### PR DESCRIPTION
## Summary

Two small improvements to keep things consistent and defensive:

### Changes

1. **docker-compose.yml**: Sync healthcheck `start_period` from 10s → 15s to match the Dockerfile HEALTHCHECK instruction (PR #513). The docker-compose healthcheck overrides the Dockerfile's, so they must agree.

2. **tmdb.py**: Add O(1) dedup set in `fetch_tmdb_list` for defensive duplicate filtering — consistent with the same pattern already applied in `trakt.py` and `imdb.py`.

### Testing

- ✅ All 550+ tests pass with 100% coverage (1960/1960 lines)
- ✅ Ruff lint and format pass cleanly