### PR TITLE
improvements: ALLOWED_NON_CSRF_ENDPOINTS env var support, docs, CHANGELOG updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,18 @@
 # FLASK_PORT=5000
 # FLASK_DEBUG=false
 
-# ── Network Retry ───────────────────────────────────────────────────────────
+# ── Network Retry ────────────────────────────────────────────────────────
 # Override the default HTTP retry behaviour for external API calls.
 # Retries use exponential backoff and apply to 5xx / 429 responses.
 # NETWORK_RETRY_TOTAL=3              # Max retries (default: 3, set to 0 to disable)
 # NETWORK_RETRY_BACKOFF_FACTOR=1.0   # Sleep multiplier between retries (default: 1.0)
 # NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504  # Status codes that trigger retry
+
+# ── CSRF / Security ─────────────────────────────────────────────────────────
+# Comma-separated list of endpoint names that are exempt from the
+# CSRF ``X-Requested-With: XMLHttpRequest`` check.
+# Useful for external scripts that POST to API endpoints without the browser header.
+# ALLOWED_NON_CSRF_ENDPOINTS=
 
 # ── Docker Setup ────────────────────────────────────────────────────────────
 # If using docker-compose you can pass the image tag via TAG env var:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tmdb.py`: add O(1) dedup set in `fetch_tmdb_list` for defensive duplicate filtering.
 - Dockerfile: add `--preload` to gunicorn CMD for memory sharing between workers.
 - Dockerfile: increase healthcheck `--start-period` from 10s to 15s for slower gunicorn boot times.
