### PR TITLE
improvements: validate anilist status, csrf opt-out, test coverage

### DIFF
--- a/anilist.py
+++ b/anilist.py
@@ -42,10 +42,21 @@ query ($userName: String, $status: MediaListStatus) {
 
 
 def _resolve_anilist_status(status: str | None) -> str | None:
-    """Normalize a user-provided AniList status to the API's expected value."""
+    """Normalize a user-provided AniList status to the API's expected value.
+
+    Raises:
+        ValueError: If *status* is not ``None``, ``"ALL"``, or a recognised
+                    status key from :data:`_ANILIST_STATUS_MAP`.
+
+    """
     if not status or status.upper() == "ALL":
         return None
-    return _ANILIST_STATUS_MAP.get(status.upper())
+    normalized = _ANILIST_STATUS_MAP.get(status.upper())
+    if normalized is None:
+        valid = sorted(_ANILIST_STATUS_MAP)
+        msg = f"Unknown AniList status: {status!r}. Valid values: {valid}"
+        raise ValueError(msg)
+    return normalized
 
 
 def _extract_media_ids(data: dict) -> list[int]:

--- a/routes.py
+++ b/routes.py
@@ -145,11 +145,28 @@ def _check_auth() -> ResponseReturnValue | None:
     )
 
 
+# Endpoints that are exempted from the CSRF X-Requested-With check.
+# Add endpoint names here when you need to POST from non-browser clients
+# that cannot set the ``X-Requested-With: XMLHttpRequest`` header.
+_ALLOWED_NON_CSRF_REQUESTS: frozenset[str] = frozenset()
+
+
 @bp.before_request
 def _check_csrf() -> ResponseReturnValue | None:
-    """Require X-Requested-With header on state-changing requests."""
+    """Require ``X-Requested-With`` header on state-changing requests.
+
+    POST, PUT, DELETE, and PATCH requests from the browser must include the
+    ``X-Requested-With: XMLHttpRequest`` header (set automatically by
+    JavaScript ``fetch``/``XMLHttpRequest``).
+
+    To permit a specific endpoint to accept requests **without** this header
+    (e.g. for external scripts), add its endpoint name to
+    :data:`_ALLOWED_NON_CSRF_REQUESTS`.
+    """
     if request.method in ("POST", "PUT", "DELETE", "PATCH"):
         if current_app.config.get("TESTING"):
+            return None
+        if request.endpoint and request.endpoint in _ALLOWED_NON_CSRF_REQUESTS:
             return None
         if request.headers.get("X-Requested-With") != "XMLHttpRequest":
             return _error("CSRF validation failed", 403)

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -161,6 +161,38 @@ def test_fetch_anilist_all(mock_post) -> None:
     assert "status" not in kwargs["json"]["variables"]
 
 
+def test_anilist_status_invalid() -> None:
+    """An unknown status raises ValueError with valid options in message."""
+    with pytest.raises(ValueError) as exc_info:
+        fetch_anilist_list("user", "bogus_status")
+    msg = str(exc_info.value)
+    assert "bogus_status" in msg
+    assert "COMPLETED" in msg
+    assert "CURRENT" in msg
+
+
+def test_anilist_status_valid_values() -> None:
+    """Direct calls to the resolver return correct values (not public, verify via fetch_anilist_list)."""
+    import anilist as anilist_module
+
+    # Each valid status should map correctly
+    assert anilist_module._resolve_anilist_status(None) is None
+    assert anilist_module._resolve_anilist_status("ALL") is None
+    assert anilist_module._resolve_anilist_status("all") is None
+    assert anilist_module._resolve_anilist_status("COMPLETED") == "COMPLETED"
+    assert anilist_module._resolve_anilist_status("WATCHING") == "CURRENT"
+    assert anilist_module._resolve_anilist_status("rewatching") == "REPEATING"
+
+
+@pytest.mark.parametrize("invalid", ["FINISHED", "HOLDING"])
+def test_anilist_status_invalid_values(invalid: str) -> None:
+    """Various invalid status values all raise ValueError."""
+    import anilist as anilist_module
+
+    with pytest.raises(ValueError, match="Unknown AniList status"):
+        anilist_module._resolve_anilist_status(invalid)
+
+
 # ---------------------------------------------------------------------------
 # tmdb.py — code uses network.get
 # ---------------------------------------------------------------------------

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1160,12 +1160,22 @@ def test_handle_http_error_http_none_code() -> None:
 # --- Remaining branch coverage for routes.py ---
 
 
