### PR TITLE
docs(changelog): add PR #1039 entry (test count and docstring)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `README.md`: update test count from 642+ to exact 749 and improve
+  `_validate_group_entry` docstring. (PR #1039)
+
 ### Added
 
 - `routes.py`: add health check endpoint at `/api/health` for Docker/Kubernetes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- `README.md`: update test count from 642+ to exact 749 and improve
-  `_validate_group_entry` docstring. (PR #1039)
-
 ### Added
 
 - `routes.py`: add health check endpoint at `/api/health` for Docker/Kubernetes
@@ -57,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `README.md`: update test count from 642+ to exact 749 and improve
+  `_validate_group_entry` docstring. (PR #1039)
 - `config.py`: localize `Path(CONFIG_DIR)` / `Path(CONFIG_FILE)` to module-
   level variables for cleaner coverage tracking. (PR #568)
 - `routes.py`: cache `dir_depth = len(Path(dirpath).parts)` in


### PR DESCRIPTION
Adds changelog entry for the recently merged PR #1039 which updated the test count in README from 642+ to exact 749 and improved the _validate_group_entry docstring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test coverage metrics in the README (now at 749 tests).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->