### PR TITLE
fix: raise ConnectionError for ConnectTimeoutError, not Timeout

### DIFF
--- a/network.py
+++ b/network.py
@@ -145,11 +145,14 @@ _SESSION = _build_retry_session()
 
 
 def _reraise_timeout(exc: requests.ConnectionError) -> None:
-    """Re-raise a retry timeout as :class:`requests.Timeout`, regardless of reason.
+    """Re-raise a retry timeout as the appropriate exception type.
 
-    Detects both ``ReadTimeoutError`` and ``ConnectTimeoutError`` wrapped by
-    the retry adapter's ``MaxRetryError``, and re-raises them as the standard
-    ``requests.Timeout`` exception so callers see the expected exception type.
+    Detects ``ReadTimeoutError`` and ``ConnectTimeoutError`` wrapped by the
+    retry adapter's ``MaxRetryError``, and re-raises them as their natural
+    exception type so callers see the expected signal:
+
+    - ``ReadTimeoutError`` -> :class:`requests.Timeout`
+    - ``ConnectTimeoutError`` -> :class:`requests.ConnectionError`
     """
     inner = exc.args[0] if exc.args else None
     if not isinstance(inner, MaxRetryError):
@@ -161,7 +164,7 @@ def _reraise_timeout(exc: requests.ConnectionError) -> None:
         raise requests.Timeout(msg) from reason
     if isinstance(reason, ConnectTimeoutError):
         msg = "Connection timed out."
-        raise requests.Timeout(msg) from reason
+        raise requests.ConnectionError(msg) from reason
 
 
 def _request(method: str, url: str, **kwargs: Any) -> requests.Response:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -20,14 +20,14 @@ def test_reraise_timeout_read() -> None:
 
 
 def test_reraise_timeout_connect() -> None:
-    """_reraise_timeout raises requests.Timeout for ConnectTimeoutError."""
+    """_reraise_timeout raises requests.ConnectionError for ConnectTimeoutError."""
     from network import _reraise_timeout
 
     connect_err = ConnectTimeoutError("pool", "url", "msg")
     max_retry = MaxRetryError("pool", "url", reason=connect_err)
     conn_err = requests.ConnectionError(max_retry)
 
-    with pytest.raises(requests.Timeout, match=r"Connection timed out\."):
+    with pytest.raises(requests.ConnectionError, match=r"Connection timed out\."):
         _reraise_timeout(conn_err)
 
 
@@ -170,7 +170,7 @@ def testdelete_timeout_re_raise(monkeypatch) -> None:
 
 
 def testpost_maxretry_non_readtimeout(monkeypatch) -> None:
-    """Post raises requests.Timeout when MaxRetryError reason is ConnectTimeout."""
+    """Post raises requests.ConnectionError when MaxRetryError reason is ConnectTimeout."""
     from network import _SESSION, post
 
     connect_err = ConnectTimeoutError("pool", "url", "msg")
@@ -181,12 +181,12 @@ def testpost_maxretry_non_readtimeout(monkeypatch) -> None:
         raise conn_err
 
     monkeypatch.setattr(_SESSION, "post", _fail)
-    with pytest.raises(requests.Timeout, match=r"Connection timed out\."):
+    with pytest.raises(requests.ConnectionError, match=r"Connection timed out\."):
         post("http://example.com/api")
 
 
 def testdelete_maxretry_non_readtimeout(monkeypatch) -> None:
-    """Delete raises requests.Timeout when MaxRetryError reason is ConnectTimeout."""
+    """Delete raises requests.ConnectionError when MaxRetryError reason is ConnectTimeout."""
     from network import _SESSION, delete
 
     connect_err = ConnectTimeoutError("pool", "url", "msg")
@@ -197,7 +197,7 @@ def testdelete_maxretry_non_readtimeout(monkeypatch) -> None:
         raise conn_err
 
     monkeypatch.setattr(_SESSION, "delete", _fail)
-    with pytest.raises(requests.Timeout, match=r"Connection timed out\."):
+    with pytest.raises(requests.ConnectionError, match=r"Connection timed out\."):
         delete("http://example.com/api")
 
 


### PR DESCRIPTION
## Summary

Fixes a bug where `_reraise_timeout` incorrectly converted `ConnectTimeoutError` to `requests.Timeout`. A connection timeout means the TCP handshake itself failed — that is a connection-level error, not a read/response timeout.

This was causing `test_connection_error` to fail because the test expects `ConnectionError` as the cause but got `Timeout`.

## Changes

- **network.py**: `ConnectTimeoutError` now raises `requests.ConnectionError` instead of `requests.Timeout`
- **tests/test_network.py**: Updated 3 test assertions to match the corrected behavior

## Testing

- 575/575 tests pass (17 skipped)
- Specifically `test_connection_error` in `test_virtual_jellyfin_exhaustive.py` now passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed HTTP client error handling to properly categorize connection timeouts: these errors are now raised as `ConnectionError` exceptions instead of generic `Timeout` exceptions. This enables more precise error diagnosis and handling for connection-related issues, allowing applications to better distinguish between connection failures and other timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->