### PR TITLE
routes: extract CSRF mutating methods to module-level constant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,12 +23,18 @@
 # FLASK_PORT=5000
 # FLASK_DEBUG=false
 
-# ── Network Retry ───────────────────────────────────────────────────────────
+# ── Network Retry ────────────────────────────────────────────────────────
 # Override the default HTTP retry behaviour for external API calls.
 # Retries use exponential backoff and apply to 5xx / 429 responses.
 # NETWORK_RETRY_TOTAL=3              # Max retries (default: 3, set to 0 to disable)
 # NETWORK_RETRY_BACKOFF_FACTOR=1.0   # Sleep multiplier between retries (default: 1.0)
 # NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504  # Status codes that trigger retry
+
+# ── CSRF / Security ─────────────────────────────────────────────────────────
+# Comma-separated list of endpoint names that are exempt from the
+# CSRF ``X-Requested-With: XMLHttpRequest`` check.
+# Useful for external scripts that POST to API endpoints without the browser header.
+# ALLOWED_NON_CSRF_ENDPOINTS=
 
 # ── Docker Setup ────────────────────────────────────────────────────────────
 # If using docker-compose you can pass the image tag via TAG env var:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tmdb.py`: add O(1) dedup set in `fetch_tmdb_list` for defensive duplicate filtering.
 - Dockerfile: add `--preload` to gunicorn CMD for memory sharing between workers.
 - Dockerfile: increase healthcheck `--start-period` from 10s to 15s for slower gunicorn boot times.
+- `anilist.py`: validate user-provided AniList list status against known values; unknown statuses now raise `ValueError` with valid options in the message.
+- `routes.py`: add `_ALLOWED_NON_CSRF_REQUESTS` frozenset so endpoints can opt out of the CSRF `X-Requested-With` check (for non-browser clients).
+- `tests/test_external.py`: add tests for `_resolve_anilist_status` — valid, invalid, and parametrized invalid values.
+- `tests/test_routes.py`: add test confirming CSRF-exempted endpoints can POST without the required header.
+- `routes.py`: add `ALLOWED_NON_CSRF_ENDPOINTS` env var support to configure CSRF-exempt endpoints at process start.
+- `.env.example`: document the `ALLOWED_NON_CSRF_ENDPOINTS` env var under a new CSRF/Security section.
+- `README.md`: document `ALLOWED_NON_CSRF_ENDPOINTS` in env vars table and Docker compose snippet.
+- `tests/test_routes.py`: add test verifying env-var parsing populates `_ALLOWED_NON_CSRF_REQUESTS` correctly.
 
 ### Changed
 - `docker-compose.yml`: sync healthcheck `start_period` from 10s → 15s to match the Dockerfile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.env.example`: document the `ALLOWED_NON_CSRF_ENDPOINTS` env var under a new CSRF/Security section.
 - `README.md`: document `ALLOWED_NON_CSRF_ENDPOINTS` in env vars table and Docker compose snippet.
 - `tests/test_routes.py`: add test verifying env-var parsing populates `_ALLOWED_NON_CSRF_REQUESTS` correctly.
+- `.gitignore` now excludes `.ruff_cache/`, `.coverage`, and `htmlcov/`.
+- `pyproject.toml` now includes a `[tool.ruff.format]` section with explicit
+  quote-style, indent-style, and line-ending settings.
+- Consolidated duplicate `### Added` and `### Changed` headings under
+  `[Unreleased]` (Keep a Changelog format).
 
 ### Changed
 - `docker-compose.yml`: sync healthcheck `start_period` from 10s → 15s to match the Dockerfile.
 - Dockerfile: remove `requirements-dev.txt` copy from builder stage (unused in production).
