### PR TITLE
docs: Clarify log file path in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ Examples:
 
 - Use the [GitHub issue tracker](https://github.com/entcheneric/jellyfin-auto-groupings/issues).
 - Include steps to reproduce, expected behavior, and actual behavior.
-- Include relevant logs (from `logs/jellyfin-groupings.log`) if applicable.
+- Include relevant logs (from `logs/jellyfin-groupings.log` inside the container or `./logs/jellyfin-groupings.log` if you mounted the logs volume) if applicable.
 - Include your Jellyfin version and deployment method (Docker, native, etc.).
 
 ## Code of Conduct


### PR DESCRIPTION
Update the 'Reporting Issues' section of CONTRIBUTING.md to reference the correct in-container log path (`/app/logs/jellyfin-groupings.log`) and mention the optional logs volume mount for when users need to access logs from the host.

This aligns the contributing guide with the log path documentation improvements made in PR #551.