### PR TITLE
refactor: promote _get_cover_path to public get_cover_path

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -55,7 +55,7 @@ from jellyfin import (
     get_users,
 )
 from scheduler import _scheduler, update_scheduler_jobs, validate_cron
-from sync import _get_cover_path, clear_library_cache, preview_group, run_sync
+from sync import get_cover_path, clear_library_cache, preview_group, run_sync
 
 _APP_START_TIME: float = time.time()
 
@@ -861,11 +861,11 @@ def upload_cover() -> ResponseReturnValue:
 
     Expects a JSON body with ``group_name`` and ``image`` (data URL).
     Decodes and saves the image to a location determined by
-    :func:`sync._get_cover_path`: it saves to
+    :func:`sync.get_cover_path`: it saves to
     ``target_base/.covers/[md5(group_name)].jpg`` when the target directory
     exists, otherwise it falls back to ``config/covers/[md5(group_name)].jpg``.
     The file name used is md5(group_name) + .jpg. Reference
-    :func:`sync._get_cover_path` for the detailed storage precedence.
+    :func:`sync.get_cover_path` for the detailed storage precedence.
 
     Returns:
         JSON with ``status`` and ``message``.
@@ -906,7 +906,7 @@ def upload_cover() -> ResponseReturnValue:
         cfg = load_config()
         target_path = str(cfg.get("target_path", ""))
 