-def test_csrf_exempted_endpoint_skips_csrf_without_header(app, client) -> None:
+def test_csrf_exempted_endpoint_skips_csrf_without_header(
+    app, client, monkeypatch
+) -> None:
     """Endpoints listed in _ALLOWED_NON_CSRF_REQUESTS bypass the CSRF check."""
     import routes as routes_module
 
     old_allowed = routes_module._ALLOWED_NON_CSRF_REQUESTS
+    old_testing = app.config.get("TESTING")
     app.config["TESTING"] = False
+
+    # Mock the outbound network call so the test doesn't hit a real server.
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {}
+    monkeypatch.setattr(routes_module.network, "get", MagicMock(return_value=mock_resp))
+
     try:
         # Exempt a real POST endpoint from CSRF
         routes_module._ALLOWED_NON_CSRF_REQUESTS = frozenset({"main.test_server"})
@@ -1182,7 +1192,7 @@ def test_csrf_exempted_endpoint_skips_csrf_without_header(app, client) -> None:
         )
     finally:
         routes_module._ALLOWED_NON_CSRF_REQUESTS = old_allowed
-        app.config["TESTING"] = True
+        app.config["TESTING"] = old_testing
 
 
 def test_csrf_protection_with_header(client) -> None:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1177,7 +1177,9 @@ def test_csrf_exempted_endpoint_skips_csrf_without_header(app, client) -> None:
         assert response.status_code != 403, (
             "CSRF exemption should have allowed the request without X-Requested-With header"
         )
-        assert not response.is_json or "CSRF" not in response.get_json().get("message", "")
+        assert not response.is_json or "CSRF" not in response.get_json().get(
+            "message", ""
+        )
     finally:
         routes_module._ALLOWED_NON_CSRF_REQUESTS = old_allowed
         app.config["TESTING"] = True

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1160,6 +1160,29 @@ def test_handle_http_error_http_none_code() -> None:
 # --- Remaining branch coverage for routes.py ---
 
 
+def test_csrf_exempted_endpoint_skips_csrf_without_header(app, client) -> None:
+    """Endpoints listed in _ALLOWED_NON_CSRF_REQUESTS bypass the CSRF check."""
+    import routes as routes_module
+
+    old_allowed = routes_module._ALLOWED_NON_CSRF_REQUESTS
+    app.config["TESTING"] = False
+    try:
+        # Exempt a real POST endpoint from CSRF
+        routes_module._ALLOWED_NON_CSRF_REQUESTS = frozenset({"main.test_server"})
+        response = client.post(
+            "/api/test-server",
+            json={"jellyfin_url": "http://jf:8096", "api_key": "abc123"},
+        )
+        # Should NOT get 403 (CSRF failure) — instead we get whatever the view returns
+        assert response.status_code != 403, (
+            "CSRF exemption should have allowed the request without X-Requested-With header"
+        )
+        assert not response.is_json or "CSRF" not in response.get_json().get("message", "")
+    finally:
+        routes_module._ALLOWED_NON_CSRF_REQUESTS = old_allowed
+        app.config["TESTING"] = True
+
+
 def test_csrf_protection_with_header(client) -> None:
     from flask import current_app
 


### PR DESCRIPTION
## Summary

Three improvements:

### 1. anilist.py — Validate status input
`_resolve_anilist_status` now raises `ValueError` with a helpful message listing valid options when an unknown status is passed, instead of silently returning `None`.

### 2. routes.py — CSRF opt-out for non-browser callers
Added `_ALLOWED_NON_CSRF_REQUESTS` frozenset. Endpoints registered here can accept POST/PUT/DELETE/PATCH requests without the `X-Requested-With: XMLHttpRequest` header (useful for curl scripts and external automation).

### 3. Tests — Cover new `_resolve_anilist_status` edge cases
Added tests validating:
- Valid statuses map correctly
- `None` and `"ALL"` return `None`
- Invalid statuses raise `ValueError`
- Case-insensitive matching works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened AniList status validation to reject unknown status values and provide informative error messages that include the complete list of valid status options.

* **Tests**
  * Expanded test suite with comprehensive coverage for AniList status validation, including proper error handling for invalid statuses and verification of CSRF bypass for allowlisted endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->