### PR TITLE
test: add tests for double-checked locking race condition in _fetch_full_library

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1128,6 +1128,59 @@ def test_fetch_full_library_unexpected_error(mock_fetch) -> None:
     assert "Jellyfin connection error" in error
 
 
+@patch("sync.fetch_jellyfin_items")
+def test_fetch_full_library_double_checked_locking(mock_fetch) -> None:
+    """Double-checked locking preserves a fresh entry set by another thread."""
+    import time
+
+    _LIBRARY_CACHE.clear()
+    cache_key = ("http://jf", "key")
+
+    # Pre-populate a stale entry (TTL expired — 10 minutes old vs 300s TTL)
+    stale_time = time.monotonic() - 600
+    _LIBRARY_CACHE[cache_key] = (stale_time, [{"Id": "old"}])
+
+    def _simulate_concurrent_store(*args, **kwargs):
+        # Simulate: another thread finished first and stored a fresh entry
+        _LIBRARY_CACHE[cache_key] = (time.monotonic(), [{"Id": "from_other_thread"}])
+        return [{"Id": "from_this_thread"}]
+
+    mock_fetch.side_effect = _simulate_concurrent_store
+
+    items, error, code = _fetch_full_library("http://jf", "key", "Group")
+
+    assert code == 200
+    assert error is None
+    # The cache entry should be the fresh one from the other thread
+    # (the double-check detects it's still fresh and doesn't overwrite)
+    assert _LIBRARY_CACHE[cache_key][1] == [{"Id": "from_other_thread"}]
+
+
+@patch("sync.fetch_jellyfin_items")
+def test_fetch_full_library_double_checked_overwrite_stale(mock_fetch) -> None:
+    """Double-checked locking overwrites stale entry set by another thread."""
+    import time
+
+    _LIBRARY_CACHE.clear()
+    cache_key = ("http://jf", "key")
+
+    def _simulate_concurrent_store(*args, **kwargs):
+        # Simulate: another thread stored an ALSO-stale entry (TTL expired)
+        stale_time = time.monotonic() - 600
+        _LIBRARY_CACHE[cache_key] = (stale_time, [{"Id": "stale_from_other_thread"}])
+        return [{"Id": "from_this_thread"}]
+
+    mock_fetch.side_effect = _simulate_concurrent_store
+
+    items, error, code = _fetch_full_library("http://jf", "key", "Group")
+
+    assert code == 200
+    assert error is None
+    # The cache entry should have been overwritten because the other thread's
+    # entry was also stale
+    assert _LIBRARY_CACHE[cache_key][1] == [{"Id": "from_this_thread"}]
+
+
 @patch("sync._fetch_full_library")
 def test_match_jellyfin_items_by_provider_library_error(mock_lib) -> None:
     _LIBRARY_CACHE.clear()


### PR DESCRIPTION
## Summary

Adds two tests that exercise the double-checked locking path recently added to `_fetch_full_library` (PR #1052):

1. **test_fetch_full_library_double_checked_locking** — Verifies that when another thread stores a fresh cache entry while this thread is fetching, the fresh entry is preserved (not overwritten)

2. **test_fetch_full_library_double_checked_overwrite_stale** — Verifies that when another thread stores a stale (TTL-expired) entry, it gets overwritten by this thread's fresh result

Both tests pass.
