### PR TITLE
docker: Improve healthcheck with requests library and add logs volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ services:
       # Your media root. Needed so the app can verify files and follow symlinks.
       # Use the same path Jellyfin uses if possible to simplify mapping.
       - /mnt/user/media:/media:ro
+      
+      # Optional: persist application logs for troubleshooting
+      # - ./logs:/app/logs
     restart: unless-stopped
 ```
 
@@ -487,7 +490,13 @@ If symlinks point to non-existent files, verify your path mapping:
 ### Nothing Happens When I Click Sync
 - Check the browser console (F12) for JavaScript errors.
 - Verify the Jellyfin server is reachable from the app container.
-- Check the app logs (`logs/jellyfin-groupings.log`) for detailed error messages.
+- Check the app logs for detailed error messages. Logs are written to
+  `app/logs/jellyfin-groupings.log` inside the container. To persist them
+  across restarts, add a volume mount in your docker-compose:
+  ```yaml
+  volumes:
+    - ./logs:/app/logs
+  ```
 - Verify the Flask backend is running (`docker logs jellyfin-groupings`).
 - Ensure you have at least one group configured.
 

--- a/README.md
+++ b/README.md
@@ -491,12 +491,14 @@ If symlinks point to non-existent files, verify your path mapping:
 - Check the browser console (F12) for JavaScript errors.
 - Verify the Jellyfin server is reachable from the app container.
 - Check the app logs for detailed error messages. Logs are written to
-  `app/logs/jellyfin-groupings.log` inside the container. To persist them
+  `/app/logs/jellyfin-groupings.log` inside the container. To persist them
   across restarts, add a volume mount in your docker-compose:
+
   ```yaml
   volumes:
     - ./logs:/app/logs
   ```
+
 - Verify the Flask backend is running (`docker logs jellyfin-groupings`).
 - Ensure you have at least one group configured.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,12 @@ services:
       #    precedence; this is the legacy fallback location)
       # - ./config/covers:/app/config/covers
 
+      # 5. Application logs (optional but helpful for troubleshooting)
+      # Logs are written to app/logs/jellyfin-groupings.log by default.
+      # - ./logs:/app/logs
+
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/')"]
+      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:5000/', timeout=3).raise_for_status()"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       # - ./config/covers:/app/config/covers
 
       # 5. Application logs (optional but helpful for troubleshooting)
-      # Logs are written to app/logs/jellyfin-groupings.log by default.
+      # Logs are written to /app/logs/jellyfin-groupings.log by default.
       # - ./logs:/app/logs
 
     healthcheck:


### PR DESCRIPTION
## Summary

Two small improvements to the Docker deployment infrastructure:

### docker-compose.yml
- **Healthcheck**: Use `requests.get().raise_for_status()` with `timeout=3` instead of `urllib.request.urlopen()`. The `requests` library is already installed in the container (it's a project dependency), and `raise_for_status()` provides proper error propagation. Using `python` instead of `python3` for consistency with the Dockerfile's healthcheck command.
- **Logs volume**: Add commented-out volume mount for `./logs:/app/logs` so users can persist application logs across restarts for troubleshooting.

### README.md
- Add the logs volume example to the Docker compose quick-start section.
- Expand the troubleshooting section to explain how to persist logs and mount the volume.

Closes #--- (no issue, just cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced troubleshooting guide for sync issues with improved logging instructions.
  * Added Docker Compose example showing how to persist application logs across container restarts.

* **Improvements**
  * Updated service health check for more reliable monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->