-        cover_path = _get_cover_path(
+        cover_path = get_cover_path(
             group_name,
             target_path,
             check_exists=False,

--- a/sync.py
+++ b/sync.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "clear_library_cache",
+    "get_cover_path",
     "parse_complex_query",
     "preview_group",
     "run_cleanup_broken_symlinks",
@@ -177,7 +178,7 @@ def _translate_path(
     return jellyfin_path
 
 
-def _get_cover_path(
+def get_cover_path(
     group_name: str,
     target_base: str,
     check_exists: bool = True,
@@ -1371,7 +1372,7 @@ def _process_collection_group(
     result: dict[str, Any] = {"group": group_name, "links": len(item_ids)}
 
     if auto_set_library_covers:
-        source_cover = _get_cover_path(group_name, target_base)
+        source_cover = get_cover_path(group_name, target_base)
         if source_cover and Path(source_cover).exists():
             try:
                 set_collection_image(url, api_key, collection_id, source_cover)
@@ -1607,7 +1608,7 @@ def _prepare_group_directory(
             non-dry-run mode).
 
     """
-    source_cover: str | None = _get_cover_path(group_name, target_base)
+    source_cover: str | None = get_cover_path(group_name, target_base)
 
     if not dry_run:
         if Path(group_dir).exists():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -175,7 +175,7 @@ def test_upload_cover_security_check(client) -> None:
     assert response.status_code == 413
 
 
-@patch("routes._get_cover_path")
+@patch("routes.get_cover_path")
 def test_upload_cover_success(mock_get_path, client, tmp_path) -> None:
     mock_get_path.return_value = str(tmp_path / "test.jpg")
     # Base64 for a tiny transparent pixel
@@ -498,7 +498,7 @@ def test_upload_cover_invalid_base64(client) -> None:
     assert "Malformed image data" in response.get_json()["message"]
 
 
-@patch("routes._get_cover_path")
+@patch("routes.get_cover_path")
 def test_upload_cover_server_error(mock_get_cover, client) -> None:
     mock_get_cover.side_effect = OSError("Disk full")
     img_data = (
@@ -513,7 +513,7 @@ def test_upload_cover_server_error(mock_get_cover, client) -> None:
     assert response.get_json()["status"] == "error"
 
 
-@patch("routes._get_cover_path")
+@patch("routes.get_cover_path")
 def test_upload_cover_unresolvable_path(mock_get_cover, client) -> None:
     mock_get_cover.return_value = None
     img_data = (
@@ -546,7 +546,7 @@ def test_upload_cover_unsupported_mime(client) -> None:
 def test_upload_cover_mime_extension_mapping(client, tmp_path) -> None:
     """Upload with a non-JPEG MIME type uses the correct file extension."""
     from config import save_config
-    from routes import _get_cover_path
+    from routes import get_cover_path
 
     save_config({"target_path": str(tmp_path)})
     img_data = (
@@ -559,7 +559,7 @@ def test_upload_cover_mime_extension_mapping(client, tmp_path) -> None:
     )
     assert response.status_code == 200
     # Verify the file was saved with .png extension
-    cover_path = _get_cover_path(
+    cover_path = get_cover_path(
         "TestGroup",
         str(tmp_path),
         check_exists=False,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -27,7 +27,7 @@ from sync import (
     _fetch_items_for_tmdb_group,
     _fetch_items_for_trakt_group,
     _filter_by_watch_state,
-    _get_cover_path,
+    get_cover_path,
     _is_in_season,
     _match_condition,
     _match_jellyfin_items_by_provider,
@@ -150,17 +150,17 @@ def test_library_cache() -> None:
     assert _LIBRARY_CACHE[key][0]["Id"] == "1"
 
 
-def test_get_cover_path(tmp_path) -> None:
+def testget_cover_path(tmp_path) -> None:
     # Setup dummy paths
     target_base = str(tmp_path / "target")
     (Path(target_base) / ".covers").mkdir(parents=True, exist_ok=True)
     # Mock __file__ to control legacy path? A bit hard.
     # Let's just test the logic for check_exists=False
-    path = _get_cover_path("My Group", target_base, check_exists=False)
+    path = get_cover_path("My Group", target_base, check_exists=False)
     assert ".covers" in path
     assert path.endswith(".jpg")
     # Test non-existent with check_exists=True
-    assert _get_cover_path("Missing Group", target_base, check_exists=True) is None
+    assert get_cover_path("Missing Group", target_base, check_exists=True) is None
     # Test existent in lib
     lib_path = str(
         Path(target_base)
@@ -169,7 +169,7 @@ def test_get_cover_path(tmp_path) -> None:
     )
     with Path(lib_path).open("w") as f:
         f.write("test")
-    assert _get_cover_path("Existent", target_base, check_exists=True) == lib_path
+    assert get_cover_path("Existent", target_base, check_exists=True) == lib_path
 
 
 @patch("sync.fetch_jellyfin_items")
@@ -1086,16 +1086,16 @@ def test_filter_by_watch_state() -> None:
     ]
 
 
-def test_get_cover_path_no_target_base() -> None:
-    path = _get_cover_path("Group", "", check_exists=False)
+def testget_cover_path_no_target_base() -> None:
+    path = get_cover_path("Group", "", check_exists=False)
     assert "config/covers" in path
 
 
 @patch("pathlib.Path.exists")
-def test_get_cover_path_legacy_exists(mock_exists) -> None:
-    # _get_cover_path checks lib path first, then legacy path
+def testget_cover_path_legacy_exists(mock_exists) -> None:
+    # get_cover_path checks lib path first, then legacy path
     mock_exists.side_effect = [False, True]
-    path = _get_cover_path("LegacyGroup", "/some/target", check_exists=True)
+    path = get_cover_path("LegacyGroup", "/some/target", check_exists=True)
     assert "config/covers" in path
 
 
@@ -1380,7 +1380,7 @@ def test_fetch_items_metadata_unexpected_error(mock_fetch) -> None:
 
 @patch("pathlib.Path.exists")
 @patch("sync.set_collection_image")
-@patch("sync._get_cover_path")
+@patch("sync.get_cover_path")
 @patch("sync.add_to_collection")
 @patch("sync.create_collection")
 @patch("sync.find_collection_by_name")
@@ -1413,7 +1413,7 @@ def test_process_collection_group_create_and_cover(
 
 @patch("pathlib.Path.exists")
 @patch("sync.set_collection_image")
-@patch("sync._get_cover_path")
+@patch("sync.get_cover_path")
 @patch("sync.add_to_collection")
 @patch("sync.find_collection_by_name")
 def test_process_collection_group_cover_error(
@@ -1721,7 +1721,7 @@ def test_process_group_library_already_exists(mock_meta, mock_add, tmp_path) -> 
 
 
 @patch("sync.set_virtual_folder_image")
-@patch("sync._get_cover_path")
+@patch("sync.get_cover_path")
 @patch("sync._fetch_items_for_metadata_group")
 def test_process_group_auto_set_library_covers(
     mock_meta,
@@ -2120,7 +2120,7 @@ def test_process_group_missing_host_path(mock_meta, tmp_path) -> None:
     assert result["links"] == 0
 
 
-@patch("sync._get_cover_path")
+@patch("sync.get_cover_path")
 @patch("sync._fetch_items_for_metadata_group")
 def test_process_group_auto_cover_missing(mock_meta, mock_cover, tmp_path) -> None:
     host = tmp_path / "movie.mkv"

--- a/tests/test_sync_extended.py
+++ b/tests/test_sync_extended.py
@@ -554,7 +554,7 @@ def test_run_sync_with_library_creation(
 
 @patch("sync.shutil.copy2")
 @patch("sync.set_virtual_folder_image")
-@patch("sync._get_cover_path")
+@patch("sync.get_cover_path")
 @patch("sync.shutil.rmtree")
 @patch("pathlib.Path.mkdir")
 @patch("pathlib.Path.exists")

--- a/tests/test_sync_integration.py
+++ b/tests/test_sync_integration.py
@@ -8,7 +8,7 @@ TEST_URL = "http://localhost:8096"
 TEST_API_KEY = "test_key"
 
 
-@patch("sync._get_cover_path")
+@patch("sync.get_cover_path")
 @patch("pathlib.Path.mkdir")
 @patch("pathlib.Path.exists")
 @patch("sync.shutil.rmtree")

--- a/tests/test_sync_uncovered.py
+++ b/tests/test_sync_uncovered.py
@@ -632,23 +632,23 @@ def test_sort_items_in_memory_all_missing() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _get_cover_path edge cases
+# get_cover_path edge cases
 # ---------------------------------------------------------------------------
 
 
-def test_get_cover_path_no_covers_dir(tmp_path) -> None:
+def testget_cover_path_no_covers_dir(tmp_path) -> None:
     """Returns None when no cover file exists and check_exists is True."""
-    from sync import _get_cover_path
+    from sync import get_cover_path
 
-    result = _get_cover_path("Test Group", str(tmp_path), check_exists=True)
+    result = get_cover_path("Test Group", str(tmp_path), check_exists=True)
     assert result is None
 
 
-def test_get_cover_path_check_exists_false_without_target(tmp_path) -> None:
+def testget_cover_path_check_exists_false_without_target(tmp_path) -> None:
     """check_exists=False falls back to legacy path when target_base is not a dir."""
-    from sync import _get_cover_path
+    from sync import get_cover_path
 
-    result = _get_cover_path(
+    result = get_cover_path(
         "Test Group",
         "/nonexistent",
         check_exists=False,


### PR DESCRIPTION
## Summary

- Renamed  to  in  to properly signal it as a public API (it was already imported and used cross-module by )
- Added  to 's  list
- Updated all internal references in  and 
- Updated all test references across 6 test files

## Why

The function was named with a leading underscore (Python convention for private) but was imported and used by  — a clear signal that it should be public. This change makes the API intent explicit and consistent.

## Test plan

- [x] All existing tests pass (825 passed, 19 skipped)
- [x] No remaining references to  in source or test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cover upload and cover path handling so cover images are resolved consistently across the app.
  * Added support for fallback cover locations when a preferred path is unavailable.
  * Ensured missing target locations still resolve to a usable default cover directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->