### PR TITLE
Improve error handling in routes.py

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -717,6 +717,8 @@ def test_server() -> ResponseReturnValue:
         return _error(f"Server returned status {response.status_code}", 400)
     except requests.exceptions.RequestException as exc:
         return _error(f"Connection error: {exc!s}", 400)
+    except (ValueError, TypeError):
+        return _error("Invalid server URL or API key format", 400)
 
 
 # ---------------------------------------------------------------------------
@@ -762,6 +764,21 @@ def _fetch_jellyfin_endpoint(
             items.extend(page)
     except RuntimeError:
         if items:
+            logger.debug(
+                "Partial fetch for %s — returning %s items after error",
+                endpoint,
+                len(items),
+            )
+            return items
+        logger.exception("Failed to fetch any items from %s", endpoint)
+        raise
+    except requests.RequestException:
+        if items:
+            logger.debug(
+                "Partial fetch for %s — returning %s items after request error",
+                endpoint,
+                len(items),
+            )
             return items
         raise
     return items

--- a/routes.py
+++ b/routes.py
@@ -715,10 +715,10 @@ def test_server() -> ResponseReturnValue:
         if response.status_code == 200:
             return _success("Connected to Jellyfin successfully!")
         return _error(f"Server returned status {response.status_code}", 400)
-    except requests.exceptions.RequestException as exc:
-        return _error(f"Connection error: {exc!s}", 400)
     except (ValueError, TypeError):
         return _error("Invalid server URL or API key format", 400)
+    except requests.exceptions.RequestException as exc:
+        return _error(f"Connection error: {exc!s}", 400)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/frontend/sidebar-resizer.test.js
+++ b/tests/frontend/sidebar-resizer.test.js
@@ -111,17 +111,14 @@ describe('sidebar-resizer module', () => {
     mod.initSidebarResizer();
 
     const resizer = document.getElementById('sidebar-resizer');
-    // jsdom does not support Touch constructor, so we use a custom event
-    const touchStart = new TouchEvent('touchstart', {
-      touches: [{ clientX: 300, target: resizer }],
-      cancelable: true,
-    });
+    // jsdom does not support TouchEvent constructor reliably, so we use
+    // standard Event + Object.assign to attach the touches property
+    const touchStart = new Event('touchstart', { bubbles: true, cancelable: true });
+    Object.assign(touchStart, { touches: [{ clientX: 300, target: resizer }] });
     resizer.dispatchEvent(touchStart);
 
-    const touchMove = new TouchEvent('touchmove', {
-      touches: [{ clientX: 600, target: document.body }],
-      cancelable: true,
-    });
+    const touchMove = new Event('touchmove', { bubbles: true, cancelable: true });
+    Object.assign(touchMove, { touches: [{ clientX: 600, target: document.body }] });
     document.dispatchEvent(touchMove);
 
     const width = getComputedStyle(document.documentElement)
@@ -129,7 +126,8 @@ describe('sidebar-resizer module', () => {
       .trim();
     expect(width).toBe('600px');
 
-    document.dispatchEvent(new TouchEvent('touchend'));
+    const touchEnd = new Event('touchend', { bubbles: true, cancelable: true });
+    document.dispatchEvent(touchEnd);
   });
 
   it('should add active class to resizer on mousedown', async () => {

--- a/tests/frontend/sidebar-resizer.test.js
+++ b/tests/frontend/sidebar-resizer.test.js
@@ -1,0 +1,147 @@
+/**
+ * @file Tests for the sidebar-resizer feature module.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Set up the DOM elements that sidebar-resizer.js references.
+ */
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="sidebar-resizer"></div>
+    <div id="sidebar"></div>
+  `;
+  // Set initial CSS custom property
+  document.documentElement.style.setProperty('--sidebar-width', '300px');
+  // Clear any saved width from previous tests
+  localStorage.removeItem('sidebarWidth');
+}
+
+describe('sidebar-resizer module', () => {
+  beforeEach(() => {
+    setupDOM();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('should export initSidebarResizer as a function', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    expect(typeof mod.initSidebarResizer).toBe('function');
+  });
+
+  it('should restore saved sidebar width from localStorage', async () => {
+    localStorage.setItem('sidebarWidth', '400');
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+    const width = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sidebar-width')
+      .trim();
+    expect(width).toBe('400px');
+  });
+
+  it('should keep default width when no saved width exists', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+    const width = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sidebar-width')
+      .trim();
+    expect(width).toBe('300px');
+  });
+
+  it('should not throw when resizer element is missing', async () => {
+    document.body.innerHTML = '';
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    expect(() => mod.initSidebarResizer()).not.toThrow();
+  });
+
+  it('should clamp sidebar width to minimum 200px', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+
+    // Simulate mousedown on resizer
+    const resizer = document.getElementById('sidebar-resizer');
+    resizer.dispatchEvent(new MouseEvent('mousedown', { clientX: 150 }));
+
+    // Simulate mousemove at 150px (below minimum)
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 150 }));
+
+    const width = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sidebar-width')
+      .trim();
+    expect(width).toBe('200px');
+
+    // Clean up: simulate mouseup
+    document.dispatchEvent(new MouseEvent('mouseup'));
+  });
+
+  it('should clamp sidebar width to maximum 800px', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+
+    const resizer = document.getElementById('sidebar-resizer');
+    resizer.dispatchEvent(new MouseEvent('mousedown', { clientX: 900 }));
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 900 }));
+
+    const width = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sidebar-width')
+      .trim();
+    expect(width).toBe('800px');
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+  });
+
+  it('should persist width to localStorage on mouseup', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+
+    const resizer = document.getElementById('sidebar-resizer');
+    resizer.dispatchEvent(new MouseEvent('mousedown', { clientX: 300 }));
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 500 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(localStorage.getItem('sidebarWidth')).toBe('500');
+  });
+
+  it('should handle touch events for resize', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+
+    const resizer = document.getElementById('sidebar-resizer');
+    // jsdom does not support Touch constructor, so we use a custom event
+    const touchStart = new TouchEvent('touchstart', {
+      touches: [{ clientX: 300, target: resizer }],
+      cancelable: true,
+    });
+    resizer.dispatchEvent(touchStart);
+
+    const touchMove = new TouchEvent('touchmove', {
+      touches: [{ clientX: 600, target: document.body }],
+      cancelable: true,
+    });
+    document.dispatchEvent(touchMove);
+
+    const width = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sidebar-width')
+      .trim();
+    expect(width).toBe('600px');
+
+    document.dispatchEvent(new TouchEvent('touchend'));
+  });
+
+  it('should add active class to resizer on mousedown', async () => {
+    const mod = await import('../../static/js/features/sidebar-resizer.js');
+    mod.initSidebarResizer();
+
+    const resizer = document.getElementById('sidebar-resizer');
+    resizer.dispatchEvent(new MouseEvent('mousedown', { clientX: 300 }));
+
+    expect(resizer.classList.contains('active')).toBe(true);
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    expect(resizer.classList.contains('active')).toBe(false);
+  });
+});

--- a/tests/frontend/test-connection.test.js
+++ b/tests/frontend/test-connection.test.js
@@ -19,10 +19,10 @@ function setupDOM() {
     <div id="maintenance-card"></div>
     <div id="groupings-section"></div>
     <div id="scheduler-card"></div>
-    <div id="target_path"></div>
-    <div id="media_path_in_jellyfin"></div>
-    <div id="media_path_on_host"></div>
-    <div id="target_path_in_jellyfin"></div>
+    <input id="target_path" />
+    <input id="media_path_in_jellyfin" />
+    <input id="media_path_on_host" />
+    <input id="target_path_in_jellyfin" />
     <div id="target_path_group">
       <button>Browse</button>
     </div>
@@ -35,9 +35,9 @@ function setupDOM() {
     <div id="target_path_in_jellyfin_group">
       <button>Browse</button>
     </div>
-    <div id="jellyfin_url"></div>
-    <div id="api_key"></div>
-    <div id="test-btn"></div>
+    <input id="jellyfin_url" />
+    <input id="api_key" />
+    <button id="test-btn"></button>
     <div id="status-msg"></div>
     <div id="error-dialog-modal" class="modal">
       <div id="error-dialog-message"></div>
@@ -145,5 +145,16 @@ describe('test-connection module', () => {
     const result = await mod.testConnection('http://test', 'key');
     expect(result.success).toBe(false);
     expect(result.message).toBe('API unreachable');
+  });
+
+  it('testConnection should use fallback message when API error has no message', async () => {
+    vi.doMock('../../static/js/core/api.js', () => ({
+      testServer: vi.fn().mockResolvedValue({ status: 'error' }),
+    }));
+
+    const mod = await import('../../static/js/features/test-connection.js');
+    const result = await mod.testConnection('http://test', 'bad-key');
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Connection failed');
   });
 });

--- a/tests/frontend/test-connection.test.js
+++ b/tests/frontend/test-connection.test.js
@@ -1,0 +1,149 @@
+/**
+ * @file Tests for the test-connection feature module.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock the metadata module to avoid deep DOM dependencies
+vi.mock('../../static/js/features/metadata.js', () => ({
+  updateSourceTypeOptions: vi.fn(),
+  refreshMetadata: vi.fn(),
+}));
+
+/**
+ * Set up the DOM elements that test-connection.js references.
+ */
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="status-dot"></div>
+    <div id="status-text"></div>
+    <div id="maintenance-card"></div>
+    <div id="groupings-section"></div>
+    <div id="scheduler-card"></div>
+    <div id="target_path"></div>
+    <div id="media_path_in_jellyfin"></div>
+    <div id="media_path_on_host"></div>
+    <div id="target_path_in_jellyfin"></div>
+    <div id="target_path_group">
+      <button>Browse</button>
+    </div>
+    <div id="media_path_in_jellyfin_group">
+      <button>Browse</button>
+    </div>
+    <div id="media_path_on_host_group">
+      <button>Browse</button>
+    </div>
+    <div id="target_path_in_jellyfin_group">
+      <button>Browse</button>
+    </div>
+    <div id="jellyfin_url"></div>
+    <div id="api_key"></div>
+    <div id="test-btn"></div>
+    <div id="status-msg"></div>
+    <div id="error-dialog-modal" class="modal">
+      <div id="error-dialog-message"></div>
+      <button class="close-modal-btn">X</button>
+    </div>
+    <div id="loading-overlay">
+      <div id="loading-overlay-title"></div>
+      <div id="loading-overlay-status"></div>
+      <div id="progress-bar-fill"></div>
+      <div id="progress-percentage"></div>
+      <div id="progress-eta" style="display:none"></div>
+    </div>
+    <select id="source_category"><option value="jellyfin">Jellyfin</option></select>
+    <select id="source_type"></select>
+  `;
+}
+
+describe('test-connection module', () => {
+  beforeEach(() => {
+    setupDOM();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('should export updateValidationUI and testConnection', async () => {
+    const mod = await import('../../static/js/features/test-connection.js');
+    expect(typeof mod.updateValidationUI).toBe('function');
+    expect(typeof mod.testConnection).toBe('function');
+    expect(typeof mod.testConnectionFromSidebar).toBe('function');
+  });
+
+  it('updateValidationUI(true) should set connected state', async () => {
+    const mod = await import('../../static/js/features/test-connection.js');
+    mod.updateValidationUI(true);
+
+    const statusDot = document.getElementById('status-dot');
+    const statusText = document.getElementById('status-text');
+    const maintenanceCard = document.getElementById('maintenance-card');
+
+    expect(statusDot.className).toBe('connection-dot online');
+    expect(statusText.textContent).toBe('Connected');
+    expect(maintenanceCard.classList.contains('locked-section')).toBe(false);
+  });
+
+  it('updateValidationUI(false) should set disconnected state', async () => {
+    const mod = await import('../../static/js/features/test-connection.js');
+    mod.updateValidationUI(false);
+
+    const statusDot = document.getElementById('status-dot');
+    const statusText = document.getElementById('status-text');
+    const maintenanceCard = document.getElementById('maintenance-card');
+
+    expect(statusDot.className).toBe('connection-dot offline');
+    expect(statusText.textContent).toBe('Disconnected');
+    expect(maintenanceCard.classList.contains('locked-section')).toBe(true);
+  });
+
+  it('updateValidationUI should disable path fields when disconnected', async () => {
+    const mod = await import('../../static/js/features/test-connection.js');
+    mod.updateValidationUI(false);
+
+    const targetPath = document.getElementById('target_path');
+    expect(targetPath.disabled).toBe(true);
+  });
+
+  it('updateValidationUI should enable path fields when connected', async () => {
+    const mod = await import('../../static/js/features/test-connection.js');
+    mod.updateValidationUI(true);
+
+    const targetPath = document.getElementById('target_path');
+    expect(targetPath.disabled).toBe(false);
+  });
+
+  it('testConnection should return success when API returns success', async () => {
+    // Mock the testServer import
+    vi.doMock('../../static/js/core/api.js', () => ({
+      testServer: vi.fn().mockResolvedValue({ status: 'success', message: 'Connected!' }),
+    }));
+
+    const mod = await import('../../static/js/features/test-connection.js');
+    const result = await mod.testConnection('http://test', 'key');
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Connected!');
+  });
+
+  it('testConnection should return failure when API returns error', async () => {
+    vi.doMock('../../static/js/core/api.js', () => ({
+      testServer: vi.fn().mockResolvedValue({ status: 'error', message: 'Bad key' }),
+    }));
+
+    const mod = await import('../../static/js/features/test-connection.js');
+    const result = await mod.testConnection('http://test', 'bad-key');
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Bad key');
+  });
+
+  it('testConnection should handle API exceptions gracefully', async () => {
+    vi.doMock('../../static/js/core/api.js', () => ({
+      testServer: vi.fn().mockRejectedValue(new Error('Network error')),
+    }));
+
+    const mod = await import('../../static/js/features/test-connection.js');
+    const result = await mod.testConnection('http://test', 'key');
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('API unreachable');
+  });
+});

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2109,6 +2109,74 @@ def test_get_cleanup_permission_denied(mock_iterdir, client, tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# test_server: ValueError / TypeError handling (lines 720-721)
+# ---------------------------------------------------------------------------
+
+
+@patch("routes.network.get")
+def test_test_server_value_error(mock_get, client) -> None:
+    """ValueError from network.get is caught and returns 400."""
+    mock_get.side_effect = ValueError("malformed URL")
+    response = client.post(
+        "/api/test-server",
+        json={"jellyfin_url": "not-a-url", "api_key": "key"},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "Invalid server URL" in data["message"]
+
+
+@patch("routes.network.get")
+def test_test_server_type_error(mock_get, client) -> None:
+    """TypeError from network.get is caught and returns 400."""
+    mock_get.side_effect = TypeError("unsupported operand type")
+    response = client.post(
+        "/api/test-server",
+        json={"jellyfin_url": "http://test", "api_key": "valid-key"},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "Invalid server URL" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# _fetch_jellyfin_endpoint: requests.RequestException with partial data
+# (lines 775-783)
+# ---------------------------------------------------------------------------
+
+
+@patch("jellyfin.network.get")
+@pytest.mark.usefixtures("temp_config")
+def test_fetch_jellyfin_endpoint_request_exception_partial(mock_get, client) -> None:
+    """requests.RequestException after partial data returns partial results."""
+    resp1 = MagicMock()
+    resp1.status_code = 200
+    resp1.json.return_value = {
+        "Items": [{"Name": f"G{i}"} for i in range(200)],
+        "TotalRecordCount": 201,
+    }
+    resp1.raise_for_status = MagicMock()
+
+    # Second call raises a raw requests.RequestException (bypasses _get_json's
+    # conversion to RuntimeError, hitting the safety net in _fetch_jellyfin_endpoint)
+    resp2 = MagicMock()
+    resp2.raise_for_status.side_effect = requests.exceptions.ConnectionError("fail")
+
+    mock_get.side_effect = [resp1, resp2]
+    result = _fetch_jellyfin_endpoint("http://jf", "key", "Genres")
+    assert len(result) == 200
+
+
+@patch("jellyfin.network.get")
+@pytest.mark.usefixtures("temp_config")
+def test_fetch_jellyfin_endpoint_request_exception_no_data(mock_get, client) -> None:
+    """requests.RequestException with no data re-raises."""
+    mock_get.side_effect = requests.exceptions.ConnectionError("fail")
+    with pytest.raises(RuntimeError):
+        _fetch_jellyfin_endpoint("http://jf", "key", "Genres")
+
+
+# ---------------------------------------------------------------------------
 # Index: rendered wizard state present in HTML (Issue #797)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2145,34 +2145,36 @@ def test_test_server_type_error(mock_get, client) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("jellyfin.network.get")
+@patch("jellyfin._get_json")
 @pytest.mark.usefixtures("temp_config")
-def test_fetch_jellyfin_endpoint_request_exception_partial(mock_get, client) -> None:
-    """requests.RequestException after partial data returns partial results."""
-    resp1 = MagicMock()
-    resp1.status_code = 200
-    resp1.json.return_value = {
-        "Items": [{"Name": f"G{i}"} for i in range(200)],
-        "TotalRecordCount": 201,
-    }
-    resp1.raise_for_status = MagicMock()
+def test_fetch_jellyfin_endpoint_request_exception_partial(mock_get_json, client) -> None:
+    """requests.RequestException after partial data returns partial results.
 
-    # Second call raises a raw requests.RequestException (bypasses _get_json's
-    # conversion to RuntimeError, hitting the safety net in _fetch_jellyfin_endpoint)
-    resp2 = MagicMock()
-    resp2.raise_for_status.side_effect = requests.exceptions.ConnectionError("fail")
+    Patches jellyfin._get_json so that the raw requests.RequestException
+    flows through _paginate_jellyfin into _fetch_jellyfin_endpoint's
+    except requests.RequestException handler (bypassing _get_json's
+    conversion to RuntimeError).
+    """
+    from routes import _fetch_jellyfin_endpoint
 
-    mock_get.side_effect = [resp1, resp2]
+    # First call returns a page of items
+    mock_get_json.side_effect = [
+        {"Items": [{"Name": f"G{i}"} for i in range(200)], "TotalRecordCount": 201},
+        # Second call raises a raw requests.RequestException
+        requests.exceptions.ConnectionError("fail"),
+    ]
     result = _fetch_jellyfin_endpoint("http://jf", "key", "Genres")
     assert len(result) == 200
 
 
-@patch("jellyfin.network.get")
+@patch("jellyfin._get_json")
 @pytest.mark.usefixtures("temp_config")
-def test_fetch_jellyfin_endpoint_request_exception_no_data(mock_get, client) -> None:
+def test_fetch_jellyfin_endpoint_request_exception_no_data(mock_get_json, client) -> None:
     """requests.RequestException with no data re-raises."""
-    mock_get.side_effect = requests.exceptions.ConnectionError("fail")
-    with pytest.raises(RuntimeError):
+    from routes import _fetch_jellyfin_endpoint
+
+    mock_get_json.side_effect = requests.exceptions.ConnectionError("fail")
+    with pytest.raises(requests.exceptions.ConnectionError):
         _fetch_jellyfin_endpoint("http://jf", "key", "Genres")
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2147,7 +2147,9 @@ def test_test_server_type_error(mock_get, client) -> None:
 
 @patch("jellyfin._get_json")
 @pytest.mark.usefixtures("temp_config")
-def test_fetch_jellyfin_endpoint_request_exception_partial(mock_get_json, client) -> None:
+def test_fetch_jellyfin_endpoint_request_exception_partial(
+    mock_get_json, client
+) -> None:
     """requests.RequestException after partial data returns partial results.
 
     Patches jellyfin._get_json so that the raw requests.RequestException
@@ -2169,7 +2171,9 @@ def test_fetch_jellyfin_endpoint_request_exception_partial(mock_get_json, client
 
 @patch("jellyfin._get_json")
 @pytest.mark.usefixtures("temp_config")
-def test_fetch_jellyfin_endpoint_request_exception_no_data(mock_get_json, client) -> None:
+def test_fetch_jellyfin_endpoint_request_exception_no_data(
+    mock_get_json, client
+) -> None:
     """requests.RequestException with no data re-raises."""
     from routes import _fetch_jellyfin_endpoint
 


### PR DESCRIPTION
## Changes

### 
- **Logging**: Added  calls when partial data is returned after a RuntimeError or requests.RequestException, making mid-fetch failures observable in logs.
- **Broader catch**: Added  alongside the existing , so transient HTTP failures (connection reset, DNS failure, etc.) are also handled gracefully with partial-data return when available.

### 
- Added  handler so malformed URL/API key input produces a clear JSON error message instead of propagating an unhandled exception.

## Testing
All 749+ tests pass with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved `/api/test-server` validation by treating `ValueError` and `TypeError` as request formatting errors, returning a clear HTTP 400 response for invalid server URL/API key.
* Enhanced Jellyfin metadata pagination error handling to retain already-fetched items on partial failures and improve debug logging for easier troubleshooting.

## Tests
* Added/expanded frontend test coverage for sidebar resizing and connection validation UI behavior.
* Added backend unit tests for `/api/test-server` error responses and Jellyfin partial-fetch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->