### PR TITLE
style: fix ruff I001 import sorting in routes.py

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -19,6 +19,8 @@ import shutil
 import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -35,21 +37,6 @@ from flask import (
 from werkzeug.exceptions import HTTPException
 
 import network
-
-# Resolve the application version from package metadata.
-# Falls back to a dev placeholder when running from source
-# (i.e. the package is not installed via pip).
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
-
-try:
-    __version__: str = _pkg_version("jellyfin-groupings")
-except PackageNotFoundError:
-    __version__ = "1.0.0+dev"
-del _pkg_version
-
-if TYPE_CHECKING:
-    from flask.typing import ResponseReturnValue
-
 from _common import DEFAULT_SEARCH_ROOTS as _DEFAULT_SEARCH_ROOTS
 from _common import SOURCE_TYPES as _ALLOWED_PREVIEW_TYPES
 from _common import normalize_group_relpath
@@ -67,7 +54,19 @@ from jellyfin import (
     get_users,
 )
 from scheduler import _scheduler, update_scheduler_jobs, validate_cron
-from sync import get_cover_path, clear_library_cache, preview_group, run_sync
+from sync import clear_library_cache, get_cover_path, preview_group, run_sync
+
+# Resolve the application version from package metadata.
+# Falls back to a dev placeholder when running from source
+# (i.e. the package is not installed via pip).
+try:
+    __version__: str = _pkg_version("jellyfin-groupings")
+except PackageNotFoundError:
+    __version__ = "1.0.0+dev"
+del _pkg_version
+
+if TYPE_CHECKING:
+    from flask.typing import ResponseReturnValue
 
 _APP_START_TIME: float = time.time()
 


### PR DESCRIPTION
## Summary

Fixes the ruff `I001` (import sorting) lint error in `routes.py` that has been failing the CI **lint** check.

The `importlib.metadata` import was placed after other executable statements, and the first-party imports (`_common`, `config`, `jellyfin`, `scheduler`, `sync`) sat below the `TYPE_CHECKING` block. All imports are moved to the top of the module, and the version-detection + `TYPE_CHECKING` blocks now follow the import block.

## Notes
- No runtime behavior change. Verified: module imports cleanly and the version fallback test still passes.
- This is a pre-existing failure on `main` (the lint check has been red). The remaining `main` CI failures (format issues in `sync.py`/`tmdb.py`/`test_sync.py`, coverage gaps in newer main code, e2e infra) are separate and not addressed here.