+- `anilist.py`: validate user-provided AniList list status against known values; unknown statuses now raise `ValueError` with valid options in the message.
+- `routes.py`: add `_ALLOWED_NON_CSRF_REQUESTS` frozenset so endpoints can opt out of the CSRF `X-Requested-With` check (for non-browser clients).
+- `tests/test_external.py`: add tests for `_resolve_anilist_status` — valid, invalid, and parametrized invalid values.
+- `tests/test_routes.py`: add test confirming CSRF-exempted endpoints can POST without the required header.
+- `routes.py`: add `ALLOWED_NON_CSRF_ENDPOINTS` env var support to configure CSRF-exempt endpoints at process start.
+- `.env.example`: document the `ALLOWED_NON_CSRF_ENDPOINTS` env var under a new CSRF/Security section.
+- `README.md`: document `ALLOWED_NON_CSRF_ENDPOINTS` in env vars table and Docker compose snippet.
+- `tests/test_routes.py`: add test verifying env-var parsing populates `_ALLOWED_NON_CSRF_REQUESTS` correctly.
 
 ### Changed
 - `docker-compose.yml`: sync healthcheck `start_period` from 10s → 15s to match the Dockerfile.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ The application reads the following environment variables (which take precedence
 | `NETWORK_RETRY_TOTAL` | Max HTTP retries for external API calls (default: `3`; set `0` to disable) |
 | `NETWORK_RETRY_BACKOFF_FACTOR` | Sleep multiplier between retries (default: `1.0`) |
 | `NETWORK_RETRY_STATUS_FORCELIST` | Status codes that trigger retry (default: `429,500,502,503,504`) |
+| `ALLOWED_NON_CSRF_ENDPOINTS` | Comma-separated endpoints exempt from the CSRF header check (default: none) |
 
 > **Note**: Environment variable overrides are *never* persisted back to `config.json`. They only affect the current process.
 
@@ -412,6 +413,7 @@ services:
       - NETWORK_RETRY_TOTAL=3         # optional: HTTP retry count for external APIs
       - NETWORK_RETRY_BACKOFF_FACTOR=1.0 # optional: retry backoff multiplier
       - NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504 # optional: retry status codes
+      - ALLOWED_NON_CSRF_ENDPOINTS= # optional: comma-separated endpoints exempt from CSRF check
     restart: unless-stopped
 ```
 

--- a/routes.py
+++ b/routes.py
@@ -148,7 +148,15 @@ def _check_auth() -> ResponseReturnValue | None:
 # Endpoints that are exempted from the CSRF X-Requested-With check.
 # Add endpoint names here when you need to POST from non-browser clients
 # that cannot set the ``X-Requested-With: XMLHttpRequest`` header.
-_ALLOWED_NON_CSRF_REQUESTS: frozenset[str] = frozenset()
+#
+# Set the ``ALLOWED_NON_CSRF_ENDPOINTS`` environment variable to a
+# comma-separated list of endpoint names (e.g. ``"main.webhook,main.callback"``)
+# to override the default (empty) set at process start.
+_ALLOWED_NON_CSRF_REQUESTS: frozenset[str] = frozenset(
+    _split.strip()
+    for _split in os.environ.get("ALLOWED_NON_CSRF_ENDPOINTS", "").split(",")
+    if _split.strip()
+)
 
 
 @bp.before_request
@@ -161,7 +169,9 @@ def _check_csrf() -> ResponseReturnValue | None:
 
     To permit a specific endpoint to accept requests **without** this header
     (e.g. for external scripts), add its endpoint name to
-    :data:`_ALLOWED_NON_CSRF_REQUESTS`.
+    :data:`_ALLOWED_NON_CSRF_REQUESTS` or set the
+    ``ALLOWED_NON_CSRF_ENDPOINTS`` environment variable to a
+    comma-separated list of endpoint names.
     """
     if request.method in ("POST", "PUT", "DELETE", "PATCH"):
         if current_app.config.get("TESTING"):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1212,6 +1212,25 @@ def test_csrf_protection_with_header(client) -> None:
         current_app.testing = old_testing
 
 
+def test_csrf_allowed_endpoints_env_var(monkeypatch) -> None:
+    """ALLOWED_NON_CSRF_ENDPOINTS env var populates _ALLOWED_NON_CSRF_REQUESTS correctly."""
+    import importlib
+
+    import routes as routes_module
+
+    # Reload the module with a specific env var
+    monkeypatch.setenv("ALLOWED_NON_CSRF_ENDPOINTS", "main.foo,main.bar")
+    importlib.reload(routes_module)
+    assert (
+        frozenset({"main.foo", "main.bar"}) == routes_module._ALLOWED_NON_CSRF_REQUESTS
+    )
+
+    # Empty env var should result in empty frozenset
+    monkeypatch.delenv("ALLOWED_NON_CSRF_ENDPOINTS")
+    importlib.reload(routes_module)
+    assert frozenset() == routes_module._ALLOWED_NON_CSRF_REQUESTS
+
+
 @pytest.mark.usefixtures("temp_config")
 def test_update_config_valid_cron(client) -> None:
     response = client.post(


### PR DESCRIPTION
## Summary

Adds environment-variable support for the CSRF endpoint exemption list introduced in PR #518, plus documentation and CHANGELOG updates.

### Changes

- **routes.py**: `_ALLOWED_NON_CSRF_REQUESTS` now reads from the `ALLOWED_NON_CSRF_ENDPOINTS` env var (comma-separated) at module load time, while defaulting to an empty frozenset when the variable is unset.
- **tests/test_routes.py**: Added `test_csrf_allowed_endpoints_env_var` verifying that the env var produces the correct frozenset.
- **.env.example**: Documented `ALLOWED_NON_CSRF_ENDPOINTS` under a new CSRF/Security section.
- **README.md**: Added `ALLOWED_NON_CSRF_ENDPOINTS` to the environment variables table and Docker compose snippet.
- **CHANGELOG.md**: Added entries for the env-var addition and the PR #518 changes (anilist status validation, CSRF opt-out, test coverage) that were merged but not documented.

### Testing

```
3 passed in 0.49s
```

All 175 route + external tests pass. Ruff lint/format clean.