### PR TITLE
fix: suppress RUF059 lint warnings, improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ If symlinks point to non-existent files, verify your path mapping:
 
 ### Nothing Happens When I Click Sync
 - Check the browser console (F12) for JavaScript errors.
+- Check the **Network** tab (F12) to verify API requests complete successfully.
 - Verify the Jellyfin server is reachable from the app container.
 - Check the app logs for detailed error messages. Logs are written to
   `/app/logs/jellyfin-groupings.log` inside the container. To persist them

--- a/docs/API.md
+++ b/docs/API.md
@@ -214,6 +214,9 @@ Save a base64-encoded cover image for a group.
 | `group_name` | string | yes |
 | `image` | string | yes — data URL, e.g. `data:image/png;base64,...` |
 
+**Allowed MIME types:** `image/jpeg`, `image/png`, `image/webp`, `image/gif`.
+Only these four types are accepted; unsupported types return a `400` error.
+
 **Response `200`:** `{ "status": "success", "message": "Cover saved successfully" }`
 
 **Errors:** `400` invalid format; `413` payload too large (~4 MB).

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1147,7 +1147,7 @@ def test_fetch_full_library_double_checked_locking(mock_fetch) -> None:
 
     mock_fetch.side_effect = _simulate_concurrent_store
 
-    items, error, code = _fetch_full_library("http://jf", "key", "Group")
+    _items, error, code = _fetch_full_library("http://jf", "key", "Group")
 
     assert code == 200
     assert error is None
@@ -1172,7 +1172,7 @@ def test_fetch_full_library_double_checked_overwrite_stale(mock_fetch) -> None:
 
     mock_fetch.side_effect = _simulate_concurrent_store
 
-    items, error, code = _fetch_full_library("http://jf", "key", "Group")
+    _items, error, code = _fetch_full_library("http://jf", "key", "Group")
 
     assert code == 200
     assert error is None


### PR DESCRIPTION
## Summary

Three small improvements:

1. **Fix lint warnings** — Prefix two unused unpacked variables with underscore in `test_sync.py` to satisfy ruff's RUF059 check. These were the only two lint violations in the entire project.
2. **Document cover upload MIME types** — Add the list of allowed image types (`image/jpeg`, `image/png`, `image/webp`, `image/gif`) to the `POST /api/upload_cover` section of `docs/API.md`.
3. **Improve troubleshooting docs** — Add a hint about checking the browser Network tab to the "Nothing Happens When I Click Sync" section in `README.md`.

## Testing

- ✅ `ruff check .` — all checks pass (was 2 errors before this fix)
- ✅ `ruff format --check .` — 48 files already formatted
- ✅ `mypy .` — no issues in 14 source files
- ✅ `pytest` — all tests pass (100% coverage)
- ✅ `npm test` — all 70 frontend tests pass