### PR TITLE
docs: add GUNICORN_WORKERS env var, fix lint, merge PR #999

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,11 @@
 # Default: 120
 # GUNICORN_TIMEOUT=120
 
+# Number of gunicorn worker processes. Increase for multi-core hosts to
+# handle concurrent requests. A good rule of thumb is 2-4 per CPU core.
+# Default: 2
+# GUNICORN_WORKERS=2
+
 # ── HTTP Retry Configuration ───────────────────────────────
 # Controls retry behaviour for external API calls (IMDb, Trakt, TMDb, AniList, MAL)
 # Set NETWORK_RETRY_TOTAL=0 to disable retries entirely.

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,13 @@ USER appuser
 # ------------------------------------------------------------------
 # Gunicorn configuration — timeout is configurable via GUNICORN_TIMEOUT
 # (default 120s) for deployments with slow API responses or large libraries.
+# Worker count is configurable via GUNICORN_WORKERS (default 2) for
+# multi-core hosts.
 # ------------------------------------------------------------------
 ENV GUNICORN_TIMEOUT=120
+ENV GUNICORN_WORKERS=2
 
-# shell entrypoint expands $GUNICORN_TIMEOUT at container start so the
-# environment variable can be overridden without rebuilding the image.
-ENTRYPOINT ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:5000 --workers 2 --timeout ${GUNICORN_TIMEOUT} --preload --access-logfile - --error-logfile - app:app"]
+# shell entrypoint expands $GUNICORN_TIMEOUT and $GUNICORN_WORKERS at
+# container start so environment variables can be overridden without
+# rebuilding the image.
+ENTRYPOINT ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:5000 --workers ${GUNICORN_WORKERS} --timeout ${GUNICORN_TIMEOUT} --preload --access-logfile - --error-logfile - app:app"]

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ The application reads the following environment variables (which take precedence
 | `FLASK_DEBUG` | Enable Flask debug mode (`true`/`false`) |
 | `LOG_LEVEL` | Log level for application output. Accepts `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default: `INFO`) |
 | `GUNICORN_TIMEOUT` | Gunicorn worker timeout in seconds for long-running API calls (default: `120`). Increase this if sync operations time out |
+| `GUNICORN_WORKERS` | Number of gunicorn worker processes for handling concurrent requests (default: `2`). Increase for multi-core hosts |
 | `ANILIST_API_URL` | AniList GraphQL endpoint (default: `https://graphql.anilist.co`) |
 | `VIRTUAL_JF_PORT` | Port for mock Jellyfin server used during development (default: `8096`) |
 | `NETWORK_RETRY_TOTAL` | Max HTTP retries for external API calls (default: `3`; set `0` to disable) |
@@ -464,6 +465,7 @@ services:
       - ALLOWED_NON_CSRF_ENDPOINTS= # optional: comma-separated Flask endpoint names (e.g. "main.webhook,main.callback") exempt from CSRF check
       - LOG_LEVEL=INFO                   # optional: log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
       - GUNICORN_TIMEOUT=120            # optional: gunicorn worker timeout in seconds (default: 120)
+      - GUNICORN_WORKERS=2              # optional: gunicorn worker process count (default: 2)
       - FLASK_DEBUG=false              # optional: set to true for debug mode
     restart: unless-stopped
 ```

--- a/routes.py
+++ b/routes.py
@@ -341,7 +341,9 @@ def _validate_scheduler_types(sched: dict[str, Any], errors: list[str]) -> None:
 
 
 def _validate_group_rules(
-    rules: list[dict[str, Any]], prefix: str, errors: list[str],
+    rules: list[dict[str, Any]],
+    prefix: str,
+    errors: list[str],
 ) -> None:
     """Validate type correctness of a group's complex query rules."""
     for j, rule in enumerate(rules):
@@ -356,7 +358,9 @@ def _validate_group_rules(
 
 
 def _validate_group_types(
-    group: dict[str, Any], prefix: str, errors: list[str],
+    group: dict[str, Any],
+    prefix: str,
+    errors: list[str],
 ) -> None:
     """Validate type correctness of a single group definition."""
     if not isinstance(group, dict):
@@ -722,7 +726,10 @@ def upload_cover() -> ResponseReturnValue:
         target_path = str(cfg.get("target_path", ""))
 
         cover_path = _get_cover_path(
-            group_name, target_path, check_exists=False, ext=ext,
+            group_name,
+            target_path,
+            check_exists=False,
+            ext=ext,
         )
         if cover_path is None:
             return _error("Could not resolve cover storage path", 500)
@@ -1223,7 +1230,8 @@ def health_check() -> ResponseReturnValue:
                 "server": {
                     "uptime_seconds": math.ceil(time.time() - _APP_START_TIME),
                     "started_at": time.strftime(
-                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(_APP_START_TIME),
+                        "%Y-%m-%dT%H:%M:%SZ",
+                        time.gmtime(_APP_START_TIME),
                     ),
                 },
             },

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2353,7 +2353,7 @@ def test_run_sync_path_translation_active(
 
 # ---------------------------------------------------------------------------
 # Complex query parser — edge cases
-# Covers issues #968–#975 (good-first-issue testing tickets)
+# Covers issues #968-#975 (good-first-issue testing tickets)
 # ---------------------------------------------------------------------------
 
 
@@ -2405,7 +2405,9 @@ def test_parse_complex_query_impossible_year_and() -> None:
 
 def test_parse_complex_query_nested_and_or_with_not() -> None:
     """Complex chain with AND, OR, NOT in various positions."""
-    rules = parse_complex_query("Action AND NOT Comedy OR Drama AND NOT Horror", "genre")
+    rules = parse_complex_query(
+        "Action AND NOT Comedy OR Drama AND NOT Horror", "genre"
+    )
     assert len(rules) == 4
     assert rules[0] == {"operator": "AND", "type": "genre", "value": "Action"}
     assert rules[1] == {"operator": "AND NOT", "type": "genre", "value": "Comedy"}
@@ -2458,9 +2460,7 @@ def test_parse_complex_query_special_chars_in_values() -> None:
 def test_parse_complex_query_unicode_values() -> None:
     """Unicode characters in actor/genre names are preserved."""
     rules = parse_complex_query("actor:Àgént Cöñnor", "genre")
-    assert rules == [
-        {"operator": "AND", "type": "actor", "value": "Àgént Cöñnor"}
-    ]
+    assert rules == [{"operator": "AND", "type": "actor", "value": "Àgént Cöñnor"}]
 
     rules = parse_complex_query("genre:科学 AND actor:トム・クルーズ", "tag")
     assert len(rules) == 2


### PR DESCRIPTION
## Summary

Closes #965 by adding  environment variable support to the Dockerfile and documenting it in README and .env.example.

### Changes

1. **Fix pre-existing lint failures** (RUF003 en-dash → hyphen in test comment, ruff format routes.py) — these were causing CI lint checks to fail on PRs.
2. **Dockerfile**: Make  configurable via env var (default `2`), alongside the existing .
3. **.env.example**: Add  documentation entry.
4. **README**: Add  to Environment Variables table and to the Docker Compose example section.
5. **PR #999** (GUNICORN_TIMEOUT) was already merged into main via `gh pr merge`.

Closes #965 (document GUNICORN_WORKERS)