### PR TITLE
feat(sync): support nested group folders via '/' in group names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Nested groups: a group name may now contain `/` to create a folder tree
+  (`Anime/Action` → `<target>/Anime/Action`). Point one Jellyfin library at the
+  tree root and browse it as folders — useful on TV clients, where navigating
+  folders is far easier than using filters.
+- `_common.py`: `normalize_group_relpath()` normalises a group name into a safe
+  relative path (trims segments, collapses empty ones, accepts `\` as a
+  separator) and rejects `.`/`..` segments and NUL bytes.
+
 - `routes.py`: add `/api/version` endpoint returning the current application
   version string.
 - `routes.py`: include `version` field in `/api/health` response.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,31 @@ table for the full list.
    - *Example:* If your Target Path is mapped to `/mnt/user/jellyfin-groupings-virtual` on the host, and you created a group named `Action`, add `/mnt/user/jellyfin-groupings-virtual/Action` to Jellyfin.
    - **Note:** Ensure your Jellyfin container also has this virtual root mounted!
 
+### Nested groups (folders inside folders)
+
+A group name may contain `/` to place it inside a sub-folder:
+
+| Group name | Resulting directory |
+|---|---|
+| `Action` | `<target>/Action` |
+| `Anime/Action` | `<target>/Anime/Action` |
+| `Anime/By Studio/Ghibli` | `<target>/Anime/By Studio/Ghibli` |
+
+This is useful when you would rather **browse a folder tree on a TV** than use
+Jellyfin's filters, which are cumbersome with a remote control. Add a single
+library of type `Mixed Movies and Shows` pointing at the tree root (e.g.
+`/groupings/Anime`) and Jellyfin renders every level below it as navigable
+folders.
+
+Because such a tree is meant to be *one* library, **nested groups are skipped by
+"Auto-create libraries"** — otherwise you would get a separate Jellyfin library
+per sub-folder. Top-level groups are still created automatically.
+
+Names are normalised before use: surrounding whitespace per segment is trimmed,
+empty segments collapse (`Anime//Action` → `Anime/Action`), and names containing
+`.`/`..` segments or NUL bytes are rejected so a group directory can never be
+created — or deleted — outside your target path.
+
 ---
 
 ## 🛠️ Advanced: Complex Queries

--- a/_common.py
+++ b/_common.py
@@ -93,3 +93,47 @@ DEFAULT_LIST_MAX_PAGES: int = 50
 
 #: Default page size for paginated API calls.
 DEFAULT_LIST_PAGE_LIMIT: int = 1_000
+
+
+# ---------------------------------------------------------------------------
+# Group names / nested folder paths
+# ---------------------------------------------------------------------------
+
+
+def normalize_group_relpath(name: str) -> str | None:
+    """Normalise a group name into a safe *relative* folder path.
+
+    A group name may describe a nested location by separating levels with
+    ``/`` (or ``\\`` on Windows-style input), e.g. ``"Anime/Action"`` creates
+    ``<target>/Anime/Action``. This lets users build a browsable folder tree
+    in Jellyfin instead of a flat list of libraries.
+
+    Every segment is stripped of surrounding whitespace, and empty segments
+    are dropped so ``"Anime//Action"`` and ``"Anime/ Action "`` normalise to
+    ``"Anime/Action"``.
+
+    The result is always relative and always stays inside the target
+    directory: absolute paths, ``.``/``..`` segments and NUL bytes are
+    rejected outright rather than sanitised, so a malformed name can never
+    be silently turned into a path that escapes the base directory.
+
+    Args:
+        name: The raw group name.
+
+    Returns:
+        The normalised relative path using ``/`` separators, or ``None`` if
+        *name* is not a valid, safe group name.
+
+    """
+    if not isinstance(name, str) or "\x00" in name:
+        return None
+
+    segments = [seg.strip() for seg in name.replace("\\", "/").split("/")]
+    cleaned = [seg for seg in segments if seg]
+
+    if not cleaned:
+        return None
+    if any(seg in (".", "..") for seg in cleaned):
+        return None
+
+    return "/".join(cleaned)

--- a/routes.py
+++ b/routes.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 
 from _common import DEFAULT_SEARCH_ROOTS as _DEFAULT_SEARCH_ROOTS
 from _common import SOURCE_TYPES as _ALLOWED_PREVIEW_TYPES
+from _common import normalize_group_relpath
 from config import (
     _active_env_overrides,
     load_config,
@@ -1078,16 +1079,36 @@ def get_cleanup_items() -> ResponseReturnValue:
     if not target_base or not Path(target_base).exists():
         return _success("", items=[])
 
-    configured_groups: set[str] = {
-        str(g.get("name")) for g in config.get("groups", []) if g.get("name")
-    }
+    configured_groups: set[str] = set()
+    # Parents of nested groups ("Anime" for "Anime/Action") are structural, not
+    # leftovers — listing them as deletable would offer to wipe every child.
+    parent_dirs: set[str] = set()
+    for g in config.get("groups", []):
+        rel = normalize_group_relpath(str(g.get("name") or ""))
+        if not rel:
+            continue
+        configured_groups.add(rel)
+        parts = rel.split("/")
+        for depth in range(1, len(parts)):
+            parent_dirs.add("/".join(parts[:depth]))
+
+    max_depth = max((len(g.split("/")) for g in configured_groups), default=1)
+
+    def _walk(directory: Path, prefix: str, depth: int) -> list[dict[str, Any]]:
+        found: list[dict[str, Any]] = []
+        for entry in directory.iterdir():
+            if not entry.is_dir() or entry.name.startswith("."):
+                continue
+            rel = f"{prefix}/{entry.name}" if prefix else entry.name
+            if rel in parent_dirs and depth < max_depth:
+                # Structural parent: descend instead of offering it for deletion.
+                found.extend(_walk(entry, rel, depth + 1))
+            else:
+                found.append({"name": rel, "is_configured": rel in configured_groups})
+        return found
 
     try:
-        entries = [
-            {"name": entry.name, "is_configured": entry.name in configured_groups}
-            for entry in Path(target_base).iterdir()
-            if entry.is_dir() and not entry.name.startswith(".")
-        ]
+        entries = _walk(Path(target_base), "", 1)
         return _success("", items=sorted(entries, key=lambda x: str(x["name"])))
     except OSError as exc:
         return _error(str(exc), 500)
@@ -1114,10 +1135,14 @@ def _delete_folder(
         was removed successfully.
 
     """
-    # Prevent path-traversal attacks: reject names with separators
-    if not _is_valid_folder_name(name):
+    # Group names may be nested ("Anime/Action"); normalisation rejects
+    # absolute paths and ``.``/``..`` segments, so the result always stays
+    # below target_base. The resolve() check below is the second line of
+    # defence against symlinked sub-directories.
+    relpath = normalize_group_relpath(name)
+    if relpath is None:
         return False, f"Invalid folder name: {name}"
-    path = Path(target_base) / name
+    path = Path(target_base).joinpath(*relpath.split("/"))
     # Resolve the path to ensure it is still within target_base (symlink-safe)
     try:
         resolved = path.resolve()
@@ -1135,6 +1160,7 @@ def _delete_folder(
         return False, None
     try:
         shutil.rmtree(path)
+        _prune_empty_parents(path.parent, Path(target_base))
         if auto_create_libraries and url and api_key:
             try:
                 delete_virtual_folder(url, api_key, name)
@@ -1144,6 +1170,45 @@ def _delete_folder(
         return False, f"Failed to delete {name}: {exc}"
     else:
         return True, None
+
+
+def _prune_empty_parents(directory: Path, base: Path) -> None:
+    """Remove now-empty parent directories left behind by a nested group.
+
+    Walks upwards from *directory* and removes each directory that became
+    empty, stopping at *base* (which is never removed).
+
+    Args:
+        directory: The first parent to consider.
+        base: The target root; the walk never goes at or above it.
+
+    """
+    try:
+        base_resolved = base.resolve()
+    except (OSError, RuntimeError):
+        return
+
+    current = directory
+    while True:
+        try:
+            resolved = current.resolve()
+        except (OSError, RuntimeError):
+            return
+        if resolved == base_resolved or base_resolved not in resolved.parents:
+            return
+        try:
+            next(current.iterdir())
+        except StopIteration:
+            pass  # empty -> remove it
+        except OSError:
+            return
+        else:
+            return  # still holds entries
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
 
 
 @bp.route("/api/cleanup", methods=["POST"])

--- a/sync.py
+++ b/sync.py
@@ -29,6 +29,7 @@ import requests
 
 from _common import COMPLEX_QUERY_SOURCE_TYPES as _COMPLEX_QUERY_SOURCE_TYPES
 from _common import LIST_SOURCE_TYPES as _LIST_SOURCE_TYPES
+from _common import normalize_group_relpath
 from anilist import fetch_anilist_list
 from imdb import fetch_imdb_list
 from jellyfin import (
@@ -1414,9 +1415,22 @@ def _auto_create_library(
         The updated result dict.
 
     """
+    # Nested groups ("Anime/Action") are meant to be browsed as folders inside
+    # a single library the user points at the tree root, so auto-creating one
+    # Jellyfin library per sub-folder would defeat the purpose.
+    relpath = normalize_group_relpath(group_name)
+    is_nested = relpath is not None and "/" in relpath
+    if is_nested:
+        logger.info(
+            "Skipping library auto-creation for nested grouping %r "
+            "(point one library at the tree root instead)",
+            group_name,
+        )
+
     if (
         not dry_run
         and auto_create_libraries
+        and not is_nested
         and links_created > 0
         and existing_libraries is not None
         and group_name not in existing_libraries
@@ -1874,7 +1888,14 @@ def _process_group(
     if not group_name:
         return {"group": "(unnamed)", "links": 0, "error": "Empty group name"}
 
-    group_dir: str = str(Path(target_base) / group_name)
+    # A name may describe a nested folder ("Anime/Action"). Normalising here
+    # keeps the resulting directory inside target_base — important because
+    # _prepare_group_directory rmtree()s it.
+    relpath: str | None = normalize_group_relpath(group_name)
+    if relpath is None:
+        return {"group": group_name, "links": 0, "error": "Invalid group name"}
+
+    group_dir: str = str(Path(target_base).joinpath(*relpath.split("/")))
     sort_order: str = group.get("sort_order", "") or ""
     source_type: str | None = group.get("source_type")
     source_value: str | None = group.get("source_value")

--- a/templates/partials/main/groupings.html
+++ b/templates/partials/main/groupings.html
@@ -29,7 +29,13 @@
         <div class="form-group mb-1_25">
             <label for="group_name">Group Name</label>
             <input type="text" id="group_name" placeholder="Action Movies" required>
-            <small>Becomes the folder name and Jellyfin library name.</small>
+            <small>
+                Becomes the folder name and Jellyfin library name.
+                Use <code>/</code> to nest, e.g. <code>Anime/Action</code> &rarr;
+                <code>&lt;target&gt;/Anime/Action</code>. Point one library at the
+                tree root to browse it as folders; nested groups are skipped by
+                auto-created libraries.
+            </small>
         </div>
 
         <h4 class="section-accent-heading section-dashed-top">

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,7 @@
 """Tests for the _common module (shared constants and utilities)."""
 
+import pytest
+
 from _common import (
     COMPLEX_QUERY_SOURCE_TYPES,
     DEFAULT_LIST_FETCH_TIMEOUT,
@@ -9,7 +11,65 @@ from _common import (
     DEFAULT_SEARCH_ROOTS,
     LIST_SOURCE_TYPES,
     SOURCE_TYPES,
+    normalize_group_relpath,
 )
+
+
+class TestNormalizeGroupRelpath:
+    """Tests for nested group-name normalisation."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Simple", "Simple"),
+            ("Anime/Action", "Anime/Action"),
+            ("A/B/C", "A/B/C"),
+            ("Anime//Action", "Anime/Action"),
+            ("Anime/ Action ", "Anime/Action"),
+            ("  Spaced  ", "Spaced"),
+            ("Anime\\Action", "Anime/Action"),
+            ("/leading/slash", "leading/slash"),
+            ("trailing/slash/", "trailing/slash"),
+        ],
+    )
+    def test_accepts_and_normalises(self, raw: str, expected: str) -> None:
+        """Valid names normalise to a relative, slash-separated path."""
+        assert normalize_group_relpath(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "   ",
+            ".",
+            "..",
+            "../etc",
+            "../../etc/passwd",
+            "a/../b",
+            "a/./b",
+            "with\x00null",
+            "/",
+            "///",
+        ],
+    )
+    def test_rejects_unsafe_names(self, raw: str) -> None:
+        """Empty, relative-traversal and NUL-containing names are rejected."""
+        assert normalize_group_relpath(raw) is None
+
+    def test_rejects_non_string(self) -> None:
+        """Non-string input is rejected rather than raising."""
+        assert normalize_group_relpath(None) is None  # type: ignore[arg-type]
+        assert normalize_group_relpath(123) is None  # type: ignore[arg-type]
+
+    def test_result_never_escapes_base(self, tmp_path) -> None:
+        """Joining the result onto a base never leaves that base."""
+        base = tmp_path / "groupings"
+        base.mkdir()
+        for raw in ("Anime/Action", "/abs/path", "a/b/c", "Anime\\Action"):
+            rel = normalize_group_relpath(raw)
+            assert rel is not None
+            joined = base.joinpath(*rel.split("/")).resolve()
+            assert base.resolve() in joined.parents or joined.parent == base.resolve()
 
 
 class TestSourceTypes:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -814,6 +814,35 @@ def test_get_cleanup_items_with_groups(client, tmp_path) -> None:
     assert data["items"][0]["is_configured"] is True
 
 
+def test_get_cleanup_items_lists_nested_groups(client, tmp_path) -> None:
+    """Nested groups are listed by their full relative path.
+
+    The structural parent ("Anime") must not appear as its own deletable
+    entry — offering it would let a single click wipe every child group.
+    """
+    target = tmp_path / "target"
+    (target / "Anime" / "Action").mkdir(parents=True)
+    (target / "Anime" / "Leftover").mkdir(parents=True)
+    (target / "Toplevel").mkdir()
+    save_config(
+        {
+            "target_path": str(target),
+            "groups": [{"name": "Anime/Action"}, {"name": "Toplevel"}],
+        },
+    )
+
+    response = client.get("/api/cleanup")
+
+    assert response.status_code == 200
+    items = {i["name"]: i["is_configured"] for i in response.get_json()["items"]}
+    assert items == {
+        "Anime/Action": True,
+        "Anime/Leftover": False,
+        "Toplevel": True,
+    }
+    assert "Anime" not in items
+
+
 @patch("routes.Path.iterdir")
 @pytest.mark.usefixtures("temp_config")
 def test_get_cleanup_items_oserror(mock_iterdir, client, tmp_path) -> None:
@@ -1882,16 +1911,48 @@ def test_check_auth_with_no_password(app, monkeypatch) -> None:
 
 
 def test_delete_folder_invalid_name() -> None:
-    """_delete_folder rejects folder names with path separators (line 741)."""
+    """_delete_folder rejects names that would escape the target base."""
     from routes import _delete_folder
 
-    deleted, err = _delete_folder("../etc", "/tmp/base", False, "", "")
-    assert deleted is False
-    assert err == "Invalid folder name: ../etc"
+    for bad in ("../etc", "a/../b", ".", "", "   ", "with\x00null"):
+        deleted, err = _delete_folder(bad, "/tmp/base", False, "", "")
+        assert deleted is False
+        assert err == f"Invalid folder name: {bad}"
 
-    deleted, err = _delete_folder("sub/dir", "/tmp/base", False, "", "")
-    assert deleted is False
-    assert err == "Invalid folder name: sub/dir"
+
+def test_delete_folder_accepts_nested_name(tmp_path) -> None:
+    """Nested group names ("Anime/Action") are valid and delete that folder."""
+    from routes import _delete_folder
+
+    base = tmp_path / "groupings"
+    nested = base / "Anime" / "Action"
+    nested.mkdir(parents=True)
+    (nested / "link").touch()
+
+    deleted, err = _delete_folder("Anime/Action", str(base), False, "", "")
+
+    assert deleted is True
+    assert err is None
+    assert not nested.exists()
+    # The now-empty parent is pruned, but the base itself is kept.
+    assert not (base / "Anime").exists()
+    assert base.exists()
+
+
+def test_delete_folder_keeps_parent_with_siblings(tmp_path) -> None:
+    """A parent that still holds other groups is not pruned."""
+    from routes import _delete_folder
+
+    base = tmp_path / "groupings"
+    (base / "Anime" / "Action").mkdir(parents=True)
+    (base / "Anime" / "Romance").mkdir(parents=True)
+
+    deleted, err = _delete_folder("Anime/Action", str(base), False, "", "")
+
+    assert deleted is True
+    assert err is None
+    assert (base / "Anime").exists()
+    assert (base / "Anime" / "Romance").exists()
 
 
 def test_delete_folder_path_traversal_via_symlink(tmp_path) -> None:

--- a/tests/test_sync_nested_groups.py
+++ b/tests/test_sync_nested_groups.py
@@ -1,0 +1,99 @@
+"""Tests for nested group directories in _process_group."""
+
+from pathlib import Path
+from typing import Any
+
+from sync import _process_group
+
+
+def _run(group: dict[str, Any], target: Path) -> dict[str, Any]:
+    """Invoke _process_group with a source that resolves to no items."""
+    return _process_group(
+        group,
+        str(target),
+        "http://jellyfin.invalid",
+        "key",
+        "/data",
+        "/data",
+        "",
+        "",
+        "",
+        dry_run=False,
+    )
+
+
+class TestNestedGroupDirectories:
+    """A group name with '/' creates the corresponding folder tree."""
+
+    def test_nested_name_creates_directory_tree(self, tmp_path, monkeypatch) -> None:
+        """'Anime/Action' produces <target>/Anime/Action."""
+        monkeypatch.setattr(
+            "sync._resolve_group_source", lambda *a, **k: ([], None, None)
+        )
+        target = tmp_path / "groupings"
+        target.mkdir()
+
+        result = _run(
+            {"name": "Anime/Action", "source_type": "genre", "source_value": "Action"},
+            target,
+        )
+
+        assert "error" not in result or result.get("error") is None
+        assert (target / "Anime" / "Action").is_dir()
+
+    def test_deeply_nested_name(self, tmp_path, monkeypatch) -> None:
+        """More than two levels are supported."""
+        monkeypatch.setattr(
+            "sync._resolve_group_source", lambda *a, **k: ([], None, None)
+        )
+        target = tmp_path / "groupings"
+        target.mkdir()
+
+        _run(
+            {
+                "name": "Anime/By Studio/Ghibli",
+                "source_type": "genre",
+                "source_value": "Action",
+            },
+            target,
+        )
+
+        assert (target / "Anime" / "By Studio" / "Ghibli").is_dir()
+
+    def test_traversal_name_is_rejected(self, tmp_path, monkeypatch) -> None:
+        """A name escaping the target base errors out and touches nothing.
+
+        This matters because the group directory is rmtree()d before it is
+        recreated — an unchecked name would delete an arbitrary directory.
+        """
+        monkeypatch.setattr(
+            "sync._resolve_group_source", lambda *a, **k: ([], None, None)
+        )
+        target = tmp_path / "groupings"
+        target.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "precious.txt").write_text("keep me")
+
+        result = _run(
+            {"name": "../outside", "source_type": "genre", "source_value": "Action"},
+            target,
+        )
+
+        assert result["error"] == "Invalid group name"
+        assert result["links"] == 0
+        assert (outside / "precious.txt").exists()
+
+    def test_plain_name_still_works(self, tmp_path, monkeypatch) -> None:
+        """Non-nested names behave exactly as before."""
+        monkeypatch.setattr(
+            "sync._resolve_group_source", lambda *a, **k: ([], None, None)
+        )
+        target = tmp_path / "groupings"
+        target.mkdir()
+
+        _run(
+            {"name": "Action", "source_type": "genre", "source_value": "Action"}, target
+        )
+
+        assert (target / "Action").is_dir()


### PR DESCRIPTION
A group name may now describe a folder tree: 'Anime/Action' creates <target>/Anime/Action instead of a single flat directory. Point one Jellyfin library at the tree root and every level below shows up as a navigable folder — considerably more usable on TV clients than Jellyfin's filters, which are painful with a remote control.

Nested groups are skipped by auto-created libraries: such a tree is meant to be one library, so creating a separate Jellyfin library per sub-folder would defeat the purpose. Top-level groups are unaffected.

Group names now pass through normalize_group_relpath(), which trims each segment, collapses empty ones and rejects '.'/'..' segments and NUL bytes. This also closes a path-traversal hole: _prepare_group_directory() calls shutil.rmtree() on the group directory, so a name like '../../etc' would previously have deleted a directory outside the configured target path.

The cleanup view descends into structural parents rather than listing them as unconfigured leftovers — otherwise deleting 'Anime' would take every child group with it — and _delete_folder() now accepts nested names and prunes parent directories that became empty.


Claude-Session: https://claude.ai/code/session_016cz61NSn2cHd3JLkawtLQC