### PR TITLE
docs, chore: Improve README dev setup and make PYTEST_ARGS apply to all test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ test:
 	python3 -m pytest -x $(PYTEST_ARGS) --ignore=tests/test_deep_sync.py
 
 test-all:
-	python3 -m pytest
+	python3 -m pytest $(PYTEST_ARGS)
 
 test-cov:
-	python3 -m pytest --cov=. --cov-report=term-missing
+	python3 -m pytest $(PYTEST_ARGS) --cov=. --cov-report=term-missing
 
 test-to-file:
 	python3 run_tests_to_file.py

--- a/README.md
+++ b/README.md
@@ -324,16 +324,22 @@ See [`.env.example`](.env.example) for quick setup.
 ### Building from Source
 
 1. Clone the repo.
-2. Create a virtual environment:
+2. Copy `.env.example` to `.env` and fill in your values for local development.
+3. Create a virtual environment:
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
    ```
-3. Install the package (including dev extras):
+4. Install the package (including dev extras):
    ```bash
    pip install -e .[dev]
    ```
-4. Run: `python3 app.py`.
+5. (Optional) Install pre-commit hooks for lint/format/typecheck/coverage checks:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+6. Run: `python3 app.py`.
 
 ### Print-Friendly Pages
 
@@ -375,6 +381,14 @@ make install-dev
 make test
 make run
 ```
+
+> [!TIP]
+> The default `make test` (and `make test-all` / `make test-cov`) uses pytest's `-q` flag for quiet output.
+> Override verbosity by setting `PYTEST_ARGS`, e.g.:
+> ```bash
+> make test PYTEST_ARGS='-v'    # verbose output
+> make test PYTEST_ARGS=''      # default pytest verbosity
+> ```
 
 ### 🧪 Testing
 


### PR DESCRIPTION
## Changes

### Makefile
- Apply `PYTEST_ARGS` variable (default: `-q`) to **test-all** and **test-cov** targets for consistency — previously only the **test** target used it.

### README
- **Building from Source**: Add step to copy `.env.example` → `.env` and install pre-commit hooks for local development.
- **Makefile targets**: Add a tip explaining that `PYTEST_ARGS` can be overridden for verbose debugging.

## Why
- Makes configurable verbosity universal across all test targets.
- Helps new contributors get set up faster by documenting the `.env.example` and pre-commit hook workflow within the README.