### PR TITLE
chore: Deduplicate .gitignore, standardise Makefile on python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,6 @@ node_modules/
 
 # Coverage artifacts (from ``coverage.py`` with ``source=``)
 *.py,cover
-.coverage
-htmlcov/
 
 # Build artifacts
 *.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ install-dev:
 # ── Testing ─────────────────────────────────────────────────────────────────
 
 test:
-	python -m pytest -x -q --ignore=tests/test_deep_sync.py
+	python3 -m pytest -x -q --ignore=tests/test_deep_sync.py
 
 test-all:
-	python -m pytest
+	python3 -m pytest
 
 test-cov:
-	python -m pytest --cov=. --cov-report=term-missing
+	python3 -m pytest --cov=. --cov-report=term-missing
 
 test-to-file:
-	python run_tests_to_file.py
+	python3 run_tests_to_file.py
 
 # ── Linting & Type Checking ─────────────────────────────────────────────────
 
@@ -48,10 +48,10 @@ clean:
 # ── Development ──────────────────────────────────────────────────────────────
 
 run:
-	python app.py
+	python3 app.py
 
 virtual-jellyfin:
-	python start_virtual_jellyfin.py
+	python3 start_virtual_jellyfin.py
 
 # ── Docker ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Changes

- **`.gitignore`**: Removed duplicate `.coverage` and `htmlcov/` entries (were listed twice).
- **`Makefile`**: Changed all targets to use `python3` instead of `python` for consistency with CONTRIBUTING.md and the system-standard Python 3 convention.

Both changes are simple housekeeping — no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and build configuration files to improve project maintenance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->