### PR TITLE
chore: add Makefile targets for frontend tests and E2E workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,15 @@ test-fast:
 test-to-file:
 	python3 run_tests_to_file.py
 
+test-frontend:
+	npm test
+
+test-frontend-cov:
+	npm run test:coverage
+
+install-frontend:
+	npm install
+
 # ── Linting & Type Checking ─────────────────────────────────────────────────
 
 lint:
@@ -63,6 +72,17 @@ run:
 
 virtual-jellyfin:
 	python3 start_virtual_jellyfin.py
+
+# ── E2E Tests ────────────────────────────────────────────────────────────────
+
+e2e-up:
+	docker compose -f e2e/docker-compose.e2e.yml up -d
+
+e2e-run:
+	python3 -m pytest tests/test_e2e/ -v
+
+e2e-down:
+	docker compose -f e2e/docker-compose.e2e.yml down -v
 
 # ── Docker ──────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ A `Makefile` is provided for common development tasks:
 | `clean` | Remove `__pycache__`, `.pytest_cache`, and build artifacts |
 | `run` | Start the Flask development server (`python app.py`) |
 | `virtual-jellyfin` | Start the mock Jellyfin server for testing |
+| `test-frontend` | Run frontend Vitest tests (`npm test`) |
+| `test-frontend-cov` | Run frontend tests with coverage (`npm run test:coverage`) |
+| `install-frontend` | Install frontend dependencies (`npm install`) |
+| `e2e-up` | Start E2E services (Jellyfin + app) |
+| `e2e-run` | Run E2E test suite |
+| `e2e-down` | Stop and clean up E2E services |
 | `docker-build` | Build the Docker image |
 | `docker-run` | Run the Docker container |
 


### PR DESCRIPTION
## Summary

Adds convenient Makefile targets for frontend testing and E2E test orchestration, with updated README documentation.

### Changes
- **Makefile**: Added `test-frontend`, `test-frontend-cov`, `install-frontend`, `e2e-up`, `e2e-run`, `e2e-down` targets
- **README.md**: Updated Makefile reference table with new targets

### Testing
These are purely additive Makefile convenience targets — no functional code changes.