### PR TITLE
docs,ux: add CHANGELOG entries for PR #535 merge and R keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `tests/test_routes_uncovered.py`: 12 new direct unit tests for
+  `_validate_cron_expressions` covering all valid/invalid cron patterns
+  (global schedule, cleanup schedule, group schedule, disabled groups).
+  (PR #535)
+- `README.md`: update test count from 608+ to 642+. (PR #535)
+- `static/js/app.js`: add <kbd>R</kbd> keyboard shortcut to reload the
+  groups list without a full page refresh.
+
 ### Fixed
 - `network.py`: guard against NaN/Inf `NETWORK_RETRY_BACKOFF_FACTOR` values
   that parses as valid ``float`` but produce unusable retry behaviour.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -67,6 +67,13 @@ function wireKeyboardShortcuts() {
                     openCleanupModal();
                 }
                 break;
+            case 'r':
+                // R = Reload (refresh groups list)
+                if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+                    e.preventDefault();
+                    renderGroups();
+                }
+                break;
         }
     });
 }


### PR DESCRIPTION
## Summary

Two small improvements following the PR #535 merge:

### Documentation
- Added CHANGELOG entries for recently merged PR #535 (12 new cron expression tests, test count update to 642+)

### UX
- Added <kbd>R</kbd> keyboard shortcut to reload the groups list via `renderGroups()` without needing a full page refresh
- Consistent with existing shortcuts: <kbd>S</kbd> (sync), <kbd>D</kbd> (preview/dry-run), <kbd>C</kbd> (cleanup), now <kbd>R</kbd> (reload)