### PR TITLE
chore: fix trailing commas and type annotations (ruff auto-fix)

### DIFF
--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -530,7 +530,7 @@ def test_collect_tmdb_ids_dedup() -> None:
             {"id": 456},
             {"id": 123},  # duplicate
             {"id": 789},
-        ]
+        ],
     }
     ids: list[str] = []
     seen: set[str] = set()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,6 +8,7 @@ CSRF protection, and error handling — all with mocked dependencies.
 import os
 from datetime import UTC
 from pathlib import Path
+from typing import Never
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -559,7 +560,7 @@ def test_upload_cover_mime_extension_mapping(client, tmp_path) -> None:
     assert response.status_code == 200
     # Verify the file was saved with .png extension
     cover_path = _get_cover_path(
-        "TestGroup", str(tmp_path), check_exists=False, ext="png"
+        "TestGroup", str(tmp_path), check_exists=False, ext="png",
     )
     assert cover_path is not None
     assert Path(cover_path).exists()
@@ -631,17 +632,17 @@ def test_health_check_scheduler_job_exception_skipped(client) -> None:
     # A job whose .next_run_time.isoformat() raises
     class BadJob:
         @property
-        def id(self):
+        def id(self) -> str:
             return "bad_job"
 
         @property
-        def name(self):
+        def name(self) -> str:
             return "bad"
 
         @property
         def next_run_time(self):
             class BadTime:
-                def isoformat(self):
+                def isoformat(self) -> Never:
                     msg = "isoformat error"
                     raise RuntimeError(msg)
 
@@ -1160,7 +1161,7 @@ def test_preview_grouping_trakt_list(mock_preview, client) -> None:
             "jellyfin_url": "http://t",
             "api_key": "k",
             "trakt_client_id": "test_client_id",
