### PR TITLE
docs: add missing env vars to docker-compose.yml and close env var documentation issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,14 @@ services:
       # - NETWORK_RETRY_TOTAL=3
       # - NETWORK_RETRY_BACKOFF_FACTOR=1.0
       # - NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504
+      # Comma-separated Flask endpoint names exempt from the X-Requested-With CSRF check:
+      # - ALLOWED_NON_CSRF_ENDPOINTS=main.webhook,main.callback
+      # Control log verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL; default: INFO):
+      # - LOG_LEVEL=INFO
+      # Gunicorn worker timeout in seconds for long-running sync (default: 120):
+      # - GUNICORN_TIMEOUT=120
+      # Number of gunicorn worker processes (default: 2):
+      # - GUNICORN_WORKERS=2
     volumes:
       # 1. Config persistence
       # Stores your API keys and group definitions. 


### PR DESCRIPTION
## Summary

Adds missing environment variable comments to `docker-compose.yml` that were already documented in the README env table and `.env.example`.

### Changes

**docker-compose.yml:** Added comments for:
- `ALLOWED_NON_CSRF_ENDPOINTS` - comma-separated Flask endpoint names exempt from CSRF check (closes #957)
- `LOG_LEVEL` - control log verbosity (default: INFO)
- `GUNICORN_TIMEOUT` - worker timeout in seconds (default: 120)
- `GUNICORN_WORKERS` - worker process count (default: 2)

### Issues already documented in README + .env.example (verified, also closing):
- #955 APP_PASSWORD ✓
- #956 VIRTUAL_JF_PORT ✓ 
- #958 NETWORK_RETRY_TOTAL ✓
- #959 NETWORK_RETRY_BACKOFF_FACTOR ✓
- #960 NETWORK_RETRY_STATUS_FORCELIST ✓
- #961 FLASK_PORT ✓ (also covered by recently merged PR #1001)
- #962 FLASK_DEBUG ✓ (also covered by PR #1001)
- #963 JELLYFIN_API_KEY ✓
- #964 ANILIST_API_URL ✓

### Testing
All existing tests pass. No functional changes.