-
-### Added
-- `.gitignore` now excludes `.ruff_cache/`, `.coverage`, and `htmlcov/`.
-- `pyproject.toml` now includes a `[tool.ruff.format]` section with explicit
-  quote-style, indent-style, and line-ending settings.
-
-### Changed
+- `routes.py`: extract CSRF-mutating method check into `_CSRF_MUTATING_METHODS`
+  module-level tuple to avoid re-creating the tuple on every request.
+- `routes.py`: use walrus operator in `_ALLOWED_NON_CSRF_REQUESTS` frozenset
+  to avoid calling `strip()` twice per env-var element.
+- `Makefile`: add `test-to-file` target wrapping `run_tests_to_file.py` for
+  developer convenience.
 - `pyproject.toml` ruff lint config reverted from `select`/`ignore` back to
   `extend-select`/`extend-ignore`. The change was reverted because `select`
   overrides Ruff's default rule sets (E, F, W, etc.), while `extend-select`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.gitignore` now excludes `.ruff_cache/`, `.coverage`, and `htmlcov/`.
 - `pyproject.toml` now includes a `[tool.ruff.format]` section with explicit
   quote-style, indent-style, and line-ending settings.
-- Consolidated duplicate `### Added` and `### Changed` headings under
-  `[Unreleased]` (Keep a Changelog format).
 
 ### Changed
 - `docker-compose.yml`: sync healthcheck `start_period` from 10s → 15s to match the Dockerfile.
@@ -43,8 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that were never executed.
 - `letterboxd.py` `_extract_ids_from_list_page`: removed unnecessary
   `re.DOTALL` flags from single-line regex patterns.
-
-### Added
 - `ANILIST_API_URL` environment variable example in `docker-compose.yml`.
 - Tests for `_fill_defaults` resilience when `scheduler` is `null` or a non-dict
   value in the stored config.
@@ -85,8 +81,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `resolved.relative_to(base_resolved)` instead of substring matching.
 - `config.py` `_fill_defaults` now uses `copy.deepcopy` for missing nested
   keys via membership check, eliminating aliasing with `DEFAULT_CONFIG`.
-
-### Changed
 - Scrollbar thumb colors now use `color-mix(in srgb, var(--text-secondary) …%,
   transparent)` instead of hardcoded `rgba(255,255,255,…)` — adapts correctly
   in light theme.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev test test-all test-cov lint format-check typecheck clean format run virtual-jellyfin docker-build docker-run
+.PHONY: install install-dev test test-all test-cov test-to-file lint format-check typecheck clean format run virtual-jellyfin docker-build docker-run
 
 # ── Installation ────────────────────────────────────────────────────────────
 
@@ -18,6 +18,9 @@ test-all:
 
 test-cov:
 	python -m pytest --cov=. --cov-report=term-missing
+
+test-to-file:
+	python run_tests_to_file.py
 
 # ── Linting & Type Checking ─────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The application reads the following environment variables (which take precedence
 | `NETWORK_RETRY_TOTAL` | Max HTTP retries for external API calls (default: `3`; set `0` to disable) |
 | `NETWORK_RETRY_BACKOFF_FACTOR` | Sleep multiplier between retries (default: `1.0`) |
 | `NETWORK_RETRY_STATUS_FORCELIST` | Status codes that trigger retry (default: `429,500,502,503,504`) |
