### PR TITLE
fix: add test-fast to .PHONY, add SCHEDULER_ENABLED to Docker env docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev test test-all test-cov test-to-file lint format-check typecheck clean format run virtual-jellyfin docker-build docker-run
+.PHONY: install install-dev test test-all test-cov test-fast test-to-file lint format-check typecheck clean format run virtual-jellyfin docker-build docker-run
 
 # ── Installation ────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ services:
       - GUNICORN_TIMEOUT=120            # optional: gunicorn worker timeout in seconds (default: 120)
       - GUNICORN_WORKERS=2              # optional: gunicorn worker process count (default: 2)
       - FLASK_PORT=5000                 # optional: server port (default: 5000)
+      - SCHEDULER_ENABLED=1              # optional: set to 0 to disable background scheduler (default: 1)
       - FLASK_DEBUG=false               # optional: set to true for debug mode (default: false)
     restart: unless-stopped
 ```


### PR DESCRIPTION
## Summary\n\nFollow-up to PR #1035 — two small improvements caught during review:\n\n- **Makefile**: Add `test-fast` target to the `.PHONY` declaration so Make doesn't treat it as a file target (noticed by CodeRabbit in PR #1035 review)\n- **README.md**: Add `SCHEDULER_ENABLED` to the Docker environment variables example in the Docker section