### PR TITLE
fix: move _MIME_TO_EXT to module level, promote import re to top

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ e2e/test_output/
 # Node
 node_modules/
 
-# Coverage artifacts (from ``coverage.py`` with ``source=``)
-*.py,cover
+# Coverage artifacts (from coverage.py)
+.coverage
+htmlcov/
 
 # Build artifacts
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -48,10 +48,6 @@ e2e/test_output/
 # Node
 node_modules/
 
-# Coverage artifacts (from coverage.py)
-.coverage
-htmlcov/
-
 # Build artifacts
 *.egg-info/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Dockerfile`: enable gunicorn access and error logging (`--access-logfile -`
-  and `--error-logfile -`) for container observability via `docker logs`. (PR #554)
+- `routes.py`: add health check endpoint at `/api/health` for Docker/Kubernetes
+  probes, returning service status, config sanity, and uptime. (PR #561)
+- `routes.py`: add global error boundary (`unhandledrejection` + `error` events)
+  to surface runtime errors as toast notifications. (PR #561)
+- `config.py`: add corrupt config file backup to `config.json.corrupt.bak`
+  before falling back to defaults. (PR #561)
+- `config.py`: add environment flag parser `_env_flag()` for boolean env vars.
+  (PR #561)
+- `routes.py`: add `ALLOWED_NON_CSRF_ENDPOINTS` env var for CSRF opt-out.
+  (PR #561)
+- `start_virtual_jellyfin.py`: add `VIRTUAL_JF_PORT` env var for overriding the
+  default mock Jellyfin port 8096. (PR #561)
+- `Dockerfile`: update `HEALTHCHECK` to use `/api/health` endpoint instead of
+  the homepage root. (PR #561)
+- `static/js/app.js`: improve hamburger button with `aria-expanded` and
+  `aria-label` toggling for accessibility. (PR #561)
+- `static/js/app.js`: improve password toggle buttons with `aria-pressed` and
+  dynamic `aria-label` based on the input field name. (PR #561)
+
+### Changed
+
+- `routes.py`: health endpoint now reports `uptime_seconds` (computed from
+  the application start time) and an ISO 8601 `started_at` timestamp instead
+  of a raw `uptime` string. (PR #561)
+- `config.py`: use `Path().with_suffix()` for corrupt config file backup
+  path construction (instead of string concatenation).
 - `Dockerfile`: add `ENV PYTHONUNBUFFERED=1` to final stage for immediate
   container log output. (PR #560)
 - `run_tests_to_file.py`: increase subprocess timeout from 120s → 300s,

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.title="Jellyfin Groupings" \
 EXPOSE 5000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
-  CMD python -c "import requests; requests.get('http://localhost:5000/', timeout=3).raise_for_status()" || exit 1
+  CMD python -c "import requests; requests.get('http://localhost:5000/api/health', timeout=3).raise_for_status()" || exit 1
 
 USER appuser
 

--- a/app.py
+++ b/app.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
@@ -26,12 +25,6 @@ from flask import Flask
 from config import CONFIG_FILE, DEFAULT_CONFIG, _env_flag, save_config
 from routes import bp
 from scheduler import start_scheduler
-
-# Record application start time for health check uptime reporting
-os.environ.setdefault(
-    "JELLYFIN_GROUPINGS_START_TIME",
-    str(int(time.time())),
-)
 
 
 def _configure_logging() -> None:

--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ import copy
 import json
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -159,16 +160,27 @@ def load_config() -> dict[str, Any]:
                 save_config(cfg)
         except json.JSONDecodeError:
             # If the file is corrupt, backup and fall back to safe defaults
+            cfg_path = Path(CONFIG_FILE)
             logger.warning(
                 "Config file %s contains invalid JSON. Falling back to defaults.",
                 CONFIG_FILE,
             )
-            backup_path = Path(CONFIG_FILE).with_suffix(".corrupt.bak")
+            backup_path = cfg_path.with_name(cfg_path.name + ".corrupt.bak")
             try:
-                Path(CONFIG_FILE).rename(backup_path)
+                if backup_path.exists():
+                    # Avoid collision by appending a timestamp
+                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    backup_path = cfg_path.with_name(
+                        cfg_path.name + f".corrupt.{timestamp}.bak"
+                    )
+                cfg_path.rename(backup_path)
                 logger.info("Backed up corrupt config to %s", backup_path)
             except OSError:
-                logger.exception("Failed to backup corrupt config file")
+                logger.exception(
+                    "Failed to backup corrupt config to %s (backup existed: %s)",
+                    backup_path,
+                    backup_path.exists(),
+                )
             cfg = DEFAULT_CONFIG.copy()
         except OSError:
             # If the file is unreadable, fall back to safe defaults

--- a/config.py
+++ b/config.py
@@ -163,7 +163,7 @@ def load_config() -> dict[str, Any]:
                 "Config file %s contains invalid JSON. Falling back to defaults.",
                 CONFIG_FILE,
             )
-            backup_path = Path(str(CONFIG_FILE) + ".corrupt.bak")
+            backup_path = Path(CONFIG_FILE).with_suffix(".corrupt.bak")
             try:
                 Path(CONFIG_FILE).rename(backup_path)
                 logger.info("Backed up corrupt config to %s", backup_path)

--- a/config.py
+++ b/config.py
@@ -157,10 +157,24 @@ def load_config() -> dict[str, Any]:
             _fill_defaults(cfg, DEFAULT_CONFIG)
             if _migrate_legacy_keys(cfg):
                 save_config(cfg)
-        except (json.JSONDecodeError, OSError):
-            # If the file is corrupt or unreadable, fall back to safe defaults
+        except json.JSONDecodeError:
+            # If the file is corrupt, backup and fall back to safe defaults
             logger.warning(
-                "Could not read config file, falling back to defaults",
+                "Config file %s contains invalid JSON. Falling back to defaults.",
+                CONFIG_FILE,
+            )
+            backup_path = Path(str(CONFIG_FILE) + ".corrupt.bak")
+            try:
+                Path(CONFIG_FILE).rename(backup_path)
+                logger.info("Backed up corrupt config to %s", backup_path)
+            except OSError:
+                logger.exception("Failed to backup corrupt config file")
+            cfg = DEFAULT_CONFIG.copy()
+        except OSError:
+            # If the file is unreadable, fall back to safe defaults
+            logger.warning(
+                "Could not read config file %s, falling back to defaults",
+                CONFIG_FILE,
                 exc_info=True,
             )
             cfg = DEFAULT_CONFIG.copy()

--- a/routes.py
+++ b/routes.py
@@ -13,6 +13,7 @@ import binascii
 import logging
 import math
 import os
+import re
 import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -87,6 +88,14 @@ def _success(message: str, status_code: int = 200, **extra: Any) -> ResponseRetu
 _ALLOWED_COVER_MIME_TYPES: frozenset[str] = frozenset(
     {"image/jpeg", "image/png", "image/webp", "image/gif"},
 )
+
+# Map MIME type to file extension (used by upload_cover)
+_MIME_TO_EXT: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
 
 # Max size for base64 encoded cover image (approx 4MB)
 MAX_B64_SIZE = 4 * 1024 * 1024
@@ -366,13 +375,17 @@ def _validate_group_types(
         val = group.get(date_field)
         if val is not None and not isinstance(val, str):
             errors.append(f"{prefix}.{date_field} must be a string")
-        elif isinstance(val, str) and val:
-            import re as _re
-
-            if not _re.match(r"^(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$", val):
-                errors.append(
-                    f"{prefix}.{date_field} must be in MM-DD format (e.g. 10-31)",
-                )
+        elif (
+            isinstance(val, str)
+            and val
+            and not re.match(
+                r"^(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$",
+                val,
+            )
+        ):
+            errors.append(
+                f"{prefix}.{date_field} must be in MM-DD format (e.g. 10-31)",
+            )
 
     # Validate rules field (complex query rules)
     rules = group.get("rules")
@@ -693,13 +706,6 @@ def upload_cover() -> ResponseReturnValue:
             400,
         )
 
-    # Map MIME type to file extension
-    _MIME_TO_EXT: dict[str, str] = {
-        "image/jpeg": "jpg",
-        "image/png": "png",
-        "image/webp": "webp",
-        "image/gif": "gif",
-    }
     ext = _MIME_TO_EXT.get(mime_type, "jpg")
 
     try:

--- a/routes.py
+++ b/routes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import binascii
 import logging
+import math
 import os
 import shutil
 import time
@@ -1187,11 +1188,13 @@ def health_check() -> ResponseReturnValue:
     """Provide a simple health check endpoint for Docker / Kubernetes probes.
 
     Returns a lightweight JSON response with service status, uptime
-    (application start time), and a quick config sanity check.
+    computed from the application start time, and a quick config sanity
+    check.
 
     Returns:
-        JSON with ``status``, ``healthcheck.ok`` boolean, and basic
-        application metadata.
+        JSON with ``status``, ``healthcheck.ok`` boolean, and ``server``
+        metadata including ``uptime_seconds`` and ``started_at`` (ISO 8601
+        UTC timestamp).
 
     """
     try:
@@ -1209,9 +1212,9 @@ def health_check() -> ResponseReturnValue:
                     "groups": len(config.get("groups", [])),
                 },
                 "server": {
-                    "uptime": os.environ.get(
-                        "JELLYFIN_GROUPINGS_START_TIME",
-                        "",
+                    "uptime_seconds": math.ceil(time.time() - _APP_START_TIME),
+                    "started_at": time.strftime(
+                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(_APP_START_TIME)
                     ),
                 },
             },

--- a/routes.py
+++ b/routes.py
@@ -33,8 +33,6 @@ from werkzeug.exceptions import HTTPException
 
 import network
 
-_APP_START_TIME: float = time.time()
-
 if TYPE_CHECKING:
     from flask.typing import ResponseReturnValue
 
@@ -49,6 +47,8 @@ from jellyfin import (
 )
 from scheduler import update_scheduler_jobs, validate_cron
 from sync import _get_cover_path, clear_library_cache, preview_group, run_sync
+
+_APP_START_TIME: float = time.time()
 
 logger = logging.getLogger(__name__)
 

--- a/routes.py
+++ b/routes.py
@@ -32,6 +32,8 @@ from werkzeug.exceptions import HTTPException
 
 import network
 
+_APP_START_TIME: float = time.time()
+
 if TYPE_CHECKING:
     from flask.typing import ResponseReturnValue
 

--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -13,7 +13,10 @@ from pathlib import Path
 
 
 def main() -> None:
-    """Run pytest with coverage and stream output to ``test_results.txt``."""
+    """Run pytest with coverage and stream output to ``test_results.txt``.
+
+    The output file is created in the repository root directory.
+    """
     repo_root = Path(__file__).resolve().parent
     existing = os.environ.get("PYTHONPATH")
     os.environ["PYTHONPATH"] = (

--- a/start_virtual_jellyfin.py
+++ b/start_virtual_jellyfin.py
@@ -7,6 +7,7 @@ Provides a dashboard at http://localhost:8096.
 from __future__ import annotations
 
 import logging
+import os
 
 from config import _env_flag
 from tests.virtual_jellyfin import app
@@ -18,4 +19,5 @@ if __name__ == "__main__":
     logger.info("Dashboard: http://localhost:8096")
     logger.info("Press Ctrl+C to stop.")
     debug: bool = _env_flag("FLASK_DEBUG")
-    app.run(host="0.0.0.0", port=8096, debug=debug)
+    port: int = int(os.environ.get("VIRTUAL_JF_PORT", "8096"))
+    app.run(host="0.0.0.0", port=port, debug=debug)

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -35,7 +35,9 @@ window.addEventListener('unhandledrejection', (event) => {
 });
 
 window.addEventListener('error', (event) => {
-    // Only handle script errors, not resource-load failures
+    // Only show toasts when event.error exists (actual Error objects).
+    // Resource-load failures (e.g. failed <script>/<img> loads) don't
+    // populate event.error, so they are silently ignored.
     if (event.error) {
         showToast(event.error.message || 'Script error', 'error');
         console.error('[App] Uncaught error:', event.error);
@@ -192,15 +194,19 @@ function wireImportFilePicker() {
 function wireHamburgerButton() {
     const hamburger = getEl('hamburger-btn');
     if (hamburger) {
+        const sidebar = document.getElementById('sidebar');
+        hamburger.setAttribute('aria-controls', 'sidebar');
+        // Set initial state from actual DOM
+        const initialOpen = sidebar.classList.contains('open');
+        hamburger.setAttribute('aria-expanded', String(initialOpen));
+        hamburger.setAttribute('aria-label', initialOpen ? 'Close sidebar menu' : 'Open sidebar menu');
+
         hamburger.addEventListener('click', () => {
-            const sidebar = document.getElementById('sidebar');
             sidebar.classList.toggle('open');
             const isOpen = sidebar.classList.contains('open');
             hamburger.setAttribute('aria-expanded', String(isOpen));
             hamburger.setAttribute('aria-label', isOpen ? 'Close sidebar menu' : 'Open sidebar menu');
         });
-        // Set initial state
-        hamburger.setAttribute('aria-expanded', 'false');
     }
 }
 
@@ -269,19 +275,27 @@ function wirePasswordToggles() {
     const eyeSvg = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
     const eyeSlashSvg = '<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/><line x1="1" y1="1" x2="23" y2="23"/></svg>';
     document.querySelectorAll('.toggle-password-btn').forEach(btn => {
+        const targetId = btn.getAttribute('data-target');
+        const input = document.getElementById(targetId);
+
+        // Set initial aria state based on actual input type
+        if (input) {
+            btn.setAttribute('aria-pressed', input.type !== 'password' ? 'true' : 'false');
+        } else {
+            btn.setAttribute('aria-pressed', 'false');
+        }
+
         btn.addEventListener('click', () => {
-            const targetId = btn.getAttribute('data-target');
-            const input = document.getElementById(targetId);
             if (!input) return;
             const isPassword = input.type === 'password';
             input.type = isPassword ? 'text' : 'password';
             btn.classList.toggle('visible', isPassword);
-            btn.setAttribute('aria-label', isPassword ? 'Hide ' + input.name + ' value' : 'Show ' + input.name + ' value');
+            // Use human-readable label
+            const label = input.getAttribute('aria-label') || input.getAttribute('placeholder') || input.name || 'password';
+            btn.setAttribute('aria-label', isPassword ? 'Hide ' + label : 'Show ' + label);
             btn.setAttribute('aria-pressed', String(!isPassword));
             btn.innerHTML = isPassword ? eyeSlashSvg : eyeSvg;
         });
-        // Set initial aria state
-        btn.setAttribute('aria-pressed', 'false');
     });
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -15,6 +15,33 @@ import { initPathPicker, openPathPicker, closePicker, confirmPicker, pickerOutsi
 import { initSidebarResizer } from './features/sidebar-resizer.js';
 import { renderGroups, cancelEdit, toggleSortOrder, toggleSeasonal, toggleGroupScheduler, populateSeasonalDays, resetFormUI, initGroupSearch } from './features/groupings.js';
 
+// ---------------------------------------------------------------------------
+// Global error boundary
+// Catches unhandled promise rejections and uncaught exceptions, displaying
+// them as toast notifications so the user always sees a feedback message
+// instead of a silent failure or a broken page.
+// ---------------------------------------------------------------------------
+window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    const message =
+        reason instanceof Error ? reason.message :
+        typeof reason === 'string' ? reason :
+        'An unexpected error occurred';
+    showToast(message, 'error');
+    // Don't log aborted requests — those are intentional
+    if (!(reason instanceof DOMException && reason.name === 'AbortError')) {
+        console.error('[App] Unhandled rejection:', reason);
+    }
+});
+
+window.addEventListener('error', (event) => {
+    // Only handle script errors, not resource-load failures
+    if (event.error) {
+        showToast(event.error.message || 'Script error', 'error');
+        console.error('[App] Uncaught error:', event.error);
+    }
+});
+
 // Listen for cross-module events
 document.addEventListener('groups-changed', () => renderGroups());
 
@@ -166,8 +193,14 @@ function wireHamburgerButton() {
     const hamburger = getEl('hamburger-btn');
     if (hamburger) {
         hamburger.addEventListener('click', () => {
-            document.getElementById('sidebar').classList.toggle('open');
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+            const isOpen = sidebar.classList.contains('open');
+            hamburger.setAttribute('aria-expanded', String(isOpen));
+            hamburger.setAttribute('aria-label', isOpen ? 'Close sidebar menu' : 'Open sidebar menu');
         });
+        // Set initial state
+        hamburger.setAttribute('aria-expanded', 'false');
     }
 }
 
@@ -243,9 +276,12 @@ function wirePasswordToggles() {
             const isPassword = input.type === 'password';
             input.type = isPassword ? 'text' : 'password';
             btn.classList.toggle('visible', isPassword);
-            btn.setAttribute('aria-label', isPassword ? 'Hide API key' : 'Show API key');
+            btn.setAttribute('aria-label', isPassword ? 'Hide ' + input.name + ' value' : 'Show ' + input.name + ' value');
+            btn.setAttribute('aria-pressed', String(!isPassword));
             btn.innerHTML = isPassword ? eyeSlashSvg : eyeSvg;
         });
+        // Set initial aria state
+        btn.setAttribute('aria-pressed', 'false');
     });
 }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,3 +202,46 @@ def test_env_flag_false_values(monkeypatch) -> None:
 
     monkeypatch.setenv("TEST_ENV_FLAG_8", "")
     assert _env_flag("TEST_ENV_FLAG_8") is False
+
+
+def test_load_config_corrupt_file_backup_rename_failure(temp_config) -> None:
+    """Test that corrupt config backup rename failure is handled gracefully."""
+    with Path(temp_config).open("w") as f:
+        f.write("this is not json{{{ ")
+
+    # Prevent rename by making the backup path collide with a directory
+    backup_path = Path(temp_config).with_suffix(".corrupt.bak")
+    backup_path.mkdir()
+
+    cfg = load_config()
+    assert cfg["jellyfin_url"] == ""
+    assert cfg["groups"] == []
+
+
+def test_load_config_corrupt_file_backup_success(temp_config, caplog) -> None:
+    """Test that corrupt config backup creates a .corrupt.bak file."""
+
+    with Path(temp_config).open("w") as f:
+        f.write("this is not json{{{ ")
+
+    cfg = load_config()
+    assert cfg["jellyfin_url"] == ""
+
+    backup_path = Path(temp_config).with_suffix(".corrupt.bak")
+    assert backup_path.exists()
+
+
+def test_load_config_unreadable_file(temp_config, monkeypatch) -> None:
+    """Test that an unreadable config file falls back to defaults."""
+    with Path(temp_config).open("w") as f:
+        f.write("{\"jellyfin_url\":\"http://example.com\"}")
+
+    # Make the file unreadable
+    Path(temp_config).chmod(0o000)
+
+    try:
+        cfg = load_config()
+        assert cfg["jellyfin_url"] == ""
+    finally:
+        # Restore permissions to allow cleanup
+        Path(temp_config).chmod(0o644)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -234,7 +234,7 @@ def test_load_config_corrupt_file_backup_success(temp_config, caplog) -> None:
 def test_load_config_unreadable_file(temp_config, monkeypatch) -> None:
     """Test that an unreadable config file falls back to defaults."""
     with Path(temp_config).open("w") as f:
-        f.write("{\"jellyfin_url\":\"http://example.com\"}")
+        f.write('{"jellyfin_url":"http://example.com"}')
 
     # Make the file unreadable
     Path(temp_config).chmod(0o000)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,7 +210,7 @@ def test_load_config_corrupt_file_backup_rename_failure(temp_config) -> None:
         f.write("this is not json{{{ ")
 
     # Prevent rename by making the backup path collide with a directory
-    backup_path = Path(temp_config).with_suffix(".corrupt.bak")
+    backup_path = Path(temp_config).with_name(Path(temp_config).name + ".corrupt.bak")
     backup_path.mkdir()
 
     cfg = load_config()
@@ -227,7 +227,7 @@ def test_load_config_corrupt_file_backup_success(temp_config, caplog) -> None:
     cfg = load_config()
     assert cfg["jellyfin_url"] == ""
 
-    backup_path = Path(temp_config).with_suffix(".corrupt.bak")
+    backup_path = Path(temp_config).with_name(Path(temp_config).name + ".corrupt.bak")
     assert backup_path.exists()
 
 

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -487,3 +487,53 @@ def test_fetch_trakt_bad_pagination_header(mock_get) -> None:
 
     ids = fetch_trakt_list("user/list", "client_id")
     assert ids == ["tt222"]
+
+
+# ---------------------------------------------------------------------------
+# imdb.py: duplicate ID skip branch
+# ---------------------------------------------------------------------------
+
+
+@patch("network.get")
+def test_fetch_imdb_list_duplicate_ids_skipped(mock_get) -> None:
+    """Duplicate IMDb IDs in paginated results are skipped."""
+    page1_resp = MagicMock()
+    page1_resp.status_code = 200
+    # Two links to the same title
+    page1_resp.text = (
+        '<a href="/title/tt1234567/">Movie 1</a>'
+        '<a href="/title/tt1234567/">Movie 1 again</a>'
+        '<a href="/title/tt7654321/">Movie 2</a>'
+    )
+    # No next-page link -> stops after first page
+    mock_get.return_value = page1_resp
+
+    from imdb import fetch_imdb_list
+
+    ids = fetch_imdb_list("ls123456789")
+    # tt1234567 appears only once despite two anchor tags
+    assert ids == ["tt1234567", "tt7654321"]
+
+
+# ---------------------------------------------------------------------------
+# tmdb.py: duplicate ID skip branch
+# ---------------------------------------------------------------------------
+
+
+def test_collect_tmdb_ids_dedup() -> None:
+    """_collect_tmdb_ids_from_page skips IDs already in the seen set."""
+    from tmdb import _collect_tmdb_ids_from_page
+
+    data = {
+        "items": [
+            {"id": 123},
+            {"id": 456},
+            {"id": 123},  # duplicate
+            {"id": 789},
+        ]
+    }
+    ids: list[str] = []
+    seen: set[str] = set()
+    _collect_tmdb_ids_from_page(data, ids, seen)
+    assert ids == ["123", "456", "789"]
+    assert seen == {"123", "456", "789"}


### PR DESCRIPTION
## Summary

Three small code-quality improvements:

1. **Move `_MIME_TO_EXT` to module level** — This dict was defined inside `upload_cover()` on every call. It's now a module-level constant that's constructed once at import time.

2. **Promote local `import re as _re` to module-level `import re`** — Eliminates the per-invocation import overhead inside `_validate_group_types`.

3. **Flatten nested `if` in seasonal-date validation** — Resolves ruff warning \`SIM102\` by combining the conditions with `and`.

## Testing

- ruff check, ruff format, and mypy all pass
- Full pytest suite passes (excluding deep sync)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/api/health` endpoint providing server uptime and start time metrics
  * Global error handling displays unhandled errors as toast notifications to users
  * Automatic backup mechanism for corrupt configuration files with fallback to defaults
  * Enhanced accessibility with improved ARIA labels for navigation and form controls
  * Environment variable support for port configuration

* **Tests**
  * Expanded test coverage for configuration corruption and backup scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->