### PR TITLE
fix: add proper error handling to fetch_anilist_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #561)
 - `routes.py`: add `ALLOWED_NON_CSRF_ENDPOINTS` env var for CSRF opt-out.
   (PR #561)
+
+### Fixed
+
+- `anilist.py`: catch `requests.RequestException` in `fetch_anilist_list()`
+  and wrap it in a descriptive `RuntimeError`, matching the pattern used by
+  the other fetcher modules for consistent error reporting.
 - `start_virtual_jellyfin.py`: add `VIRTUAL_JF_PORT` env var for overriding the
   default mock Jellyfin port 8096. (PR #561)
 - `Dockerfile`: update `HEALTHCHECK` to use `/api/health` endpoint instead of

--- a/anilist.py
+++ b/anilist.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import requests
+
 import network
 
 __all__ = ["fetch_anilist_list"]
@@ -119,11 +121,15 @@ def fetch_anilist_list(
         normalized_status or "ALL",
     )
 
-    response = network.post(
-        resolved_url,
-        json={"query": _ANILIST_QUERY, "variables": variables},
-        timeout=_REQUEST_TIMEOUT,
-    )
-    response.raise_for_status()
+    try:
+        response = network.post(
+            resolved_url,
+            json={"query": _ANILIST_QUERY, "variables": variables},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        msg = f"Failed to fetch AniList list for user {username!r}: {exc}"
+        raise RuntimeError(msg) from exc
 
     return _extract_media_ids(response.json())

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -161,3 +161,35 @@ def test_fetch_anilist_list_entry_not_dict(mock_post) -> None:
     mock_post.return_value = mock_resp
     ids = fetch_anilist_list("user")
     assert ids == [12345]
+
+
+@patch("anilist.network.post")
+def test_fetch_anilist_http_error(mock_post) -> None:
+    """Anilist network error raises RuntimeError."""
+    mock_post.side_effect = requests.exceptions.RequestException(
+        "Connection refused",
+    )
+    with pytest.raises(RuntimeError, match="Failed to fetch AniList list"):
+        fetch_anilist_list("user")
+
+
+@patch("anilist.network.post")
+def test_fetch_anilist_custom_api_url(mock_post) -> None:
+    """AniList custom API URL is used when provided."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "data": {
+            "MediaListCollection": {
+                "lists": [
+                    {"entries": [{"mediaId": 42}]},
+                ],
+            },
+        },
+    }
+    mock_post.return_value = mock_resp
+    ids = fetch_anilist_list("user", api_url="https://custom.anilist.example/graphql")
+    assert ids == [42]
+    _args, kwargs = mock_post.call_args
+    assert kwargs["json"]["variables"]["userName"] == "user"
+    assert _args[0] == "https://custom.anilist.example/graphql"


### PR DESCRIPTION
## Summary

Add proper error handling to `fetch_anilist_list()` in `anilist.py` to catch network errors and raise descriptive `RuntimeError`, matching the pattern used by all other fetcher modules (`imdb.py`, `trakt.py`, `tmdb.py`, etc.).

## Changes

- **anilist.py**: Wrap `network.post()` call in try/except for `requests.RequestException`, raising `RuntimeError` with a descriptive message
- **tests/test_fetchers.py**: Added two new tests:
  - `test_fetch_anilist_http_error` — verifies `RuntimeError` on network failure
  - `test_fetch_anilist_custom_api_url` — verifies custom `api_url` parameter overrides the default endpoint
- **CHANGELOG.md**: Added entry under Fixed section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for AniList API requests. Network failures now raise clear, descriptive error messages instead of propagating low-level exceptions.

* **Tests**
  * Added test cases verifying proper error handling for failed AniList requests and validating custom API URL override functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->