-        }
+        },
     )
     response = client.post(
         "/api/grouping/preview",
@@ -1187,7 +1188,7 @@ def test_preview_grouping_tmdb_list(mock_preview, client) -> None:
             "jellyfin_url": "http://t",
             "api_key": "k",
             "tmdb_api_key": "test_key",
-        }
+        },
     )
     response = client.post(
         "/api/grouping/preview",
@@ -1228,7 +1229,7 @@ def test_preview_grouping_mal_list(mock_preview, client) -> None:
             "jellyfin_url": "http://t",
             "api_key": "k",
             "mal_client_id": "test_client",
-        }
+        },
     )
     response = client.post(
         "/api/grouping/preview",
@@ -1273,7 +1274,7 @@ def test_preview_grouping_recommendations(mock_preview, client) -> None:
             "jellyfin_url": "http://t",
             "api_key": "k",
             "tmdb_api_key": "test_key",
-        }
+        },
     )
     response = client.post(
         "/api/grouping/preview",
@@ -1926,7 +1927,7 @@ def test_delete_folder_resolve_oserror(monkeypatch, tmp_path) -> None:
 
     perm_denied = "Permission denied"
 
-    def _broken_resolve(self):
+    def _broken_resolve(self) -> Never:
         raise OSError(perm_denied)
 
     monkeypatch.setattr(Path, "resolve", _broken_resolve)
@@ -2148,7 +2149,7 @@ def test_test_server_type_error(mock_get, client) -> None:
 @patch("jellyfin._get_json")
 @pytest.mark.usefixtures("temp_config")
 def test_fetch_jellyfin_endpoint_request_exception_partial(
-    mock_get_json, client
+    mock_get_json, client,
 ) -> None:
     """requests.RequestException after partial data returns partial results.
 
@@ -2172,7 +2173,7 @@ def test_fetch_jellyfin_endpoint_request_exception_partial(
 @patch("jellyfin._get_json")
 @pytest.mark.usefixtures("temp_config")
 def test_fetch_jellyfin_endpoint_request_exception_no_data(
-    mock_get_json, client
+    mock_get_json, client,
 ) -> None:
     """requests.RequestException with no data re-raises."""
     from routes import _fetch_jellyfin_endpoint

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -358,7 +358,7 @@ def test_preview_group_tmdb_list(mock_tmdb) -> None:
     with patch("sync.fetch_jellyfin_items") as mock_jf:
         mock_jf.return_value = [{"Name": "M1", "ProviderIds": {"Tmdb": "12345"}}]
         items, err, code = preview_group(
-            "tmdb_list", "12345", "http://jf", "key", tmdb_api_key="test_key"
+            "tmdb_list", "12345", "http://jf", "key", tmdb_api_key="test_key",
         )
     assert code == 200
     assert err is None
@@ -384,7 +384,7 @@ def test_preview_group_mal_list(mock_mal) -> None:
     with patch("sync.fetch_jellyfin_items") as mock_jf:
         mock_jf.return_value = [{"Name": "A1", "ProviderIds": {"Mal": "12345"}}]
         items, err, code = preview_group(
-            "mal_list", "12345", "http://jf", "key", mal_client_id="test_client"
+            "mal_list", "12345", "http://jf", "key", mal_client_id="test_client",
         )
     assert code == 200
     assert err is None
@@ -397,7 +397,7 @@ def test_preview_group_letterboxd_list(mock_lb) -> None:
     mock_lb.return_value = ["tt1234567"]
     with patch("sync.fetch_jellyfin_items") as mock_jf:
         mock_jf.return_value = [
-            {"Name": "M1", "Id": "item1", "ProviderIds": {"Imdb": "tt1234567"}}
+            {"Name": "M1", "Id": "item1", "ProviderIds": {"Imdb": "tt1234567"}},
         ]
         items, err, code = preview_group(
             "letterboxd_list",
@@ -420,7 +420,7 @@ def test_preview_group_recommendations(mock_rec, mock_recent) -> None:
     with patch("sync.fetch_jellyfin_items") as mock_jf:
         mock_jf.return_value = [{"Name": "M1", "ProviderIds": {"Tmdb": "12345"}}]
         items, err, code = preview_group(
-            "recommendations", "user123", "http://jf", "key", tmdb_api_key="test_key"
+            "recommendations", "user123", "http://jf", "key", tmdb_api_key="test_key",
         )
     assert code == 200
     assert err is None
@@ -2515,7 +2515,7 @@ def test_parse_complex_query_impossible_year_and() -> None:
 def test_parse_complex_query_nested_and_or_with_not() -> None:
     """Complex chain with AND, OR, NOT in various positions."""
     rules = parse_complex_query(
-        "Action AND NOT Comedy OR Drama AND NOT Horror", "genre"
+        "Action AND NOT Comedy OR Drama AND NOT Horror", "genre",
     )
     assert len(rules) == 4
     assert rules[0] == {"operator": "AND", "type": "genre", "value": "Action"}

--- a/tests/test_sync_uncovered.py
+++ b/tests/test_sync_uncovered.py
@@ -156,7 +156,7 @@ def test_is_in_season_same_year_window() -> None:
     # June 15 should be in season for Jun 1 - Sep 1
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 6, 15, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         assert _is_in_season("06-01", "09-01") is True
 
 
@@ -175,14 +175,14 @@ def test_is_in_season_single_day_season() -> None:
 
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 6, 15, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         # Same day — s <= e but window is [s, e), so 06-15 < 06-15 is False
         assert _is_in_season("06-15", "06-15") is False
 
     # A leap-year single day
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2024, 2, 29, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         assert _is_in_season("02-29", "02-29") is False
 
 
@@ -198,14 +198,14 @@ def test_is_in_season_dec_31_to_jan_1_wrap() -> None:
     # but wrap-around means current >= s(12-31) OR current < e(01-01)
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 1, 15, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         # current >= 12-31? No. current < 01-01? No (15 > 1).
         assert _is_in_season("12-31", "01-01") is False
 
     # Dec 31 — should be in season
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2025, 12, 31, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         assert _is_in_season("12-31", "01-01") is True
 
 
@@ -220,7 +220,7 @@ def test_is_in_season_mar_1_to_feb_29_cross_leap() -> None:
     # Feb 28 — should be in season (current >= 03-01? No. current < 02-29? In wrap: 28 < 29 = Yes)
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2024, 2, 28, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         assert _is_in_season("03-01", "02-29") is True
 
 
@@ -234,7 +234,7 @@ def test_is_in_season_leap_feb_29_as_start() -> None:
 
     with patch("sync.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2024, 2, 29, tzinfo=UTC)
-        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        mock_dt.side_effect = datetime
         assert _is_in_season("02-29", "03-15") is True  # Inclusive start
 
 


### PR DESCRIPTION
## Summary

Ruff auto-fixes for trailing commas and type annotations across test files.

### Changes
- Add missing trailing commas in test function calls and dicts
- Add `Never` return type annotations for functions that always raise
- Simplify mock datetime `side_effect` assignments (use `datetime` directly instead of lambda)
- Add missing type annotations to test class methods

All 737 tests pass.