### PR TITLE
fix: resolve ruff formatting and stabilize cache eviction test for Python 3.13

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,8 +101,7 @@ if (
         start_scheduler()
     except Exception:
         logger.exception(
-            "Failed to start background scheduler — "
-            "scheduled syncs will not run.",
+            "Failed to start background scheduler — scheduled syncs will not run.",
         )
 
 

--- a/tests/test_sync_uncovered.py
+++ b/tests/test_sync_uncovered.py
@@ -1,5 +1,6 @@
 """Additional tests covering uncovered lines in sync.py (PermissionError, OSError, etc.)."""
 
+import time
 from typing import Any
 from unittest.mock import patch
 
@@ -666,8 +667,8 @@ def test_fetch_full_library_stale_cache_eviction() -> None:
     from sync import _LIBRARY_CACHE, _fetch_full_library
 
     cache_key = ("http://jf:8096", "testkey")
-    # Insert an expired cache entry (timestamp far in the past)
-    _LIBRARY_CACHE[cache_key] = (0.0, [{"Id": "stale-item"}])
+    # Insert an expired cache entry (timestamp well in the past)
+    _LIBRARY_CACHE[cache_key] = (time.monotonic() - 3600, [{"Id": "stale-item"}])
 
     # The fetch will see the stale entry, evict it, then try to re-fetch.
     # We mock fetch_all_jellyfin_items to return fresh data.


### PR DESCRIPTION
## Summary

Two small fixes that address pre-existing CI failures on the main branch:

### Changes

1. **app.py**: Fix ruff formatting issue — merged a split string in a `logger.exception` call that ruff was flagging as needing reformatting.

2. **tests/test_sync_uncovered.py**: Fix `test_fetch_full_library_stale_cache_eviction` to use `time.monotonic() - 3600` instead of a hardcoded `0.0` timestamp. On Python 3.13, the test was failing because the stale entry wasn't always evicted. Using a relative timestamp ensures the entry is always stale regardless of system uptime or Python version.

### CI Impact

These fixes address two of the three pre-existing CI failures on main:
- ✅ `lint` job (ruff format check) — now passes
- ✅ `test (3.13)` job — the cache eviction test now passes on Python 3.13

The `e2e` failure is a separate infrastructure issue (Docker compose setup) unrelated to these changes.