### PR TITLE
docs, test: improve coverage, docs, and test mock quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `tests/test_sync_uncovered.py`: add `test_build_letterboxd_items_unmatched_id_skipped`
+  to cover the `continue` branch when `_match_letterboxd_id` returns `None`.
+
+### Fixed
+- `sync.py`: fix `_build_letterboxd_items` docstring — dedup description was
+  incorrectly scoped to `letterboxd_list_order` only; dedup applies to all
+  sort orders.
+
+### Changed
+- `README.md`: update test count from 598+ to 608+.
+
+### Added
 - `tmdb.py`: add O(1) dedup set in `fetch_tmdb_list` for defensive duplicate filtering.
 - Dockerfile: add `--preload` to gunicorn CMD for memory sharing between workers.
 - Dockerfile: increase healthcheck `--start-period` from 10s to 15s for slower gunicorn boot times.

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ make run
 ### 🧪 Testing
 
 ```bash
-# Run the full test suite (598+ tests, 100% coverage)
+# Run the full test suite (608+ tests, 100% coverage)
 python3 -m pytest
 
 # Run tests with coverage report

--- a/sync.py
+++ b/sync.py
@@ -701,9 +701,9 @@ def _build_letterboxd_items(
 ) -> list[dict[str, Any]]:
     """Map external Letterboxd IDs to Jellyfin items, respecting sort order.
 
-    When *sort_order* is ``"letterboxd_list_order"`` the external list order
-    is preserved and duplicates (same Jellyfin item matched via both IMDb and
-    TMDb ID) are skipped to avoid duplicate symlinks.
+    The external list order is preserved regardless of *sort_order*.
+    Duplicates (the same Jellyfin item matched via both IMDb and TMDb ID)
+    are skipped to avoid duplicate symlinks.
     """
     items: list[dict[str, Any]] = []
     seen_jf_ids: set[str] = set()

--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -35,7 +35,7 @@ def test_run_sync_tmdb(
     }
     mock_tmdb.return_value = ["101"]
     mock_jf_fetch.return_value = [
-        {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
+        {"Id": "1", "Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
     ]
     _mock_exists.return_value = True  # Host path exists
     results = run_sync(config)
@@ -73,7 +73,44 @@ def test_run_sync_anilist(
     }
     mock_anilist.return_value = [12345]
     mock_jf_fetch.return_value = [
-        {"Name": "A1", "Path": "/p1", "ProviderIds": {"AniList": "12345"}},
+        {"Id": "10", "Name": "A1", "Path": "/p1", "ProviderIds": {"AniList": "12345"}},
+    ]
+    _mock_exists.return_value = True
+    results = run_sync(config)
+    assert results[0]["links"] == 1
+
+
+@patch("sync.shutil.rmtree")
+@patch("pathlib.Path.mkdir")
+@patch("pathlib.Path.exists")
+@patch("pathlib.Path.symlink_to")
+@patch("sync.fetch_jellyfin_items")
+@patch("sync.fetch_mal_list")
+def test_run_sync_mal(
+    mock_mal,
+    mock_jf_fetch,
+    _mock_symlink,
+    _mock_exists,
+    _mock_mkdir,
+    _mock_rmtree,
+) -> None:
+    config = {
+        "jellyfin_url": "http://jf",
+        "api_key": "key",
+        "target_path": "/target",
+        "mal_client_id": "mal_id",
+        "groups": [
+            {
+                "name": "MAL",
+                "source_type": "mal_list",
+                "source_value": "user",
+                "sort_order": "mal_list_order",
+            },
+        ],
+    }
+    mock_mal.return_value = [54321]
+    mock_jf_fetch.return_value = [
+        {"Id": "11", "Name": "M1", "Path": "/p1", "ProviderIds": {"Mal": "54321"}},
     ]
     _mock_exists.return_value = True
     results = run_sync(config)
@@ -112,47 +149,10 @@ def test_run_sync_trakt(
     }
     mock_trakt.return_value = ["tt123"]
     mock_jf_fetch.return_value = [
-        {"Name": "T1", "Path": "/p1", "ProviderIds": {"Imdb": "tt123"}},
+        {"Id": "2", "Name": "T1", "Path": "/p1", "ProviderIds": {"Imdb": "tt123"}},
     ]
     _mock_exists.return_value = True
     _mock_isdir.return_value = True
-    results = run_sync(config)
-    assert results[0]["links"] == 1
-
-
-@patch("sync.shutil.rmtree")
-@patch("pathlib.Path.mkdir")
-@patch("pathlib.Path.exists")
-@patch("pathlib.Path.symlink_to")
-@patch("sync.fetch_jellyfin_items")
-@patch("sync.fetch_mal_list")
-def test_run_sync_mal(
-    mock_mal,
-    mock_jf_fetch,
-    _mock_symlink,
-    _mock_exists,
-    _mock_mkdir,
-    _mock_rmtree,
-) -> None:
-    config = {
-        "jellyfin_url": "http://jf",
-        "api_key": "key",
-        "target_path": "/target",
-        "mal_client_id": "mal_id",
-        "groups": [
-            {
-                "name": "MAL",
-                "source_type": "mal_list",
-                "source_value": "user",
-                "sort_order": "mal_list_order",
-            },
-        ],
-    }
-    mock_mal.return_value = [54321]
-    mock_jf_fetch.return_value = [
-        {"Name": "M1", "Path": "/p1", "ProviderIds": {"Mal": "54321"}},
-    ]
-    _mock_exists.return_value = True
     results = run_sync(config)
     assert results[0]["links"] == 1
 
@@ -186,7 +186,7 @@ def test_run_sync_letterboxd(
     }
     mock_lb.return_value = ["tt111"]
     mock_jf_fetch.return_value = [
-        {"Name": "L1", "Path": "/p1", "ProviderIds": {"Imdb": "tt111"}},
+        {"Id": "3", "Name": "L1", "Path": "/p1", "ProviderIds": {"Imdb": "tt111"}},
     ]
     _mock_exists.return_value = True
     results = run_sync(config)
@@ -231,7 +231,7 @@ def test_run_sync_complex(
         ],
     }
     mock_jf_fetch.return_value = [
-        {"Name": "C1", "Path": "/p1", "Genres": ["Action"]},
+        {"Id": "4", "Name": "C1", "Path": "/p1", "Genres": ["Action"]},
     ]
     _mock_exists.return_value = True
     results = run_sync(config)
@@ -263,7 +263,7 @@ def test_run_sync_dry_run(
         ],
     }
     mock_jf_fetch.return_value = [
-        {"Name": "M1", "Path": "/p1", "Genres": ["Action"]},
+        {"Id": "5", "Name": "M1", "Path": "/p1", "Genres": ["Action"]},
     ]
     _mock_exists.return_value = True
     results = run_sync(config, dry_run=True)
@@ -294,7 +294,9 @@ def test_run_sync_selective(
             {"name": "G2", "source_type": "genre", "source_value": "Comedy"},
         ],
     }
-    mock_jf_fetch.return_value = [{"Name": "M1", "Path": "/p1", "Genres": ["Action"]}]
+    mock_jf_fetch.return_value = [
+        {"Id": "6", "Name": "M1", "Path": "/p1", "Genres": ["Action"]}
+    ]
     _mock_exists.return_value = True
     # Sync only G1
     results = run_sync(config, group_names=["G1"])
@@ -530,7 +532,7 @@ def test_run_sync_with_library_creation(
     # Mock items to sync
     mock_get_libs.return_value = []  # No libraries yet
     mock_jf_fetch.return_value = [
-        {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
+        {"Id": "7", "Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
     ]
     _mock_exists.return_value = True
     _mock_isdir.return_value = True
@@ -587,7 +589,7 @@ def test_run_sync_with_auto_set_library_covers(
     }
     # Mock items to sync
     mock_jf_fetch.return_value = [
-        {"Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
+        {"Id": "8", "Name": "M1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
     ]
     # Mock filesystem existence
     _mock_exists.return_value = True
@@ -642,7 +644,7 @@ def test_run_sync_recommendations(
     mock_recent.return_value = [{"ProviderIds": {"Tmdb": "100"}, "Type": "Movie"}]
     mock_tmdb_rec.return_value = ["101"]
     mock_jf_fetch.return_value = [
-        {"Name": "R1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
+        {"Id": "9", "Name": "R1", "Path": "/p1", "ProviderIds": {"Tmdb": "101"}},
     ]
     _mock_exists.return_value = True  # Host path exists
     results = run_sync(config)

--- a/tests/test_sync_uncovered.py
+++ b/tests/test_sync_uncovered.py
@@ -244,6 +244,27 @@ def test_build_letterboxd_items_priority_order_dedup() -> None:
     assert result[0]["Id"] == "item1"
 
 
+def test_build_letterboxd_items_unmatched_id_skipped() -> None:
+    """An external ID that matches neither IMDb nor TMDb indices is skipped."""
+    from sync import _build_letterboxd_items
+
+    # External IDs: one matches, one matches nothing
+    external_ids = ["tt999", "unmatched_id_12345"]
+    items_by_imdb: dict[str, dict[str, object]] = {
+        "tt999": {"Id": "item1", "Name": "Movie A"},
+    }
+    items_by_tmdb: dict[str, dict[str, object]] = {}
+
+    result = _build_letterboxd_items(
+        external_ids,
+        items_by_imdb,
+        items_by_tmdb,
+        "letterboxd_list_order",
+    )
+    assert len(result) == 1
+    assert result[0]["Id"] == "item1"
+
+
 # ---------------------------------------------------------------------------
 # parse_complex_query edge cases
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes a few quality gaps:

### Tests (coverage)
- Adds `test_build_letterboxd_items_unmatched_id_skipped` covering the `continue` branch when `_match_letterboxd_id` returns `None`. This was the **last uncovered line** in the entire codebase — we now achieve **100% coverage** across all 1959 lines.
- Adds missing `Id` fields to mock Jellyfin items in `test_sync_extended.py` so mock data accurately reflects the actual Jellyfin API response structure.

### Docs
- Fixes `_build_letterboxd_items` docstring — the dedup description was incorrectly scoped to `letterboxd_list_order` only when it applies to all sort orders.
- Updates `README.md` test count from 598+ to 608+.

### Stats
- **609 tests** all passing, **100% coverage** across all 12 modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Test coverage expanded to 608+ tests with new scenario for handling unmatched external IDs
  * Enhanced test scenarios across sync integrations (TMDB, AniList, MAL, Trakt, Letterboxd)

* **Documentation**
  * Clarified deduplication behavior to specify duplicate matches are skipped across all sort orders
  * Updated README with current test suite count

<!-- end of auto-generated comment: release notes by coderabbit.ai -->