### PR TITLE
test: add coverage for letterboxd dispatch and dedup edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scheduler.py` `validate_cron`: call `expr.strip()` once instead of twice.
 
 ### Fixed
+- Fixed `_search_local_filesystem` returning `None` on timeout/file-limit
+  instead of continuing to the next search root (prevents unbounded filesystem
+  scanning after the limit is reached).
+- Fixed `_build_letterboxd_items` deduplication: both branches (priority and
+  list-order) now use a shared `seen_jf_ids` set to prevent duplicate symlinks
+  when a Letterboxd entry matches both IMDb and TMDb provider IDs.
 - Fixed `_fill_defaults` in `config.py` to use `copy.deepcopy` for nested
   default dicts instead of `dict.copy()`, preventing shallow-copy issues
   and aliasing with `DEFAULT_CONFIG`.

--- a/tests/test_sync_uncovered.py
+++ b/tests/test_sync_uncovered.py
@@ -138,3 +138,65 @@ def test_dispatch_list_source_unknown_type() -> None:
     assert error is not None
     assert "Unknown source type" in error
     assert code == 400
+
+
+def test_dispatch_list_source_letterboxd_list() -> None:
+    """_dispatch_list_source dispatches letterboxd_list to _fetch_items_for_letterboxd_group."""
+    from sync import _dispatch_list_source
+
+    items, error, code = _dispatch_list_source(
+        "letterboxd_list",
+        "LB-Group",
+        "https://letterboxd.com/user/list/my-list",
+        "name",
+        "http://jf:8096",
+        "testkey",
+        "",
+    )
+    # Without a patched fetch_letterboxd_list, it will return error
+    # but the dispatch itself should not raise and should reach the handler
+    assert error is not None
+    assert code != 200
+    assert isinstance(items, list)
+
+
+# ---------------------------------------------------------------------------
+# _build_letterboxd_items dedup edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_build_letterboxd_items_list_order_dedup() -> None:
+    """letterboxd_list_order skips duplicates when same Jellyfin item matched via both IMDb and TMDb."""
+    from sync import _build_letterboxd_items
+
+    # External IDs: two entries that both map to the same Jellyfin item
+    external_ids = ["tt999", "123"]
+    items_by_imdb = {"tt999": {"Id": "item1", "Name": "Movie A"}}
+    items_by_tmdb = {"123": {"Id": "item1", "Name": "Movie A"}}
+
+    result = _build_letterboxd_items(
+        external_ids,
+        items_by_imdb,
+        items_by_tmdb,
+        "letterboxd_list_order",
+    )
+    assert len(result) == 1
+    assert result[0]["Id"] == "item1"
+
+
+def test_build_letterboxd_items_priority_order_dedup() -> None:
+    """Priority sort order also deduplicates entries."""
+    from sync import _build_letterboxd_items
+
+    external_ids = ["tt999", "123"]
+    items_by_imdb = {"tt999": {"Id": "item1", "Name": "Movie A"}}
+    items_by_tmdb = {"123": {"Id": "item1", "Name": "Movie A"}}
+
+    result = _build_letterboxd_items(
+        external_ids,
+        items_by_imdb,
+        items_by_tmdb,
+        "SortName",
+    )
+    assert len(result) == 1
+    assert result[0]["Id"] == "item1"


### PR DESCRIPTION
Adds test coverage for:\n\n1.  with  source type (was 1 uncovered line 1466)\n2.  dedup in both letterboxd_list_order and SortName modes\n\nReduces uncovered lines from 2 to 1 (99.95% coverage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test coverage for Letterboxd sync helpers, including validation of source type handling and error responses.
  * Added tests for deduplication logic when multiple external IDs map to the same item, covering different ordering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->