### PR TITLE
docs,makefile: improve env docs, add test-fast target, fix dev anchor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # Copy this to .env and fill in your values.
 # Environment variables take precedence over values set in the UI config.
 # They are never persisted back to config.json.
+# See README.md for full documentation.
 
 # ── API Key Overrides ──────────────────────────────────────
 # Use these to set sensitive credentials without storing them in config.json
@@ -11,7 +12,7 @@
 # MAL_CLIENT_ID=your-myanimelist-client-id
 # ANILIST_API_URL=https://graphql.anilist.co
 
-# ── Virtual Jellyjin Server (Development) ─────────────────
+# ── Virtual Jellyfin Server (Development) ─────────────────
 # Override the default port for the mock Jellyfin server used during development
 # VIRTUAL_JF_PORT=8096
 
@@ -22,6 +23,11 @@
 # ── Server Settings ────────────────────────────────────────
 # FLASK_PORT=5000
 # FLASK_DEBUG=false
+
+# ── Scheduler Control ──────────────────────────────────────
+# Set to "0" to disable the background scheduler entirely (default: "1")
+# Useful when running multiple instances or during testing.
+# SCHEDULER_ENABLED=1
 
 # ── Logging ─────────────────────────────────────────────────
 # Control the application log level. Accepts: DEBUG, INFO, WARNING, ERROR, CRITICAL
@@ -48,4 +54,6 @@
 
 # ── CSRF Exemptions ────────────────────────────────────────
 # Comma-separated Flask endpoint names exempted from the X-Requested-With header check.
+# These are ``blueprint.view`` names (e.g. "main.webhook,main.callback"),
+# NOT URL paths like "/api/...". Default: none
 # ALLOWED_NON_CSRF_ENDPOINTS=main.webhook,main.callback

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,13 @@ test-all:
 test-cov:
 	python3 -m pytest $(PYTEST_ARGS) --cov=. --cov-report=term-missing
 
+test-fast:
+	python3 -m pytest -x $(PYTEST_ARGS) -m "not exhaustive and not e2e" \
+		--ignore=tests/test_deep_sync.py \
+		--ignore=tests/test_virtual_jellyfin_exhaustive.py \
+		--ignore=tests/test_e2e \
+		tests/test_config.py tests/test_cleanup.py tests/test_scheduler.py tests/test_network.py tests/test_sync.py
+
 test-to-file:
 	python3 run_tests_to_file.py
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,9 @@ To set a cover for a group, upload an image via the group editor UI.
 
 ## 💻 Development
 
-<a id="development"></a>
+> [!TIP]
+> Looking for a quick way to jump in? Run `make install-dev test run` after cloning
+> to install dependencies, verify the test suite, and start the development server.
 
 ### Environment Variables
 
@@ -312,6 +314,7 @@ The application reads the following environment variables (which take precedence
 | `FLASK_PORT` | Server port (default: `5000`) |
 | `FLASK_DEBUG` | Enable Flask debug mode (`true`/`false`) |
 | `LOG_LEVEL` | Log level for application output. Accepts `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` (default: `INFO`) |
+| `SCHEDULER_ENABLED` | Set to `0` to disable the background scheduler (default: `1`). Useful when running multiple instances or during testing |
 | `GUNICORN_TIMEOUT` | Gunicorn worker timeout in seconds for long-running API calls (default: `120`). Increase this if sync operations time out |
 | `GUNICORN_WORKERS` | Number of gunicorn worker processes for handling concurrent requests (default: `2`). Increase for multi-core hosts |
 | `ANILIST_API_URL` | AniList GraphQL endpoint (default: `https://graphql.anilist.co`) |
@@ -367,6 +370,7 @@ A `Makefile` is provided for common development tasks:
 | `install-dev` | Install with dev extras (`pip install -e ".[dev]"`) |
 | `test` | Run the test suite (skips slow integration tests) |
 | `test-all` | Run the full test suite including integration tests |
+| `test-fast` | Run only core unit tests (config, cleanup, scheduler, network, sync) — quickest smoke test |
 | `test-cov` | Run tests with a coverage report |
 | `test-to-file` | Run tests and write output to a file (`python run_tests_to_file.py`) |
 | `lint` | Run Ruff linter and format check (`ruff check .` + `ruff format --check .`) |


### PR DESCRIPTION
## Summary

Small improvements to documentation and developer experience:

- **Makefile**: Added `test-fast` target that runs only core unit tests (config, cleanup, scheduler, network, sync) — the quickest smoke test for rapid iteration
- **README.md**: Added missing `SCHEDULER_ENABLED` env variable to the environment table; removed redundant HTML anchor in favor of the markdown heading anchor
- **.env.example**: Added `SCHEDULER_ENABLED` entry, expanded CSRF exemption documentation

## Testing

All 690 non-exhaustive tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced environment variable documentation with new `SCHEDULER_ENABLED` setting for controlling the background scheduler
  * Added development quick-start guide with setup instructions

* **Chores**
  * Introduced `test-fast` make target for faster test execution during development

<!-- end of auto-generated comment: release notes by coderabbit.ai -->