### PR TITLE
fix: import Any in anilist.py, fix cast type in network.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `network.py`: guard against NaN/Inf `NETWORK_RETRY_BACKOFF_FACTOR` values
   that parses as valid ``float`` but produce unusable retry behaviour.
+- `anilist.py`: add missing ``from typing import Any`` import to fix ruff
+  F821 undefined-name error.
+- `network.py`: fix incorrect ``cast("requests.Session", ...)`` on bound
+  method — the ``getattr`` result is a ``Callable``, not a ``Session``, which
+  fixes the mypy ``operator`` error. (PR #538)
 
 ### Added
 - `tests/test_network.py`: add tests for NaN, +Inf, and -Inf backoff factor

--- a/anilist.py
+++ b/anilist.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import network
 

--- a/network.py
+++ b/network.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import logging
 import math
 import os
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -178,7 +181,9 @@ def _reraise_timeout(exc: requests.ConnectionError) -> None:
 def _request(method: str, url: str, **kwargs: Any) -> requests.Response:
     """Send a *method* request to *url* through the retry-enabled session."""
     try:
-        http_fn = cast("requests.Session", getattr(_SESSION, method.lower()))
+        http_fn = cast(
+            "Callable[..., requests.Response]", getattr(_SESSION, method.lower())
+        )
         return http_fn(url, **kwargs)
     except requests.ConnectionError as exc:
         _reraise_timeout(exc)


### PR DESCRIPTION
## Summary

Two type-fix improvements found by CI lint checks after merging #537:

### anilist.py
- Added missing  import — fixes ruff F821 undefined-name error (usage at line 62)

### network.py
- Fixed incorrect  on a bound method obtained via . The bound method is a , not a  instance — fixes the `operator` mypy error
- Moved  import under `TYPE_CHECKING` block per ruff TC003

All existing tests continue to pass.