### PR TITLE
fix: add SCHEDULER_ENABLED to docker-compose, add TEST_TIMEOUT env to test script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       # - NETWORK_RETRY_STATUS_FORCELIST=429,500,502,503,504
       # Comma-separated Flask endpoint names exempt from the X-Requested-With CSRF check:
       # - ALLOWED_NON_CSRF_ENDPOINTS=main.webhook,main.callback
+      # Uncomment to disable the background scheduler (default: 1):
+      # - SCHEDULER_ENABLED=1
       # Control log verbosity (DEBUG, INFO, WARNING, ERROR, CRITICAL; default: INFO):
       # - LOG_LEVEL=INFO
       # Gunicorn worker timeout in seconds for long-running sync (default: 120):

--- a/run_tests_to_file.py
+++ b/run_tests_to_file.py
@@ -16,30 +16,39 @@ def main() -> None:
     """Run pytest with coverage and stream output to ``test_results.txt``.
 
     The output file is created in the repository root directory.
+    The test timeout can be controlled via the ``TEST_TIMEOUT`` environment
+    variable (default: 300 seconds).
     """
     repo_root = Path(__file__).resolve().parent
     existing = os.environ.get("PYTHONPATH")
     os.environ["PYTHONPATH"] = (
         f"{existing}{os.pathsep}{repo_root}" if existing else str(repo_root)
     )
+
     output_file = repo_root / "test_results.txt"
-    with output_file.open("w", encoding="utf-8") as f:
-        try:
-            # Running all tests with coverage and short traceback for readability
+    timeout = int(os.environ.get("TEST_TIMEOUT", "300"))
+
+    try:
+        with output_file.open("w", encoding="utf-8") as f:
             f.write("Starting test run...\n")
             f.write(f"Python: {sys.version}\n")
-            f.write(f"CWD: {repo_root}\n\n")
+            f.write(f"CWD: {repo_root}\n")
+            f.write(f"Timeout: {timeout}s\n\n")
             f.flush()
+
             result = subprocess.run(
                 [sys.executable, "-m", "pytest", "--cov=.", "--tb=short", "tests/"],
                 stdout=f,
                 stderr=subprocess.STDOUT,
-                timeout=300,
+                timeout=timeout,
                 check=False,
             )
+
             f.write(f"\nExit code: {result.returncode}\n")
-        except (subprocess.TimeoutExpired, OSError) as e:
-            f.write(f"\nERROR: {e!s}")
+    except (subprocess.TimeoutExpired, OSError) as e:
+        msg = f"\nERROR: {e!s}"
+        with output_file.open("a", encoding="utf-8") as f:
+            f.write(msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to PR #1036 — two small improvements:

- **docker-compose.yml**: Add `SCHEDULER_ENABLED` to the commented environment variables section (now documented in README)
- **run_tests_to_file.py**: Make test timeout configurable via `TEST_TIMEOUT` environment variable (default: 300s), improve error handling when the output file cannot be opened