-| `ALLOWED_NON_CSRF_ENDPOINTS` | Comma-separated endpoints exempt from the CSRF header check (default: none) |
+| `ALLOWED_NON_CSRF_ENDPOINTS` | Comma-separated list of [Flask endpoint names](https://flask.palletsprojects.com/quickstart/#about-responses) exempt from the CSRF header check. These are `blueprint.view` names (e.g., `"main.webhook,main.callback"`), **not** URL paths like `/api/...`. Default: none |
 
 > **Note**: Environment variable overrides are *never* persisted back to `config.json`. They only affect the current process.
 
@@ -328,6 +328,7 @@ A `Makefile` is provided for common development tasks:
 | `test` | Run the test suite (skips slow integration tests) |
 | `test-all` | Run the full test suite including integration tests |
 | `test-cov` | Run tests with a coverage report |
+| `test-to-file` | Run tests and write output to a file (`python run_tests_to_file.py`) |
 | `lint` | Run Ruff linter and format check (`ruff check .` + `ruff format --check .`) |
 | `format-check` | Check code formatting without auto-fixing (`ruff format --check .`) |
 | `typecheck` | Run mypy type checker (`mypy .`) |
@@ -413,7 +414,7 @@ services:
       - NETWORK_RETRY_TOTAL=3         # optional: HTTP retry count for external APIs
       - NETWORK_RETRY_BACKOFF_FACTOR=1.0 # optional: retry backoff multiplier
       - NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504 # optional: retry status codes
-      - ALLOWED_NON_CSRF_ENDPOINTS= # optional: comma-separated endpoints exempt from CSRF check
+      - ALLOWED_NON_CSRF_ENDPOINTS= # optional: comma-separated Flask endpoint names (e.g. "main.webhook,main.callback") exempt from CSRF check
     restart: unless-stopped
 ```
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ The application reads the following environment variables (which take precedence
 | `NETWORK_RETRY_TOTAL` | Max HTTP retries for external API calls (default: `3`; set `0` to disable) |
 | `NETWORK_RETRY_BACKOFF_FACTOR` | Sleep multiplier between retries (default: `1.0`) |
 | `NETWORK_RETRY_STATUS_FORCELIST` | Status codes that trigger retry (default: `429,500,502,503,504`) |
+| `ALLOWED_NON_CSRF_ENDPOINTS` | Comma-separated endpoints exempt from the CSRF header check (default: none) |
 
 > **Note**: Environment variable overrides are *never* persisted back to `config.json`. They only affect the current process.
 
@@ -412,6 +413,7 @@ services:
       - NETWORK_RETRY_TOTAL=3         # optional: HTTP retry count for external APIs
       - NETWORK_RETRY_BACKOFF_FACTOR=1.0 # optional: retry backoff multiplier
       - NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504 # optional: retry status codes
+      - ALLOWED_NON_CSRF_ENDPOINTS= # optional: comma-separated endpoints exempt from CSRF check
     restart: unless-stopped
 ```
 

--- a/routes.py
+++ b/routes.py
@@ -148,7 +148,15 @@ def _check_auth() -> ResponseReturnValue | None:
 # Endpoints that are exempted from the CSRF X-Requested-With check.
 # Add endpoint names here when you need to POST from non-browser clients
 # that cannot set the ``X-Requested-With: XMLHttpRequest`` header.
-_ALLOWED_NON_CSRF_REQUESTS: frozenset[str] = frozenset()
+#
+# Set the ``ALLOWED_NON_CSRF_ENDPOINTS`` environment variable to a
+# comma-separated list of endpoint names (e.g. ``"main.webhook,main.callback"``)
+# to override the default (empty) set at process start.
+_ALLOWED_NON_CSRF_REQUESTS: frozenset[str] = frozenset(
+    _split.strip()
+    for _split in os.environ.get("ALLOWED_NON_CSRF_ENDPOINTS", "").split(",")
+    if _split.strip()
+)
 
 
 @bp.before_request
@@ -161,7 +169,9 @@ def _check_csrf() -> ResponseReturnValue | None:
 
     To permit a specific endpoint to accept requests **without** this header
     (e.g. for external scripts), add its endpoint name to
-    :data:`_ALLOWED_NON_CSRF_REQUESTS`.
+    :data:`_ALLOWED_NON_CSRF_REQUESTS` or set the
+    ``ALLOWED_NON_CSRF_ENDPOINTS`` environment variable to a
+    comma-separated list of endpoint names.
     """
     if request.method in ("POST", "PUT", "DELETE", "PATCH"):
         if current_app.config.get("TESTING"):

--- a/routes.py
+++ b/routes.py
@@ -153,10 +153,13 @@ def _check_auth() -> ResponseReturnValue | None:
 # comma-separated list of endpoint names (e.g. ``"main.webhook,main.callback"``)
 # to override the default (empty) set at process start.
 _ALLOWED_NON_CSRF_REQUESTS: frozenset[str] = frozenset(
-    _split.strip()
+    e
     for _split in os.environ.get("ALLOWED_NON_CSRF_ENDPOINTS", "").split(",")
-    if _split.strip()
+    if (e := _split.strip())
 )
+
+# HTTP methods that require CSRF protection
+_CSRF_MUTATING_METHODS: tuple[str, ...] = ("POST", "PUT", "DELETE", "PATCH")
 
 
 @bp.before_request
@@ -173,7 +176,7 @@ def _check_csrf() -> ResponseReturnValue | None:
     ``ALLOWED_NON_CSRF_ENDPOINTS`` environment variable to a
     comma-separated list of endpoint names.
     """
-    if request.method in ("POST", "PUT", "DELETE", "PATCH"):
+    if request.method in _CSRF_MUTATING_METHODS:
         if current_app.config.get("TESTING"):
             return None
         if request.endpoint and request.endpoint in _ALLOWED_NON_CSRF_REQUESTS:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1212,6 +1212,25 @@ def test_csrf_protection_with_header(client) -> None:
         current_app.testing = old_testing
 
 
+def test_csrf_allowed_endpoints_env_var(monkeypatch) -> None:
+    """ALLOWED_NON_CSRF_ENDPOINTS env var populates _ALLOWED_NON_CSRF_REQUESTS correctly."""
+    import importlib
+
+    import routes as routes_module
+
+    # Reload the module with a specific env var
+    monkeypatch.setenv("ALLOWED_NON_CSRF_ENDPOINTS", "main.foo,main.bar")
+    importlib.reload(routes_module)
+    assert (
+        frozenset({"main.foo", "main.bar"}) == routes_module._ALLOWED_NON_CSRF_REQUESTS
+    )
+
+    # Empty env var should result in empty frozenset
+    monkeypatch.delenv("ALLOWED_NON_CSRF_ENDPOINTS")
+    importlib.reload(routes_module)
+    assert frozenset() == routes_module._ALLOWED_NON_CSRF_REQUESTS
+
+
 @pytest.mark.usefixtures("temp_config")
 def test_update_config_valid_cron(client) -> None:
     response = client.post(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1218,6 +1218,9 @@ def test_csrf_allowed_endpoints_env_var(monkeypatch) -> None:
 
     import routes as routes_module
 
+    # Capture original env value so we can restore it later
+    orig = os.environ.get("ALLOWED_NON_CSRF_ENDPOINTS")
+
     # Reload the module with a specific env var
     monkeypatch.setenv("ALLOWED_NON_CSRF_ENDPOINTS", "main.foo,main.bar")
     importlib.reload(routes_module)
@@ -1229,6 +1232,13 @@ def test_csrf_allowed_endpoints_env_var(monkeypatch) -> None:
     monkeypatch.delenv("ALLOWED_NON_CSRF_ENDPOINTS")
     importlib.reload(routes_module)
     assert frozenset() == routes_module._ALLOWED_NON_CSRF_REQUESTS
+
+    # Restore original env var and re-read to avoid leaking test state
+    if orig is not None:
+        monkeypatch.setenv("ALLOWED_NON_CSRF_ENDPOINTS", orig)
+    else:
+        monkeypatch.delenv("ALLOWED_NON_CSRF_ENDPOINTS", raising=False)
+    importlib.reload(routes_module)
 
 
 @pytest.mark.usefixtures("temp_config")


### PR DESCRIPTION
## Summary

Three small improvements to the codebase:

### 1. Extract CSRF mutating methods to module-level constant
The tuple `("POST", "PUT", "DELETE", "PATCH")` was being re-created on every request in the `_check_csrf` before_request handler. Extracted to `_CSRF_MUTATING_METHODS` at module level for a minor micro-optimization.

### 2. Avoid double `strip()` in frozenset comprehension
Used walrus operator in `_ALLOWED_NON_CSRF_REQUESTS` to call `.strip()` once per element instead of twice (once in the output expression and once in the filter condition).

### 3. Add `test-to-file` Makefile target
Wraps the existing `run_tests_to_file.py` developer utility for convenience.

### 4. Consolidate duplicate CHANGELOG headings
Merged duplicated `### Added` and `### Changed` blocks under `[Unreleased]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Network retry configuration: Customize retry count, backoff factor, and HTTP status codes for failed requests
  - CSRF endpoint exemptions: Configure specific endpoints to skip CSRF header validation

* **Documentation**
  - Updated configuration guide and Docker environment examples with new settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->