### PR TITLE
css: Add --z-locked-overlay variable and replace hardcoded z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--z-modal`, `--z-loading-overlay`, `--z-wizard`, `--z-skip-link`)
   in `variables.css` to centralise stacking context. All hardcoded z-index
   values across CSS files now reference these variables for maintainability.
+- `variables.css`: add `--z-locked-overlay` custom property (value `10`)
+  for the lock-section overlay badge. (PR #549)
 
 ### Changed
 
+- `static/css/components.css`: replace hardcoded `z-index: 10` on
+  `.locked-overlay-text` with `var(--z-locked-overlay)`. (PR #549)
 - `README.md`: update test count from "650+" to exact "650".
 - `static/js/app.js`: keyboard shortcut modal detection now uses
   `getComputedStyle` instead of fragile `[style*=]` CSS attribute selector,

--- a/static/css/components.css
+++ b/static/css/components.css
@@ -668,7 +668,7 @@ button:disabled {
     border-radius: 4px;
     font-weight: bold;
     font-size: 0.8rem;
-    z-index: 10;
+    z-index: var(--z-locked-overlay);
     box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
     pointer-events: none;
     text-transform: uppercase;

--- a/static/css/variables.css
+++ b/static/css/variables.css
@@ -26,6 +26,7 @@
     --z-modal: 1000;
     --z-loading-overlay: 2000;
     --z-wizard: 5000;
+    --z-locked-overlay: 10;
     --z-skip-link: 9999;
 }
 


### PR DESCRIPTION
Adds the missing `--z-locked-overlay` CSS custom property (value `10`) to `variables.css` and replaces the last hardcoded `z-index: 10` in `components.css` with `var(--z-locked-overlay)`. Completes the z-index custom-property system introduced earlier.

Closes: this was the only remaining hardcoded z-index value in the static CSS files.