### PR TITLE
docs: Add CHANGELOG entry for PR #558

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Makefile`: add configurable `PYTEST_ARGS` variable (default `-q`) so
   callers can override pytest verbosity (e.g. `make test PYTEST_ARGS="-v"`)
   without editing the Makefile. (PR #557)
+- `Makefile` and `README.md`: apply `PYTEST_ARGS` to `test-all` and
+  `test-cov` targets for consistency, add `.env.example` & pre-commit hooks
+  to dev setup docs, and document `PYTEST_ARGS` override tip. (PR #558)
 
 ### Changed
 


### PR DESCRIPTION
Adds an entry to the Unreleased section documenting PR #558 changes: PYTEST_ARGS applied to test-all/test-cov targets, .env.example step and pre-commit hooks in README dev setup, and PYTEST_ARGS override tip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development documentation with setup and testing configuration improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->