### PR TITLE
docs(api): remove stale /test route from non-API routes table

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -300,5 +300,4 @@ Return contents of test output log files (development test dashboard).
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/` | Main SPA |
-| `GET` | `/test` | Test dashboard |
 | `GET` | `/static/*` | Static assets |


### PR DESCRIPTION
The `GET /test` route (Test dashboard) was removed along with the stale test.html artifact, but the API documentation still listed it in the non-API routes table. This PR removes the stale entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to reflect currently supported routes, removing references to deprecated test endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->