### PR TITLE
docs: update stale test count in README, improve _validate_group_entry docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ make run
 ### 🧪 Testing
 
 ```bash
-# Run the full test suite (1354 tests, 100% coverage)
+# Run the full test suite (749 tests, 100% coverage)
 python3 -m pytest
 
 # Run tests with coverage report

--- a/scheduler.py
+++ b/scheduler.py
@@ -73,7 +73,15 @@ def _schedule_global_sync(
 
 
 def _validate_group_entry(group: Any) -> str | None:
-    """Validate a group dict and return its name, or None if invalid."""
+    """Validate a group dict and return its stripped name, or None if invalid.
+
+    Checks performed:
+    - Entry must be a dict
+    - Must have a ``name`` key with a string value
+    - Name must not be empty or whitespace-only after stripping
+
+    Returns the stripped name on success, ``None`` on failure (with a warning logged).
+    """
     if not isinstance(group, dict):
         logger.warning(
             "Skipping invalid group entry (expected dict, got %s): %s",


### PR DESCRIPTION
## Summary

Two small documentation improvements:

1. **README.md**: The test count reference was stale (1354 → actual 749). Updated to reflect the current test suite size.

2. **scheduler.py**: Expanded the `_validate_group_entry()` docstring to document the whitespace stripping behavior and all validation checks performed.

## Testing

All 749 tests pass.