### PR TITLE
docs(api): document scheduler, jellyfin reachability, and env_overrides in health check response

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,25 @@ single commit use ``git commit --no-verify`` (not recommended).
 
 ### Type Hints
 
-All Python code should use type hints. The project targets Python 3.11+.
+All Python code should use type hints. The project targets Python 3.11+ and passes mypy in strict mode for all 14 source files.
+
+### External List Source Types
+
+The project supports multiple external list sources, each with its own fetcher module:
+
+- **IMDb** (`imdb.py`) — HTML scraping of public list pages
+- **Trakt** (`trakt.py`) — Trakt v2 API
+- **TMDb** (`tmdb.py`) — TMDb v3 API (lists + content-based recommendations)
+- **Letterboxd** (`letterboxd.py`) — HTML scraping with parallel film-page resolution for IDs
+- **AniList** (`anilist.py`) — AniList GraphQL API
+- **MyAnimeList** (`mal.py`) — MyAnimeList v2 REST API
+
+When adding a new external source, follow the existing pattern:
+1. Create a new fetcher module with a `fetch_*_list(list_id, ...)` function that returns IDs as strings.
+2. Add a ``_fetch_items_for_*_group`` function in `sync.py` that calls the fetcher and matches IDs against the Jellyfin library.
+3. Register the source type in `_LIST_SOURCE_TYPES` and `_dispatch_list_source`.
+4. Add validation for the new source type in `routes.py`'s `_validate_config_types`.
+5. Update API docs and the README environment variable table.
 
 ### Running Tests and Coverage
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,8 +28,13 @@ Health check for load balancers and orchestrators.
 | `healthcheck.ok` | boolean | Service health |
 | `healthcheck.configured` | boolean | Jellyfin URL, API key, and target path present |
 | `healthcheck.groups` | number | Count of configured groupings |
+| `healthcheck.env_overrides` | array&lt;string&gt; | Active runtime config overrides from environment variables |
 | `server.uptime_seconds` | number | Process uptime |
 | `server.started_at` | string | ISO 8601 UTC start time |
+| `scheduler.running` | boolean | Whether the background scheduler is running |
+| `scheduler.job_count` | number | Number of registered scheduler jobs |
+| `scheduler.next_run_times` | array&lt;object&gt; | List of scheduled jobs with their next run time; each object has `id`, `name`, and optionally `next_run` |
+| `jellyfin.reachable` | boolean or null | Whether the Jellyfin server responded to a lightweight ping; `null` if no server URL is set |
 
 ---
 


### PR DESCRIPTION
Updates the /api/health response documentation to include:

- `healthcheck.env_overrides` — active runtime env var overrides
- `scheduler.running`, `scheduler.job_count`, `scheduler.next_run_times` — scheduler status
- `jellyfin.reachable` — Jellyfin server reachability ping result

These fields are already returned by the endpoint but were missing from the API docs.