### PR TITLE
fix(docker): correct config mount target and media path guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `unraid/jellyfin-groupings.xml`: the config volume mapped the host path onto
+  `/app/config.json`, but the app reads `/app/config/config.json`. When the host
+  file did not exist yet, Docker created a *directory* at `/app/config.json` and
+  the app silently ran unconfigured forever — settings saved in the UI vanished
+  without any error. The mapping is now a directory (`/app/config`).
+- `unraid/jellyfin-groupings.xml`, `docker-compose.yml`, `README.md`: the media
+  root was documented as `/mnt/user:/media` with "Host Root" set to `/media`.
+  Since the host-side path is written verbatim into every generated symlink,
+  that produces links Jellyfin cannot resolve, and the resulting library appears
+  empty. Docs now mount media under the same container path Jellyfin uses.
+- `README.md`: document that a folder exposed under a different name in Jellyfin
+  (host `tv` served as `/data/tvshows`) needs a second bind mount with that
+  exact target — a host symlink does not work, because `_translate_path` calls
+  `Path.resolve()` and rewrites the target back to the real folder name.
 - `sync.py`: renamed `_get_cover_path` to public `get_cover_path` for
   consistency — the function was already imported and used cross-module.
   (PR #1062)

--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ services:
       - /mnt/user/jellyfin-groupings-virtual:/groupings
       
       # Your media root. Needed so the app can verify files and follow symlinks.
-      # Use the same path Jellyfin uses if possible to simplify mapping.
-      - /mnt/user/media:/media:ro
+      # Mount it under the SAME container path Jellyfin uses — the symlinks
+      # store this path verbatim and Jellyfin has to resolve them.
+      - /mnt/user/data/movies:/data/movies:ro
+      - /mnt/user/data/anime:/data/anime:ro
+      # Folder named differently in Jellyfin? Map it to Jellyfin's name directly:
+      - /mnt/user/data/tv:/data/tvshows:ro
       
       # Optional: persist application logs for troubleshooting
       # - ./logs:/app/logs
@@ -116,8 +120,15 @@ When running in Docker, you need to tell the app how to translate paths between 
 | **Jellyfin Server URL** | The address of your Jellyfin server (e.g., `http://192.168.1.50:8096`). |
 | **API Key** | Generate one in Jellyfin: `Dashboard -> API Keys`. |
 | **Base Target Path** | Set this to `/groupings` (the internal path we mapped in Docker). |
-| **Media path as Jellyfin sees it** | The path where Jellyfin sees your media (e.g., `/data/movies`). |
-| **Same path on this machine** | The path where *this* container sees the same media (e.g., `/media`). |
+| **Media path as Jellyfin sees it** | The path where Jellyfin sees your media (e.g., `/data`). |
+| **Same path on this machine** | The path where *this* container sees the same media. Use the **same value** as above (e.g., `/data`) and mount your media there — see the warning below. |
+
+> [!WARNING]
+> **The two paths should normally be identical.** The generated symlinks store *"Same path on this machine"* verbatim as their target, and Jellyfin is the process that has to follow them. If this container sees your media at `/media` while Jellyfin sees it at `/data`, every symlink points at `/media/...` — a path Jellyfin cannot resolve, and the whole library shows up empty.
+>
+> They may only differ if Jellyfin can resolve the target path too.
+>
+> If a folder is exposed under a different name in Jellyfin (host `tv`, but Jellyfin serves it as `/data/tvshows`), add a second mount with that exact target — e.g. `- /mnt/user/data/tv:/data/tvshows:ro`. Do **not** solve it with a symlink on the host: path translation calls `Path.resolve()`, which follows the symlink and rewrites the target back to the real folder name, breaking those links again.
 
 > [!TIP]
 > Use the **"Auto-Detect Settings"** button in the UI! It will scan your media folders and try to match them with what Jellyfin reports to find the correct path translations for you.
@@ -655,11 +666,16 @@ When preview or sync fails, the error is shown in a modal dialog within the UI.
 
 ### Why does the app need both a Jellyfin-side path and a host-side path?
 
-Because Jellyfin often runs in a Docker container and sees your media at a different
-path than this app does. For example, Jellyfin might see files under `/data/movies`
-while this app sees them under `/mnt/user/media/movies`. The two path settings
-tell the app how to translate between the two views so symlinks point to the right
-files.
+Because Jellyfin often runs in a Docker container and may see your media at a
+different path than this app does. The two settings tell the app how to translate
+between the views when it reads item paths from the Jellyfin API.
+
+**In practice you usually want both values to be the same.** The host-side path is
+written verbatim into every symlink, and Jellyfin is what has to follow them. So if
+Jellyfin sees `/data/movies`, mount your media into this container at `/data/movies`
+too and set both fields to `/data`. Pointing the host side at something Jellyfin
+cannot reach (e.g. `/mnt/user/media/movies`) produces symlinks that look fine on the
+host but resolve to nothing inside Jellyfin — the library then appears empty.
 
 ### Can I use this alongside my existing Jellyfin libraries?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,18 @@ services:
       - /path/to/your/groupings-virtual:/groupings
 
       # 3. Media root
-      # Mount your real media folder here so the container can verify symlink targets.
-      # In the Web UI, set "Same path on this machine" to: /media
-      # - /path/to/your/media:/media:ro
+      # Mount your real media here using the SAME container path Jellyfin uses,
+      # and set "Same path on this machine" to that identical path.
+      # The generated symlinks store this path verbatim, so Jellyfin must be
+      # able to resolve it. Mounting at /media here while Jellyfin sees /data
+      # produces symlinks that are broken for Jellyfin.
+      # If a folder has a different name in Jellyfin (host "tv" exposed as
+      # /data/tvshows), add a second mount with that exact target instead of a
+      # symlink — path translation calls resolve() and would rewrite the target
+      # back to the real folder name.
+      # - /path/to/your/media/anime:/data/anime:ro
+      # - /path/to/your/media/movies:/data/movies:ro
+      # - /path/to/your/media/tv:/data/tvshows:ro
 
       # 4. Local covers directory (optional — library-local .covers/ takes
       #    precedence; this is the legacy fallback location)

--- a/unraid/jellyfin-groupings.xml
+++ b/unraid/jellyfin-groupings.xml
@@ -41,17 +41,17 @@
     Required="true"
     Mask="false">5000</Config>
 
-  <!-- ── Config file ─────────────────────────────────────────── -->
+  <!-- ── Config directory ────────────────────────────────────── -->
   <Config
-    Name="Config File"
-    Target="/app/config.json"
-    Default="/mnt/user/appdata/jellyfin-groupings/config.json"
+    Name="Config Directory"
+    Target="/app/config"
+    Default="/mnt/user/appdata/jellyfin-groupings/config"
     Mode="rw"
-    Description="Path to the config.json file on the host. This persists your settings (Jellyfin URL, API key, groups) across container restarts."
+    Description="Directory where the app stores config.json (Jellyfin URL, API key, groups). Must be a DIRECTORY, not a file: the app reads /app/config/config.json and creates it on first start. Mapping a not-yet-existing file here makes Docker create a directory at /app/config.json instead, and the app silently keeps running unconfigured."
     Type="Path"
     Display="always"
     Required="true"
-    Mask="false">/mnt/user/appdata/jellyfin-groupings/config.json</Config>
+    Mask="false">/mnt/user/appdata/jellyfin-groupings/config</Config>
 
   <!-- ── Groupings output directory ──────────────────────────── -->
   <Config
@@ -68,10 +68,10 @@
   <!-- ── Media root (optional, for path mapping) ─────────────── -->
   <Config
     Name="Media Root (optional)"
-    Target="/media"
-    Default="/mnt/user"
+    Target="/data"
+    Default="/mnt/user/data"
     Mode="ro"
-    Description="Mount your media root here so the container can verify and create symlinks that point to real files. Set 'Host Root' in the app's settings to /media (or the sub-path that matches your Jellyfin 'Jellyfin Root' setting). Read-only is sufficient."
+    Description="Mount your media here using the SAME container path that Jellyfin uses (e.g. /data), and set 'Host Root' to that same path. The symlinks written into the groupings folder store this path verbatim, so Jellyfin has to be able to resolve it — if you mount your media at /media here while Jellyfin sees it at /data, every generated symlink will be broken from Jellyfin's side. If a folder is named differently in Jellyfin (e.g. host 'tv' exposed as /data/tvshows), add a second mapping with that exact target rather than a symlink: path translation resolves symlinks and would rewrite the target back to the real name. Read-only is sufficient."
     Type="Path"
     Display="always"
     Required="false"


### PR DESCRIPTION
The Unraid template mapped the host config onto /app/config.json, but the app reads /app/config/config.json. When the host file did not exist yet, Docker created a directory at /app/config.json instead, leaving the app permanently unconfigured — settings saved through the UI disappeared with no error and only health checks showed up in the log.

The media root was documented as /mnt/user:/media with Host Root set to /media. Since that path is stored verbatim as the target of every symlink and Jellyfin is what resolves them, this produces a library that is empty from Jellyfin's side. Docs now mount media under the same container path Jellyfin uses.

Also document that a folder exposed under a different name in Jellyfin needs its own bind mount rather than a host symlink: _translate_path calls Path.resolve(), which follows the symlink and rewrites the target back to the real folder name.


Claude-Session: https://claude.ai/code/session_016cz61NSn2cHd3JLkawtLQC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker, server, and Unraid setup requirements for mounting media at the same container paths configured in Jellyfin.
  * Added examples for separate anime, movie, and TV media roots, including renamed host folders.
  * Expanded guidance on symlinks, path translation, and library failures caused by inaccessible targets.
  * Updated configuration-volume instructions to use a config directory mapping.
* **Changelog**
  * Documented corrections for config-volume mapping, media-root paths, and alternate-name bind mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->