### PR TITLE
fix: Add explicit bool type hint to debug variable

### DIFF
--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -17,5 +17,5 @@ if __name__ == "__main__":
     logger.info("Starting Virtual Jellyfin Mock Server...")
     logger.info("Dashboard: http://localhost:8096")
     logger.info("Press Ctrl+C to stop.")
-    debug = _env_flag("FLASK_DEBUG")
+    debug: bool = _env_flag("FLASK_DEBUG")
     app.run(host="0.0.0.0", port=8096, debug=debug)


### PR DESCRIPTION
Small improvement: add an explicit `bool` type annotation to the `debug` variable in `start_virtual_jellyfin.py` for consistency with the rest of the codebase (which uses explicit type hints throughout).