### PR TITLE
chore: Add PYTHONUNBUFFERED=1 to Dockerfile, improve test runner utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Dockerfile`: enable gunicorn access and error logging (`--access-logfile -`
   and `--error-logfile -`) for container observability via `docker logs`. (PR #554)
+- `Dockerfile`: add `ENV PYTHONUNBUFFERED=1` to final stage for immediate
+  container log output. (PR #560)
+- `run_tests_to_file.py`: increase subprocess timeout from 120s → 300s,
+  enable `--tb=short` for concise tracebacks, and log Python version and
+  CWD at report start. (PR #560)
 - `variables.css`: add `color-scheme: dark` / `color-scheme: light` declarations
   for proper native form control styling in both themes. (PR #554)
 - CSS custom property system for z-index layers (`--z-content`, `--z-toast`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Makefile`: add configurable `PYTEST_ARGS` variable (default `-q`) so
   callers can override pytest verbosity (e.g. `make test PYTEST_ARGS="-v"`)
   without editing the Makefile. (PR #557)
+- `Makefile` and `README.md`: apply `PYTEST_ARGS` to `test-all` and
+  `test-cov` targets for consistency, add `.env.example` & pre-commit hooks
+  to dev setup docs, and document `PYTEST_ARGS` override tip. (PR #558)
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN pip install --no-cache-dir --upgrade pip && \
 # ---------------------------------------------------------------------------
 FROM python:3.12-slim
 
+# Ensure Python logs are unbuffered for timely container log output
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 COPY --from=builder /opt/venv /opt/venv

--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -22,14 +22,16 @@ def main() -> None:
     output_file = repo_root / "test_results.txt"
     with output_file.open("w", encoding="utf-8") as f:
         try:
-            # Running all tests with coverage
+            # Running all tests with coverage and short traceback for readability
             f.write("Starting test run...\n")
+            f.write(f"Python: {sys.version}\n")
+            f.write(f"CWD: {repo_root}\n\n")
             f.flush()
             result = subprocess.run(
-                [sys.executable, "-m", "pytest", "--cov=.", "tests/"],
+                [sys.executable, "-m", "pytest", "--cov=.", "--tb=short", "tests/"],
                 stdout=f,
                 stderr=subprocess.STDOUT,
-                timeout=120,
+                timeout=300,
                 check=False,
             )
             f.write(f"\nExit code: {result.returncode}\n")


### PR DESCRIPTION
## Summary

Two small improvements for container ops and developer experience:

### Dockerfile
- Add `ENV PYTHONUNBUFFERED=1` to final stage — ensures Python stdout/stderr are written immediately to container logs rather than being buffered. This is a standard Docker/Python best practice that makes `docker logs` output timely, especially during startup or crashes.

### `run_tests_to_file.py`
- Increase subprocess timeout from 120s → 300s to accommodate slower CI runners or larger test suites without false failures.
- Add `--tb=short` pytest flag so failure tracebacks are concise and readable in the test_results.txt output.
- Log Python version and CWD at start of test report for better debugging context.

No behaviour changes to the application itself. All existing tests continue to pass.