### PR TITLE
chore: Make pytest -q flag configurable via PYTEST_ARGS variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   values across CSS files now reference these variables for maintainability.
 - `variables.css`: add `--z-locked-overlay` custom property (value `10`)
   for the lock-section overlay badge. (PR #549)
+- `Makefile`: add configurable `PYTEST_ARGS` variable (default `-q`) so
+  callers can override pytest verbosity (e.g. `make test PYTEST_ARGS="-v"`)
+  without editing the Makefile. (PR #557)
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,12 @@ install-dev:
 
 # ── Testing ─────────────────────────────────────────────────────────────────
 
+# PYTEST_ARGS can be overridden to add/remove flags e.g.: make test PYTEST_ARGS="-v"
+# The -q flag reduces pytest verbosity; remove it for full output during debugging.
+PYTEST_ARGS ?= -q
+
 test:
-	python3 -m pytest -x -q --ignore=tests/test_deep_sync.py
+	python3 -m pytest -x $(PYTEST_ARGS) --ignore=tests/test_deep_sync.py
 
 test-all:
 	python3 -m pytest


### PR DESCRIPTION
## Changes

- **Makefile**: Extracted the hardcoded `-q` pytest flag into a `PYTEST_ARGS` variable (default: `-q`)
- Added a comment explaining how to override for verbose debugging

### Why

Addresses [coderabbit feedback on PR #556](https://github.com/EntchenEric/jellyfin-auto-groupings/pull/556#discussion_r1234) — makes the quiet flag configurable so developers can easily switch to verbose output when debugging test failures.

### Usage

```bash
make test                      # default: quiet (-q)
make test PYTEST_ARGS='-v'     # verbose
make test PYTEST_ARGS=''       # no extra flags (default pytest verbosity)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the Makefile testing configuration by making pytest flags configurable, giving you more control over test verbosity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->