### PR TITLE
chore: config robustness, health endpoint, Docker healthcheck, a11y improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.title="Jellyfin Groupings" \
 EXPOSE 5000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
-  CMD python -c "import requests; requests.get('http://localhost:5000/', timeout=3).raise_for_status()" || exit 1
+  CMD python -c "import requests; requests.get('http://localhost:5000/api/health', timeout=3).raise_for_status()" || exit 1
 
 USER appuser
 

--- a/config.py
+++ b/config.py
@@ -157,10 +157,24 @@ def load_config() -> dict[str, Any]:
             _fill_defaults(cfg, DEFAULT_CONFIG)
             if _migrate_legacy_keys(cfg):
                 save_config(cfg)
-        except (json.JSONDecodeError, OSError):
-            # If the file is corrupt or unreadable, fall back to safe defaults
+        except json.JSONDecodeError:
+            # If the file is corrupt, backup and fall back to safe defaults
             logger.warning(
-                "Could not read config file, falling back to defaults",
+                "Config file %s contains invalid JSON. Falling back to defaults.",
+                CONFIG_FILE,
+            )
+            backup_path = Path(str(CONFIG_FILE) + ".corrupt.bak")
+            try:
+                Path(CONFIG_FILE).rename(backup_path)
+                logger.info("Backed up corrupt config to %s", backup_path)
+            except OSError:
+                logger.exception("Failed to backup corrupt config file")
+            cfg = DEFAULT_CONFIG.copy()
+        except OSError:
+            # If the file is unreadable, fall back to safe defaults
+            logger.warning(
+                "Could not read config file %s, falling back to defaults",
+                CONFIG_FILE,
                 exc_info=True,
             )
             cfg = DEFAULT_CONFIG.copy()

--- a/routes.py
+++ b/routes.py
@@ -32,6 +32,8 @@ from werkzeug.exceptions import HTTPException
 
 import network
 
+_APP_START_TIME: float = time.time()
+
 if TYPE_CHECKING:
     from flask.typing import ResponseReturnValue
 

--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -13,7 +13,10 @@ from pathlib import Path
 
 
 def main() -> None:
-    """Run pytest with coverage and stream output to ``test_results.txt``."""
+    """Run pytest with coverage and stream output to ``test_results.txt``.
+
+    The output file is created in the repository root directory.
+    """
     repo_root = Path(__file__).resolve().parent
     existing = os.environ.get("PYTHONPATH")
     os.environ["PYTHONPATH"] = (

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -7,6 +7,7 @@ Provides a dashboard at http://localhost:8096.
 from __future__ import annotations
 
 import logging
+import os
 
 from config import _env_flag
 from tests.virtual_jellyfin import app
@@ -18,4 +19,5 @@ if __name__ == "__main__":
     logger.info("Dashboard: http://localhost:8096")
     logger.info("Press Ctrl+C to stop.")
     debug: bool = _env_flag("FLASK_DEBUG")
-    app.run(host="0.0.0.0", port=8096, debug=debug)
+    port: int = int(os.environ.get("VIRTUAL_JF_PORT", "8096"))
+    app.run(host="0.0.0.0", port=port, debug=debug)

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -15,6 +15,33 @@ import { initPathPicker, openPathPicker, closePicker, confirmPicker, pickerOutsi
 import { initSidebarResizer } from './features/sidebar-resizer.js';
 import { renderGroups, cancelEdit, toggleSortOrder, toggleSeasonal, toggleGroupScheduler, populateSeasonalDays, resetFormUI, initGroupSearch } from './features/groupings.js';
 
+// ---------------------------------------------------------------------------
+// Global error boundary
+// Catches unhandled promise rejections and uncaught exceptions, displaying
+// them as toast notifications so the user always sees a feedback message
+// instead of a silent failure or a broken page.
+// ---------------------------------------------------------------------------
+window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    const message =
+        reason instanceof Error ? reason.message :
+        typeof reason === 'string' ? reason :
+        'An unexpected error occurred';
+    showToast(message, 'error');
+    // Don't log aborted requests — those are intentional
+    if (!(reason instanceof DOMException && reason.name === 'AbortError')) {
+        console.error('[App] Unhandled rejection:', reason);
+    }
+});
+
+window.addEventListener('error', (event) => {
+    // Only handle script errors, not resource-load failures
+    if (event.error) {
+        showToast(event.error.message || 'Script error', 'error');
+        console.error('[App] Uncaught error:', event.error);
+    }
+});
+
 // Listen for cross-module events
 document.addEventListener('groups-changed', () => renderGroups());
 
@@ -166,8 +193,14 @@ function wireHamburgerButton() {
     const hamburger = getEl('hamburger-btn');
     if (hamburger) {
         hamburger.addEventListener('click', () => {
-            document.getElementById('sidebar').classList.toggle('open');
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+            const isOpen = sidebar.classList.contains('open');
+            hamburger.setAttribute('aria-expanded', String(isOpen));
+            hamburger.setAttribute('aria-label', isOpen ? 'Close sidebar menu' : 'Open sidebar menu');
         });
+        // Set initial state
+        hamburger.setAttribute('aria-expanded', 'false');
     }
 }
 
@@ -243,9 +276,12 @@ function wirePasswordToggles() {
             const isPassword = input.type === 'password';
             input.type = isPassword ? 'text' : 'password';
             btn.classList.toggle('visible', isPassword);
-            btn.setAttribute('aria-label', isPassword ? 'Hide API key' : 'Show API key');
+            btn.setAttribute('aria-label', isPassword ? 'Hide ' + input.name + ' value' : 'Show ' + input.name + ' value');
+            btn.setAttribute('aria-pressed', String(!isPassword));
             btn.innerHTML = isPassword ? eyeSlashSvg : eyeSvg;
         });
+        // Set initial aria state
+        btn.setAttribute('aria-pressed', 'false');
     });
 }
 


### PR DESCRIPTION
## Changes

### config.py
- Split single  into two separate handlers
- Back up corrupt config files to `config.json.corrupt.bak` before falling back to defaults
- Clearer log messages with the config file path

### routes.py
- Added `_APP_START_TIME` module constant for future use (health endpoint uptime tracking)

### Dockerfile
- Updated `HEALTHCHECK` to use `/api/health` (existing endpoint) instead of the homepage root

### run_tests_to_file.py
- Expanded docstring to clarify output file location

### start_virtual_jellyfin.py
- Added `VIRTUAL_JF_PORT` env var support for overriding the default port 8096

### static/js/app.js
- Added global error boundary (`unhandledrejection` + `error` window listeners) so runtime JavaScript errors are surfaced as toast notifications
- Improved hamburger button with `aria-expanded` and `aria-label` toggling for accessibility
- Improved password toggle buttons with `aria-pressed` and dynamic `aria-label` based on the input field name

## Testing
- 590 existing tests all pass (no regressions)
- Ruff, ruff format, and mypy all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for corrupted configuration files with automatic backup creation
  * Added global error notifications to display issues to users

* **New Features**
  * Server port is now configurable via environment variable (defaults to 8096)
  * Enhanced accessibility features with improved ARIA labels and states for navigation and controls

* **Chores**
  * Updated health check endpoint for better system monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->